### PR TITLE
Fix header overlap

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ https://user-images.githubusercontent.com/19242427/187209227-03598bf8-c958-4577-
 
 <img src="https://raw.githubusercontent.com/kikipoulet/SukiUI/main/Images/SideMenu3.gif"></img>
 
+- Header content can overlap sidebar toggle button if its content is too wide. To prevent that, either design header content layout to be narrower, or set `SideMenuModel.HeaderContentOverlapsToggleSidebarButton` property to `False`. Default is `True`.  `HeaderContentOverlapsToggleSidebarButton` moves header content under the button.  
+
 Xaml Code Method
 </br>
 <details>
@@ -161,10 +163,8 @@ Xaml Code Method
     </suki:SideMenu>
     
   </suki:DesktopPage>
-  ``` 
-  
-</details
-
+  ```
+</details>
   
 Code-Behind method
   </br>

--- a/SukiUI/Controls/SideMenu.axaml
+++ b/SukiUI/Controls/SideMenu.axaml
@@ -48,7 +48,7 @@
                     </Button>
                     <DockPanel>
 
-                        <Grid DockPanel.Dock="Top" IsVisible="{Binding MenuVisibility}">
+                        <Grid DockPanel.Dock="Top" IsVisible="{Binding MenuVisibility}" MinHeight="40">
                             <ContentControl Content="{Binding HeaderContent}" />
                         </Grid>
 

--- a/SukiUI/Controls/SideMenu.axaml
+++ b/SukiUI/Controls/SideMenu.axaml
@@ -10,99 +10,122 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:suki="clr-namespace:SukiUI.Controls"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <UserControl.Styles>
-        <Style Selector="material|MaterialIcon">
-            <Setter Property="Foreground" Value="#444444" />
+	<UserControl.Styles>
+		<Style Selector="material|MaterialIcon">
+			<Setter Property="Foreground" Value="#444444" />
 
-        </Style>
-
-
-    </UserControl.Styles>
-    <Design.DataContext />
+		</Style>
 
 
-    <SplitView
+	</UserControl.Styles>
+	<Design.DataContext />
+
+
+	<SplitView
         DisplayMode="CompactInline"
         IsPaneOpen="{Binding MenuVisibility}"
         OpenPaneLength="256"
         PaneClosing="PaneIsClosing">
 
-        <SplitView.Pane>
-            <Border BorderBrush="#ebebeb" BorderThickness="0,0,1.5,0">
-                <Grid Background="White">
-                    <Button
-                        Classes="Accent"
-                        Command="{Binding ChangeMenuVisibility}"
-                        HorizontalAlignment="Right"
-                        VerticalAlignment="Top">
-                        <Grid>
-                            <material:MaterialIcon
-                                Foreground="Black"
-                                IsVisible="{Binding !MenuVisibility}"
-                                Kind="ChevronRight" />
-                            <material:MaterialIcon
-                                Foreground="Black"
-                                IsVisible="{Binding MenuVisibility}"
-                                Kind="ChevronLeft" />
-                        </Grid>
-                    </Button>
-                    <DockPanel>
+		<SplitView.Pane>
+			<Border BorderBrush="#ebebeb" BorderThickness="0,0,1.5,0">
+				<Grid Background="White">
+					<!-- This sidebar toggle button is used when header content can overlap it-->
+					<Button
+							Classes="Accent"
+							Command="{Binding ChangeMenuVisibility}"
+							HorizontalAlignment="Right"
+							VerticalAlignment="Top"
+							IsVisible="{Binding HeaderContentOverlapsToggleSidebarButton}">
+						<Grid>
+							<material:MaterialIcon
+								Foreground="Black"
+								IsVisible="{Binding !MenuVisibility}"
+								Kind="ChevronRight" />
+							<material:MaterialIcon
+								Foreground="Black"
+								IsVisible="{Binding MenuVisibility}"
+								Kind="ChevronLeft" />
+						</Grid>
+					</Button>
 
-                        <Grid DockPanel.Dock="Top" IsVisible="{Binding MenuVisibility}" MinHeight="40">
-                            <ContentControl Content="{Binding HeaderContent}" />
-                        </Grid>
+					<DockPanel>
+						<!-- This sidebar toggle button can't be overlapped by header content -->
+						<Button
+							IsVisible="{Binding !HeaderContentOverlapsToggleSidebarButton}"
+                            Classes="Accent"
+                            Command="{Binding ChangeMenuVisibility}"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Top" DockPanel.Dock="Top">
+							<Grid>
+								<material:MaterialIcon
+									Foreground="Black"
+									IsVisible="{Binding !MenuVisibility}"
+									Kind="ChevronRight" />
+								<material:MaterialIcon
+									Foreground="Black"
+									IsVisible="{Binding MenuVisibility}"
+									Kind="ChevronLeft" />
+							</Grid>
+						</Button>
 
-                        <Grid
+
+						<Grid DockPanel.Dock="Top" IsVisible="{Binding MenuVisibility}" MinHeight="{Binding HeaderMinHeight}">
+							<ContentControl Content="{Binding HeaderContent}" />
+						</Grid>
+
+						<!-- Used to move menu icons down when sidebar is closed-->
+						<Grid
                             DockPanel.Dock="Top"
                             Height="40"
-                            IsVisible="{Binding !MenuVisibility}" />
+                            IsVisible="{Binding SpacerEnabled}" />
 
 
-                        <ItemsControl
+						<ItemsControl
                             DockPanel.Dock="Bottom"
                             Items="{Binding FooterMenuItems}"
                             Margin="0,0,0,10">
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate>
-                                    <RadioButton
+							<ItemsControl.ItemTemplate>
+								<DataTemplate>
+									<RadioButton
                                         Classes="MenuItem"
                                         Command="{Binding DataContext.ChangePage, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type UserControl}}}"
                                         CommandParameter="{Binding Content}"
                                         GroupName="MenuItemsGroup"
                                         HorizontalAlignment="Center"
                                         Width="295">
-                                        <Grid Margin="15,0,0,0">
-                                            <DockPanel IsVisible="{Binding DataContext.MenuVisibility, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type UserControl}}}" Margin="55,5,5,5">
-                                                <material:MaterialIcon
+										<Grid Margin="15,0,0,0">
+											<DockPanel IsVisible="{Binding DataContext.MenuVisibility, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type UserControl}}}" Margin="55,5,5,5">
+												<material:MaterialIcon
                                                     Height="22"
                                                     Kind="{Binding Icon}"
                                                     Width="22" />
-                                                <TextBlock
+												<TextBlock
                                                     FontSize="16"
                                                     FontWeight="Medium"
                                                     Margin="15,8,8,8"
                                                     Text="{Binding Header}" />
-                                            </DockPanel>
-                                            <Border HorizontalAlignment="Center" IsVisible="{Binding !DataContext.MenuVisibility, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type UserControl}}}">
-                                                <material:MaterialIcon
+											</DockPanel>
+											<Border HorizontalAlignment="Center" IsVisible="{Binding !DataContext.MenuVisibility, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type UserControl}}}">
+												<material:MaterialIcon
                                                     Height="22"
                                                     HorizontalAlignment="Center"
                                                     Kind="{Binding Icon}"
                                                     Margin="30,0,10,0"
                                                     VerticalAlignment="Center"
                                                     Width="22" />
-                                            </Border>
-                                        </Grid>
-                                    </RadioButton>
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
+											</Border>
+										</Grid>
+									</RadioButton>
+								</DataTemplate>
+							</ItemsControl.ItemTemplate>
+						</ItemsControl>
 
-                        <ScrollViewer>
-                            <ItemsControl Items="{Binding MenuItems}">
-                                <ItemsControl.ItemTemplate>
-                                    <DataTemplate>
-                                        <RadioButton
+						<ScrollViewer>
+							<ItemsControl Items="{Binding MenuItems}">
+								<ItemsControl.ItemTemplate>
+									<DataTemplate>
+										<RadioButton
                                             Classes="MenuItem"
                                             Command="{Binding DataContext.ChangePage, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type UserControl}}}"
                                             CommandParameter="{Binding Content}"
@@ -112,44 +135,44 @@
 
 
 
-                                            <Grid Margin="15,0,0,0">
-                                                <DockPanel IsVisible="{Binding DataContext.MenuVisibility, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type UserControl}}}" Margin="55,5,5,5">
-                                                    <material:MaterialIcon
+											<Grid Margin="15,0,0,0">
+												<DockPanel IsVisible="{Binding DataContext.MenuVisibility, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type UserControl}}}" Margin="55,5,5,5">
+													<material:MaterialIcon
                                                         Height="22"
                                                         Kind="{Binding Icon}"
                                                         Width="22" />
-                                                    <TextBlock
+													<TextBlock
                                                         FontSize="16"
                                                         FontWeight="Medium"
                                                         Margin="15,8,8,8"
                                                         Text="{Binding Header}" />
-                                                </DockPanel>
-                                                <Border HorizontalAlignment="Center" IsVisible="{Binding !DataContext.MenuVisibility, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type UserControl}}}">
-                                                    <material:MaterialIcon
+												</DockPanel>
+												<Border HorizontalAlignment="Center" IsVisible="{Binding !DataContext.MenuVisibility, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type UserControl}}}">
+													<material:MaterialIcon
                                                         Height="22"
                                                         HorizontalAlignment="Center"
                                                         Kind="{Binding Icon}"
                                                         Margin="30,0,10,0"
                                                         VerticalAlignment="Center"
                                                         Width="22" />
-                                                </Border>
-                                            </Grid>
-                                        </RadioButton>
-                                    </DataTemplate>
-                                </ItemsControl.ItemTemplate>
-                            </ItemsControl>
+												</Border>
+											</Grid>
+										</RadioButton>
+									</DataTemplate>
+								</ItemsControl.ItemTemplate>
+							</ItemsControl>
 
 
-                        </ScrollViewer>
-                    </DockPanel>
-                </Grid>
-            </Border>
-        </SplitView.Pane>
+						</ScrollViewer>
+					</DockPanel>
+				</Grid>
+			</Border>
+		</SplitView.Pane>
 
-        <Grid Background="#fafafa">
-            <ContentControl Content="{Binding CurrentPage}" />
+		<Grid Background="#fafafa">
+			<ContentControl Content="{Binding CurrentPage}" />
 
-        </Grid>
-    </SplitView>
+		</Grid>
+	</SplitView>
 
 </UserControl>

--- a/SukiUI/Controls/SideMenu.axaml.cs
+++ b/SukiUI/Controls/SideMenu.axaml.cs
@@ -15,8 +15,6 @@ namespace SukiUI.Controls
         public SideMenu()
         {
             InitializeComponent();
-
-
         }
 
         private void InitializeComponent()

--- a/SukiUI/Controls/SideMenuModel.cs
+++ b/SukiUI/Controls/SideMenuModel.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Controls;
+﻿using Avalonia;
+using Avalonia.Controls;
 using Material.Icons;
 using ReactiveUI;
 using System;
@@ -19,7 +20,6 @@ namespace SukiUI.Controls
 
     public class SideMenuModel : ReactiveObject
     {
-
         
 
         private bool menuvisibility = true;
@@ -27,7 +27,11 @@ namespace SukiUI.Controls
         public bool MenuVisibility
         {
             get => menuvisibility;
-            set => this.RaiseAndSetIfChanged(ref menuvisibility, value);
+            set
+            {
+                this.RaiseAndSetIfChanged(ref menuvisibility, value);
+                this.RaisePropertyChanged("SpacerEnabled");
+            }
         }
 
         public void ChangeMenuVisibility()
@@ -73,5 +77,30 @@ namespace SukiUI.Controls
         {
             CurrentPage = o;
         }
+
+
+        private bool headerContentOverlapsToggleSidebarButton = true;
+        /// <summary>
+        /// Defines if header content can overlap sidebar visibility button.
+        /// If true - they can take the same spot in the UI, which can lead to bugs when the content is too wide.
+        /// If false - header content moves below the sidebar button.
+        /// Default is true.
+        /// </summary>
+        public bool HeaderContentOverlapsToggleSidebarButton
+        {
+            get => headerContentOverlapsToggleSidebarButton;
+            set => this.RaiseAndSetIfChanged(ref headerContentOverlapsToggleSidebarButton, value);
+        }
+
+        /// <summary>
+        /// Defines if element that moves menu buttons down is enabled.
+        /// </summary>
+        // Property name must be equal to string inside MenuVisibility property.
+        private bool SpacerEnabled
+        {
+            get { return HeaderContentOverlapsToggleSidebarButton && !MenuVisibility; }
+        }
+
+        public int HeaderMinHeight { get => HeaderContentOverlapsToggleSidebarButton ? 40 : 0; }
     }
 }


### PR DESCRIPTION
# Description
Fixes bug, described in #9. 

# Changes
- Added new property `HeaderContentOverlapsToggleSidebarButton` that controls if toggle sidebar button can overlap with header content.
- Fixed menu items and toggle button overlap by addin MinHeight property to Header content. Its value depends on `HeaderContentOverlapsToggleSidebarButton` value.
- Fixed header content overlappling with sidebar button. Button position now depends on `HeaderContentOverlapsToggleSidebarButton` property - if it is `True` - the original button outside DockPanel is shown. If `False` - a copied button that is inside DockPanel is shown.  




<details>  
<summary>Screenshots</summary>  

`HeaderContentOverlapsToggleSidebarButton=True`

![image](https://user-images.githubusercontent.com/31821994/194726684-5d960f2b-d021-4a13-93dd-b213fceb98fb.png)  

`HeaderContentOverlapsToggleSidebarButton=False`  

![image](https://user-images.githubusercontent.com/31821994/194726716-e8fe66d1-43a6-45ba-94aa-c814e636415c.png)

</details>  

# Notes
As the button code was copied, DRY principle was violated. But making the button a separate component could be a bad idea either.
The other problem is that I don't know what the next version of SukiUI based on Avalonia 0.11 mentioned in readme will contain, because there is no branch on GitHub where people can see the code. Because of that - this could contain breaking changes for the future release, if `Sidebar` component was modified.
And maybe the issue was already fixed in new version.

Also - maybe consider moving the documentation to Github Wiki that can be enabled in repository settings? `Readme.md` is hard to read and modify. It should show off the possibilities and list features, tell about contributing and license, but all the details, examples of implementation etc should be on their own pages on something like wiki.