### PR TITLE
Toast & ColourTheme improvements.

### DIFF
--- a/SukiTest/App.axaml
+++ b/SukiTest/App.axaml
@@ -2,15 +2,10 @@
     x:Class="SukiTest.App"
     xmlns="https://github.com/avaloniaui"
     xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
-    xmlns:system="clr-namespace:System;assembly=System.Runtime"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:sukiUi="clr-namespace:SukiUI;assembly=SukiUI">
-
     <Application.Styles>
         <sukiUi:SukiTheme ColorTheme="Blue" />
         <avalonia:MaterialIconStyles />
     </Application.Styles>
-
-
-
 </Application>

--- a/SukiTest/DashboardPage.axaml.cs
+++ b/SukiTest/DashboardPage.axaml.cs
@@ -12,6 +12,8 @@ using SukiUI.Controls;
 using System.Threading;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Threading;
+using SukiUI;
+using SukiUI.Enums;
 using SukiUI.Theme;
 
 
@@ -83,43 +85,10 @@ public partial class DashboardPage : UserControl
     {
         AvaloniaXamlLoader.Load(this);
     }
-
-    private int _test = 1;
     
     private void ShowDialog(object sender, RoutedEventArgs e)
     {
-      
         SukiHost.ShowDialog(new DialogContent(), allowBackgroundClose: true);
-        _test++;
-    }
-
-    private void ShowNotification(object sender, RoutedEventArgs e)
-    {
-        try
-        {
-            /*   var notif = new Avalonia.Controls.Notifications.Notification("Info", "message");
-               notificationManager.Position = NotificationPosition.BottomRight;
-               notificationManager.Show(notif);
-
-               notif = new Avalonia.Controls.Notifications.Notification("Error", "message", NotificationType.Error);
-               notificationManager.Position = NotificationPosition.BottomRight;
-               notificationManager.Show(notif);
-
-               notif = new Avalonia.Controls.Notifications.Notification("Warning", "message", NotificationType.Warning);
-               notificationManager.Position = NotificationPosition.BottomRight;
-               notificationManager.Show(notif); */
-
-            var notif = new Avalonia.Controls.Notifications.Notification("Success", "A new invoice has been created.",
-                NotificationType.Success);
-            MainWindow m = (MainWindow)((ClassicDesktopStyleApplicationLifetime)Application.Current.ApplicationLifetime)
-                .MainWindow;
-            m.notificationManager.Position = NotificationPosition.BottomRight;
-            m.notificationManager.Show(notif);
-        }
-        catch (Exception exc)
-        {
-            Console.WriteLine(exc.Message);
-        }
     }
 
     private void CloseHandler(object sender, RoutedEventArgs e)
@@ -173,11 +142,6 @@ public partial class DashboardPage : UserControl
     }
 
     // Write a function that returns the sum of two numbers.
-
-    private void ShowToast(object? sender, RoutedEventArgs e)
-    {
-        //InteractiveContainer.ShowToast(new TextBlock() { Text = "Hello World !", Margin = new Thickness(15, 8) }, 5);
-    }
 
     private void SetBusy(object? sender, RoutedEventArgs e)
     {

--- a/SukiTest/MainWindow.axaml
+++ b/SukiTest/MainWindow.axaml
@@ -25,13 +25,18 @@
             <suki:SideMenuModel HeaderContentOverlapsToggleSidebarButton="True">
                 <suki:SideMenuModel.HeaderContent>
                     <StackPanel Margin="0,4,0,0">
-                        <Button
-                            Classes="Accent"
-                            Click="ChangeTheme"
-                            HorizontalAlignment="Left"
-                            Margin="0,0,0,0">
-                            <material:MaterialIcon Kind="LightbulbOutline" />
-                        </Button>
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Left">
+                            <Button
+                                Classes="Accent"
+                                Click="ChangeTheme">
+                                <material:MaterialIcon Kind="LightbulbOutline" />
+                            </Button>
+                            <Button
+                                Classes="Accent"
+                                Click="ChangeColor">
+                                <material:MaterialIcon Kind="Palette"/>
+                            </Button>
+                        </StackPanel>
                         <DockPanel Margin="0,20,0,0">
                             <material:MaterialIcon
                                 DockPanel.Dock="Left"
@@ -50,7 +55,6 @@
                                     FontWeight="Thin"
                                     Margin="3,1,0,0"
                                     Text="jean@mail.com" />
-
                             </StackPanel>
                         </DockPanel>
                         <Border

--- a/SukiTest/MainWindow.axaml
+++ b/SukiTest/MainWindow.axaml
@@ -11,7 +11,7 @@
                  xmlns:suki="clr-namespace:SukiUI.Controls;assembly=SukiUI"
                  xmlns:sukiTest="clr-namespace:SukiTest"
                  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
-                 suki:SukiHost.ToastLocation="BottomLeft"
+                 suki:SukiHost.ToastLocation="BottomRight"
                  suki:SukiHost.ToastLimit="2">
     <suki:SukiWindow.LogoContent>
         <material:MaterialIcon

--- a/SukiTest/MainWindow.axaml
+++ b/SukiTest/MainWindow.axaml
@@ -11,7 +11,8 @@
                  xmlns:suki="clr-namespace:SukiUI.Controls;assembly=SukiUI"
                  xmlns:sukiTest="clr-namespace:SukiTest"
                  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
-                 suki:SukiHost.ToastLocation="BottomRight">
+                 suki:SukiHost.ToastLocation="BottomLeft"
+                 suki:SukiHost.ToastLimit="2">
     <suki:SukiWindow.LogoContent>
         <material:MaterialIcon
             Foreground="{DynamicResource SukiPrimaryColor}"

--- a/SukiTest/MainWindow.axaml.cs
+++ b/SukiTest/MainWindow.axaml.cs
@@ -5,6 +5,8 @@ using Avalonia.Markup.Xaml;
 using SukiUI.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Styling;
+using SukiUI;
+using SukiUI.Enums;
 
 namespace SukiTest
 {
@@ -48,7 +50,16 @@ namespace SukiTest
                     SukiHost.ShowToast("Success!", "You Closed A Toast By Clicking On It!");
                 });
         }
-        
-        
+
+
+        private void ChangeColor(object? sender, RoutedEventArgs e)
+        {
+            var curr = SukiTheme.GetCurrentTheme();
+            if (curr is not { } currentTheme)
+                return;
+            var newColorTheme = (SukiColorTheme)(((int)currentTheme + 1) % 3);
+            SukiTheme.TryChangeTheme(newColorTheme);
+            SukiHost.ShowToast("Successfully Changed Color", $"Changed Color To {newColorTheme}.");
+        }
     }
 }

--- a/SukiTest/MainWindow.axaml.cs
+++ b/SukiTest/MainWindow.axaml.cs
@@ -1,20 +1,10 @@
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.ComponentModel;
-using System.Threading.Tasks;
 using Avalonia;
-using Avalonia.Controls;
 using Avalonia.Controls.Notifications;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using SukiUI.Controls;
-using SukiUI.MessageBox;
-using System.Threading;
 using Avalonia.Controls.Primitives;
 using Avalonia.Styling;
-using Avalonia.Threading;
-using SukiUI.Theme;
 
 namespace SukiTest
 {

--- a/SukiUI/Controls/Stepper.axaml.cs
+++ b/SukiUI/Controls/Stepper.axaml.cs
@@ -6,6 +6,7 @@ using Avalonia.Data;
 using Avalonia.Layout;
 using Avalonia.Media;
 using System.Collections.ObjectModel;
+using Avalonia.Markup.Xaml.MarkupExtensions;
 using SukiUI.Content;
 
 namespace SukiUI.Controls
@@ -86,22 +87,13 @@ namespace SukiUI.Controls
 
         private void AddStep(string step, int index,Grid grid)
         {
-            Brush PrimaryColor = new SolidColorBrush(Colors.DodgerBlue); 
             Brush DisabledColor = new SolidColorBrush(Color.FromArgb(100,150,150,150)); 
-
-            try
-            {
-
-                PrimaryColor = new SolidColorBrush((Color)Application.Current.FindResource("SukiPrimaryColor"));
-               
-            }catch{}
 
             var griditem = new Grid(){ ColumnDefinitions = new ColumnDefinitions(){new ColumnDefinition( GridLength.Auto), new ColumnDefinition(GridLength.Star), new ColumnDefinition(GridLength.Auto)}};
 
             var icon = new PathIcon() { Height = 10, Width = 10, Data = Icons.ChevronRight, Margin = new Thickness(0,0,20,0)};
             if (index == Steps.Count - 1)
                 icon.IsVisible = false;
-            
    
             Grid.SetColumn(icon,2);
             griditem.Children.Add(icon);
@@ -113,7 +105,7 @@ namespace SukiUI.Controls
 
             if (index <= Index)
             {
-                circle.Background = PrimaryColor;
+                circle[!BackgroundProperty] = new DynamicResourceExtension("SukiPrimaryColor");
                 
                 circle.BorderThickness = new Thickness(0);
                 circle.Child = new TextBlock() {VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Text = (index + 1).ToString(), FontSize = 13, Foreground = Brushes.White};

--- a/SukiUI/Controls/SukiToast.axaml.cs
+++ b/SukiUI/Controls/SukiToast.axaml.cs
@@ -59,4 +59,15 @@ public class SukiToast : ContentControl
         _timer.Interval = model.Lifetime.TotalMilliseconds;
         _timer.Start();
     }
+
+    internal void InitializeInvisible()
+    {
+        Title = "Invisible";
+        Content = "Invisible Content";
+        Opacity = 0;
+        _timer.Interval = 1;
+        _timer.Elapsed -= TimerOnElapsed;
+        _timer.Elapsed += (_, _) => SukiHost.ClearInvisibleToast(this);
+        _timer.Start();
+    }
 }

--- a/SukiUI/Controls/WaveProgress/WaveProgress.axaml.cs
+++ b/SukiUI/Controls/WaveProgress/WaveProgress.axaml.cs
@@ -10,7 +10,12 @@ public partial class WaveProgress : UserControl
     public WaveProgress()
     {
         InitializeComponent();
-        Application.Current.ActualThemeVariantChanged += (sender, args) =>
+        Application.Current.ActualThemeVariantChanged += (_, _) =>
+        {
+            Value++;
+            Value--;
+        };
+        SukiTheme.OnThemeChanged += _ =>
         {
             Value++;
             Value--;

--- a/SukiUI/Controls/WaveProgress/WaveProgress.axaml.cs
+++ b/SukiUI/Controls/WaveProgress/WaveProgress.axaml.cs
@@ -15,7 +15,7 @@ public partial class WaveProgress : UserControl
             Value++;
             Value--;
         };
-        SukiTheme.OnThemeChanged += _ =>
+        SukiTheme.OnColorThemeChanged += _ =>
         {
             Value++;
             Value--;

--- a/SukiUI/Enums/SukiColorTheme.cs
+++ b/SukiUI/Enums/SukiColorTheme.cs
@@ -1,0 +1,6 @@
+namespace SukiUI.Enums;
+
+public enum SukiColorTheme
+{
+    Blue, Green, Red, Orange
+}

--- a/SukiUI/Theme/Index.axaml.cs
+++ b/SukiUI/Theme/Index.axaml.cs
@@ -1,18 +1,14 @@
+using System;
 using Avalonia;
 using Avalonia.Data;
 using Avalonia.Media;
 using Avalonia.Styling;
+using SukiUI.Enums;
 
 namespace SukiUI;
 
-
-public enum SukiColorTheme
-{
-    Blue, Green, Red
-}
 public partial class SukiTheme : Styles
 {
-
     public static readonly StyledProperty<SukiColorTheme> ColorThemeProperty =
         AvaloniaProperty.Register<SukiTheme, SukiColorTheme>(nameof(ColorTheme), defaultBindingMode: BindingMode.TwoWay, defaultValue: SukiColorTheme.Blue);
 
@@ -21,11 +17,25 @@ public partial class SukiTheme : Styles
         get => GetValue(ColorThemeProperty);
         set { SetValue(ColorThemeProperty, value); SetColorThemeResources(); }
     }
+    
+    /// <summary>
+    /// Called whenever the application's <see cref="SukiColorTheme"/> is changed.
+    /// Useful where controls cannot use "DynamicResource"
+    /// </summary>
+    public static Action<SukiColorTheme>? OnThemeChanged { get; set; }
+
+    private static SukiTheme? _instance;
 
     public void SetColorThemeResources()
     {
+        _instance ??= this;
+        if (Application.Current is null) return;
         switch (ColorTheme)
         {
+            case SukiColorTheme.Orange:
+                Application.Current.Resources["SukiPrimaryColor"] = Color.Parse("#ED8E12");
+                Application.Current.Resources["SukiIntBorderBrush"] = Color.Parse("#151271ED");
+                break;
             case SukiColorTheme.Red:
                 Application.Current.Resources["SukiPrimaryColor"] = Colors.IndianRed;
                 Application.Current.Resources["SukiIntBorderBrush"] = Color.Parse("#15cc8888");
@@ -41,5 +51,25 @@ public partial class SukiTheme : Styles
                 Application.Current.Resources["SukiIntBorderBrush"] = Color.Parse("#158888ff");
                 break;
         }
+    }
+
+    /// <summary>
+    /// Attempts to change the theme to the given value.
+    /// </summary>
+    /// <param name="theme">The <see cref="SukiColorTheme"/> to change to.</param>
+    public static void TryChangeTheme(SukiColorTheme theme)
+    {
+        if (_instance is null) return;
+        _instance.ColorTheme = theme;
+        OnThemeChanged?.Invoke(theme);
+    }
+
+    /// <summary>
+    /// Gets the current <see cref="SukiColorTheme"/>
+    /// </summary>
+    /// <returns>The current <see cref="SukiColorTheme"/> or null if the style hasn't been initialized.</returns>
+    public static SukiColorTheme? GetCurrentTheme()
+    {
+        return _instance?.ColorTheme;
     }
 }

--- a/SukiUI/Theme/Index.axaml.cs
+++ b/SukiUI/Theme/Index.axaml.cs
@@ -22,7 +22,7 @@ public partial class SukiTheme : Styles
     /// Called whenever the application's <see cref="SukiColorTheme"/> is changed.
     /// Useful where controls cannot use "DynamicResource"
     /// </summary>
-    public static Action<SukiColorTheme>? OnThemeChanged { get; set; }
+    public static Action<SukiColorTheme>? OnColorThemeChanged { get; set; }
 
     private static SukiTheme? _instance;
 
@@ -61,7 +61,7 @@ public partial class SukiTheme : Styles
     {
         if (_instance is null) return;
         _instance.ColorTheme = theme;
-        OnThemeChanged?.Invoke(theme);
+        OnColorThemeChanged?.Invoke(theme);
     }
 
     /// <summary>


### PR DESCRIPTION
***Major Changes***
- Added the ability to change the application's current color theme (Demo in SukiTest with a button next to the light/dark switcher)
- Added callback `OnColorThemeChanged` to `SukiTheme` which allows controls which can't use bindings to update their colour as necessary. (Example in `WaveProgress` which listens for this callback to update it's gradient).

***Improvements***
- Added `ToastLimit` attached property that limits the amount of toasts that can be visible at any one time..
- The toast shown at the start to initialize the implicit animations is now completely invisible.
- Added an orange `ColorTheme` (because I like orange).

***Fixes***
- `Stepper` now uses a `DynamicResource` with binding syntax for it's colouring so it updates correctly when the app's colour theme changes.

***Outstanding Issues***
- Performance is  increasingly poor on my system (Win10), but it might very well just be my system.
- Controls should be moved from `Style` to `ControlTheme` eventually to improve performance.
- Would be nice to support custom colours in some way.
- Background images don't really reflect the theme.
- `SukiTest` should probably be renamed `SukiUI.Demo` and have full control demos available.
- XMLDocs don't seem to be included in the `.nupkg` which makes providing documentation to devs a bit more difficult.