### PR TITLE
Theme improvements.

### DIFF
--- a/SukiTest/App.axaml
+++ b/SukiTest/App.axaml
@@ -5,7 +5,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:sukiUi="clr-namespace:SukiUI;assembly=SukiUI">
     <Application.Styles>
-        <sukiUi:SukiTheme ColorTheme="Blue" />
+        <sukiUi:SukiTheme ThemeColor="Blue" />
         <avalonia:MaterialIconStyles />
     </Application.Styles>
 </Application>

--- a/SukiTest/DashboardPage.axaml
+++ b/SukiTest/DashboardPage.axaml
@@ -5,522 +5,535 @@
              xmlns:suki="clr-namespace:SukiUI.Controls;assembly=SukiUI"
              xmlns:theme="clr-namespace:SukiUI.Theme;assembly=SukiUI"
              xmlns:material="using:Material.Icons.Avalonia"
+             xmlns:sukiUi="clr-namespace:SukiUI;assembly=SukiUI"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SukiTest.DashboardPage">
     <ScrollViewer VerticalScrollBarVisibility="Hidden">
-                                        <Grid Margin="15">
-                                            <WrapPanel Orientation="Horizontal">
+        <Grid Margin="15">
+            <WrapPanel Orientation="Horizontal">
 
 
-                                                <Grid Margin="15">
-                                                    <suki:GlassCard Margin="0,0,0,25" Width="300">
-                                                        <suki:BusyArea Name="BusySignIn"
-                                                                       BusyText="Signing In...">
-                                                            <StackPanel>
-                                                                <material:MaterialIcon
-                                                                    Foreground="{DynamicResource SukiPrimaryColor}"
-                                                                    Height="30"
-                                                                    HorizontalAlignment="Center"
-                                                                    Kind="MicrosoftEdge"
-                                                                    Margin="10"
-                                                                    Width="30" />
+                <Grid Margin="15">
+                    <suki:GlassCard Margin="0,0,0,25" Width="300">
+                        <suki:BusyArea Name="BusySignIn"
+                                       BusyText="Signing In...">
+                            <StackPanel>
+                                <material:MaterialIcon
+                                    Foreground="{DynamicResource SukiPrimaryColor}"
+                                    Height="30"
+                                    HorizontalAlignment="Center"
+                                    Kind="MicrosoftEdge"
+                                    Margin="10"
+                                    Width="30" />
 
-                                                                <TextBlock
-                                                                    FontSize="18"
-                                                                    FontWeight="DemiBold"
-                                                                    HorizontalAlignment="Center"
-                                                                    Margin="0,5,0,27"
-                                                                    Text="Sign-in to your account" />
+                                <TextBlock
+                                    FontSize="18"
+                                    FontWeight="DemiBold"
+                                    HorizontalAlignment="Center"
+                                    Margin="0,5,0,27"
+                                    Text="Sign-in to your account" />
 
-                                                                <TextBlock
-                                                                    FontWeight="DemiBold"
-                                                                    Margin="6,0,0,3"
-                                                                    Text="Username" />
-                                                                <TextBox Watermark="Username"
-                                                                         theme:TextBoxExtensions.Prefix="" />
+                                <TextBlock
+                                    FontWeight="DemiBold"
+                                    Margin="6,0,0,3"
+                                    Text="Username" />
+                                <TextBox Watermark="Username"
+                                         theme:TextBoxExtensions.Prefix="" />
 
-                                                                <TextBlock
-                                                                    FontWeight="DemiBold"
-                                                                    Margin="6,18,0,3"
-                                                                    Text="Password" />
-                                                                <TextBox
-                                                                    Margin="0,0,0,25"
-                                                                    Name="PasswordTextBox"
-                                                                    PasswordChar="*"
-                                                                    theme:TextBoxExtensions.AddDeleteButton="False" />
-                                                            </StackPanel>
-                                                        </suki:BusyArea>
-                                                    </suki:GlassCard>
-                                                    <Button Classes="Primary Rounded"
-                                                            Click="SetBusy"
-                                                            HorizontalAlignment="Center"
-                                                            Name="ButtonSignIn"
-                                                            VerticalAlignment="Bottom" Margin="0,0,0,7"
-                                                            Width="160" Height="40"
-                                                           
-                                                            FontWeight="DemiBold" >Sign In</Button>
-                                                </Grid>
+                                <TextBlock
+                                    FontWeight="DemiBold"
+                                    Margin="6,18,0,3"
+                                    Text="Password" />
+                                <TextBox
+                                    Margin="0,0,0,25"
+                                    Name="PasswordTextBox"
+                                    PasswordChar="*"
+                                    theme:TextBoxExtensions.AddDeleteButton="False" />
+                            </StackPanel>
+                        </suki:BusyArea>
+                    </suki:GlassCard>
+                    <Button Classes="Primary Rounded"
+                            Click="SetBusy"
+                            HorizontalAlignment="Center"
+                            Name="ButtonSignIn"
+                            VerticalAlignment="Bottom" Margin="0,0,0,7"
+                            Width="160" Height="40"
 
-                                                <StackPanel>
-                                                    <suki:GlassCard
-                                                        Height="80"
-                                                        Margin="15"
-                                                        Width="300">
-                                                        <Grid>
-                                                            <StackPanel HorizontalAlignment="Left"
-                                                                        VerticalAlignment="Top">
-                                                                <TextBlock FontSize="16"
-                                                                           FontWeight="DemiBold"
-                                                                           Text="Uploading File .." />
-                                                                <TextBlock FontSize="12"
-                                                                           Foreground="{DynamicResource SukiLowText}"
-                                                                           Margin="2,4,0,0"
-                                                                           Text="Presentation.pdf" />
-                                                            </StackPanel>
-                                                            <suki:CircleProgressBar Height="37"
-                                                                HorizontalAlignment="Right"
-                                                                Margin="-55,-65,-10,-65"
-                                                                StrokeWidth="4"
-                                                                Value="67"
-                                                                VerticalAlignment="Center"
-                                                                Width="37">
-                                                                <TextBlock FontSize="13"
-                                                                           FontWeight="DemiBold"
-                                                                           HorizontalAlignment="Center"
-                                                                           Margin="1,1,0,0"
-                                                                           Text="67"
-                                                                           VerticalAlignment="Center" />
-                                                            </suki:CircleProgressBar>
-                                                        </Grid>
-                                                    </suki:GlassCard>
+                            FontWeight="DemiBold">
+                        Sign In
+                    </Button>
+                </Grid>
 
-                                                    <suki:GlassCard Classes="Card"
-                                                                    Margin="15"
-                                                                    Width="300">
-                                                        <StackPanel>
-                                                            <TextBlock
-                                                                FontSize="16"
-                                                                FontWeight="DemiBold"
-                                                                HorizontalAlignment="Left"
-                                                                Text="Daily Progress" />
-                                                            <Grid Margin="0,18,0,0">
-                                                                <TextBlock
-                                                                    FontSize="12"
-                                                                    FontWeight="DemiBold"
-                                                                    Foreground="{DynamicResource SukiLowText}"
-                                                                    HorizontalAlignment="Left"
-                                                                    Text="Project Workforce" />
-                                                                <StackPanel HorizontalAlignment="Right"
-                                                                            Orientation="Horizontal">
-                                                                    <TextBlock
-                                                                        FontSize="13"
-                                                                        Foreground="Green"
-                                                                        Text="32.21%" />
-                                                                    <material:MaterialIcon
-                                                                        Foreground="Green"
-                                                                        Kind="ArrowUp"
-                                                                        Margin="5,0,0,0" />
-                                                                </StackPanel>
-                                                            </Grid>
-                                                            <ProgressBar Margin="0,1,0,0" Value="16" />
-                                                            <Grid Margin="0,13,0,0">
-                                                                <TextBlock
-                                                                    FontSize="12"
-                                                                    FontWeight="DemiBold"
-                                                                    Foreground="{DynamicResource SukiLowText}"
-                                                                    HorizontalAlignment="Left"
-                                                                    Text="Project Velocity" />
-                                                                <StackPanel HorizontalAlignment="Right"
-                                                                            Orientation="Horizontal">
-                                                                    <TextBlock
-                                                                        FontSize="13"
-                                                                        Foreground="Red"
-                                                                        Text="7.18%" />
-                                                                    <material:MaterialIcon
-                                                                        Foreground="Red"
-                                                                        Kind="ArrowDown"
-                                                                        Margin="5,0,0,0" />
-                                                                </StackPanel>
-                                                            </Grid>
-                                                            <ProgressBar Margin="0,1,0,0" Value="62" />
+                <StackPanel>
+                    <suki:GlassCard
+                        Height="80"
+                        Margin="15"
+                        Width="300">
+                        <Grid>
+                            <StackPanel HorizontalAlignment="Left"
+                                        VerticalAlignment="Top">
+                                <TextBlock FontSize="16"
+                                           FontWeight="DemiBold"
+                                           Text="Uploading File .." />
+                                <TextBlock FontSize="12"
+                                           Foreground="{DynamicResource SukiLowText}"
+                                           Margin="2,4,0,0"
+                                           Text="Presentation.pdf" />
+                            </StackPanel>
+                            <suki:CircleProgressBar Height="37"
+                                                    HorizontalAlignment="Right"
+                                                    Margin="-55,-65,-10,-65"
+                                                    StrokeWidth="4"
+                                                    Value="67"
+                                                    VerticalAlignment="Center"
+                                                    Width="37">
+                                <TextBlock FontSize="13"
+                                           FontWeight="DemiBold"
+                                           HorizontalAlignment="Center"
+                                           Margin="1,1,0,0"
+                                           Text="67"
+                                           VerticalAlignment="Center" />
+                            </suki:CircleProgressBar>
+                        </Grid>
+                    </suki:GlassCard>
 
-                                                            <Grid Margin="0,13,0,0">
-                                                                <TextBlock
-                                                                    FontSize="12"
-                                                                    FontWeight="DemiBold"
-                                                                    Foreground="{DynamicResource SukiLowText}"
-                                                                    HorizontalAlignment="Left"
-                                                                    Text="Critical Hours" />
-                                                                <StackPanel HorizontalAlignment="Right"
-                                                                            Orientation="Horizontal">
-                                                                    <TextBlock
-                                                                        FontSize="13"
-                                                                        Foreground="Green"
-                                                                        Text="16.89%" />
-                                                                    <material:MaterialIcon
-                                                                        Foreground="Green"
-                                                                        Kind="ArrowUp"
-                                                                        Margin="5,0,0,0" />
-                                                                </StackPanel>
-                                                            </Grid>
-                                                            <ProgressBar Margin="0,1,0,0" Value="34" />
+                    <suki:GlassCard Classes="Card"
+                                    Margin="15"
+                                    Width="300">
+                        <StackPanel>
+                            <TextBlock
+                                FontSize="16"
+                                FontWeight="DemiBold"
+                                HorizontalAlignment="Left"
+                                Text="Daily Progress" />
+                            <Grid Margin="0,18,0,0">
+                                <TextBlock
+                                    FontSize="12"
+                                    FontWeight="DemiBold"
+                                    Foreground="{DynamicResource SukiLowText}"
+                                    HorizontalAlignment="Left"
+                                    Text="Project Workforce" />
+                                <StackPanel HorizontalAlignment="Right"
+                                            Orientation="Horizontal">
+                                    <TextBlock
+                                        FontSize="13"
+                                        Foreground="Green"
+                                        Text="32.21%" />
+                                    <material:MaterialIcon
+                                        Foreground="Green"
+                                        Kind="ArrowUp"
+                                        Margin="5,0,0,0" />
+                                </StackPanel>
+                            </Grid>
+                            <ProgressBar Margin="0,1,0,0" Value="16" />
+                            <Grid Margin="0,13,0,0">
+                                <TextBlock
+                                    FontSize="12"
+                                    FontWeight="DemiBold"
+                                    Foreground="{DynamicResource SukiLowText}"
+                                    HorizontalAlignment="Left"
+                                    Text="Project Velocity" />
+                                <StackPanel HorizontalAlignment="Right"
+                                            Orientation="Horizontal">
+                                    <TextBlock
+                                        FontSize="13"
+                                        Foreground="Red"
+                                        Text="7.18%" />
+                                    <material:MaterialIcon
+                                        Foreground="Red"
+                                        Kind="ArrowDown"
+                                        Margin="5,0,0,0" />
+                                </StackPanel>
+                            </Grid>
+                            <ProgressBar Margin="0,1,0,0" Value="62" />
 
-                                                        </StackPanel>
-                                                    </suki:GlassCard>
+                            <Grid Margin="0,13,0,0">
+                                <TextBlock
+                                    FontSize="12"
+                                    FontWeight="DemiBold"
+                                    Foreground="{DynamicResource SukiLowText}"
+                                    HorizontalAlignment="Left"
+                                    Text="Critical Hours" />
+                                <StackPanel HorizontalAlignment="Right"
+                                            Orientation="Horizontal">
+                                    <TextBlock
+                                        FontSize="13"
+                                        Foreground="Green"
+                                        Text="16.89%" />
+                                    <material:MaterialIcon
+                                        Foreground="Green"
+                                        Kind="ArrowUp"
+                                        Margin="5,0,0,0" />
+                                </StackPanel>
+                            </Grid>
+                            <ProgressBar Margin="0,1,0,0" Value="34" />
 
-                                                </StackPanel>
+                        </StackPanel>
+                    </suki:GlassCard>
 
-
-                                                <suki:GlassCard
-                                                    Height="320"
-                                                    Margin="15"
-                                                    VerticalAlignment="Top"
-                                                    Width="300">
-                                                    <Grid>
-
-                                                        <TextBlock
-                                                            FontSize="16"
-                                                            FontWeight="DemiBold"
-                                                            Text="Humidity" />
-                                                        <Viewbox
-                                                            Height="175"
-                                                            HorizontalAlignment="Center"
-                                                            Margin="0,0,0,5"
-                                                            VerticalAlignment="Center"
-                                                            Width="175">
-                                                            <suki:WaveProgress
-                                                                Value="{Binding Value, ElementName=SliderT}" />
-                                                        </Viewbox>
-
-                                                        <DockPanel VerticalAlignment="Bottom">
-                                                            <material:MaterialIcon
-                                                                DockPanel.Dock="Left"
-                                                                Foreground="#666666"
-                                                                Height="20"
-                                                                Kind="TemperatureLow"
-                                                                Width="20" />
-                                                            <material:MaterialIcon
-                                                                DockPanel.Dock="Right"
-                                                                Foreground="#666666"
-                                                                Height="20"
-                                                                Kind="TemperatureHigh"
-                                                                Width="20" />
-                                                            <Slider
-                                                                Margin="8,0"
-                                                                Maximum="100"
-                                                                Minimum="0"
-                                                                Name="SliderT"
-                                                                Value="23" />
-                                                        </DockPanel>
-
-                                                    </Grid>
-                                                </suki:GlassCard>
-
-                                                <suki:GlassCard
-                                                    Margin="15"
-                                                    VerticalAlignment="Top"
-                                                    Width="500">
-                                                    <Grid>
-                                                        <StackPanel>
-
-                                                            <StackPanel>
-                                                                <TextBlock
-                                                                    FontWeight="DemiBold"
-                                                                    HorizontalAlignment="Left"
-                                                                    Text="Notify me when .."
-                                                                    VerticalAlignment="Top" />
-                                                                <StackPanel Margin="0,8,0,0">
-                                                                    <StackPanel Margin="0,5,0,0"
-                                                                        Orientation="Horizontal">
-                                                                        <CheckBox IsChecked="True" />
-                                                                        <TextBlock
-                                                                            FontSize="13"
-                                                                            Foreground="{DynamicResource SukiLowText}"
-                                                                            Margin="8,0,0,0"
-                                                                            Text="Daily updates"
-                                                                            VerticalAlignment="Center" />
-                                                                    </StackPanel>
-                                                                    <StackPanel Margin="0,5,0,0"
-                                                                        Orientation="Horizontal">
-                                                                        <CheckBox IsChecked="True" />
-                                                                        <TextBlock
-                                                                            FontSize="13"
-                                                                            Foreground="{DynamicResource SukiLowText}"
-                                                                            Margin="8,0,0,0"
-                                                                            Text="New event"
-                                                                            VerticalAlignment="Center" />
-                                                                    </StackPanel>
-                                                                    <StackPanel Margin="0,5,0,0"
-                                                                        Orientation="Horizontal">
-                                                                        <CheckBox IsChecked="False" />
-                                                                        <TextBlock
-                                                                            FontSize="13"
-                                                                            Foreground="{DynamicResource SukiLowText}"
-                                                                            Margin="8,0,0,0"
-                                                                            Text="When added on new team"
-                                                                            VerticalAlignment="Center" />
-                                                                    </StackPanel>
-                                                                </StackPanel>
-                                                            </StackPanel>
-                                                            <Grid Margin="0,30,0,0">
-                                                                <ToggleButton
-                                                                    Classes="Switch"
-                                                                    HorizontalAlignment="Right"
-                                                                    IsChecked="True"
-                                                                    VerticalAlignment="Center" />
-                                                                <TextBlock
-                                                                    FontWeight="DemiBold"
-                                                                    HorizontalAlignment="Left"
-                                                                    Text="Mobile Notifications"
-                                                                    VerticalAlignment="Top" />
-
-                                                                <TextBlock
-                                                                    FontSize="13"
-                                                                    Foreground="{DynamicResource SukiLowText}"
-                                                                    HorizontalAlignment="Left"
-                                                                    Margin="0,22,0,0"
-                                                                    Text="Receive push notifications on your mobile phone."
-                                                                    TextWrapping="Wrap"
-                                                                    VerticalAlignment="Bottom"
-                                                                    Width="300" />
-                                                            </Grid>
-                                                            <Grid Margin="0,30,0,0">
-                                                                <ToggleButton
-                                                                    Classes="Switch"
-                                                                    HorizontalAlignment="Right"
-                                                                    IsChecked="False"
-                                                                    VerticalAlignment="Center" />
-                                                                <TextBlock
-                                                                    FontWeight="DemiBold"
-                                                                    HorizontalAlignment="Left"
-                                                                    Text="Desktop Notifications"
-                                                                    VerticalAlignment="Top" />
-
-                                                                <TextBlock
-                                                                    FontSize="13"
-                                                                    Foreground="{DynamicResource SukiLowText}"
-                                                                    HorizontalAlignment="Left"
-                                                                    Margin="0,22,0,0"
-                                                                    Text="Receive push notifications on your computer."
-                                                                    TextWrapping="Wrap"
-                                                                    VerticalAlignment="Bottom"
-                                                                    Width="300" />
-                                                            </Grid>
-                                                            <StackPanel Margin="0,30,0,0">
-
-                                                                <TextBlock
-                                                                    FontWeight="DemiBold"
-                                                                    HorizontalAlignment="Left"
-                                                                    Text="Language"
-                                                                    VerticalAlignment="Top" />
-
-                                                                <RadioButton Margin="0,13,0,0">
-                                                                    <TextBlock
-                                                                        FontSize="13"
-                                                                        Foreground="{DynamicResource SukiLowText}"
-                                                                        Margin="8,0,0,0"
-                                                                        Text="English"
-                                                                        VerticalAlignment="Center" />
-                                                                </RadioButton>
-                                                                <RadioButton IsChecked="True" Margin="0,5,0,0">
-                                                                    <TextBlock
-                                                                        FontSize="13"
-                                                                        Foreground="{DynamicResource SukiLowText}"
-                                                                        Margin="8,0,0,0"
-                                                                        Text="Chinese"
-                                                                        VerticalAlignment="Center" />
-                                                                </RadioButton>
-                                                                <RadioButton Margin="0,5,0,0">
-                                                                    <TextBlock
-                                                                        FontSize="13"
-                                                                        Foreground="{DynamicResource SukiLowText}"
-                                                                        Margin="8,0,0,0"
-                                                                        Text="Japanese"
-                                                                        VerticalAlignment="Center" />
-                                                                </RadioButton>
+                </StackPanel>
 
 
-                                                            </StackPanel>
-                                                        </StackPanel>
-                                                        <Button
-                                                            Classes="Accent"
-                                                            Click="ShowDialog"
-                                                            HorizontalAlignment="Right"
-                                                            Margin="0"
-                                                            VerticalAlignment="Top"
-                                                            Content="Create Link" />
-                                                    </Grid>
-                                                </suki:GlassCard>
+                <suki:GlassCard
+                    Height="320"
+                    Margin="15"
+                    VerticalAlignment="Top"
+                    Width="300">
+                    <Grid>
 
-                                                <StackPanel>
-                                                    <suki:GlassCard
-                                                        Height="281"
-                                                        Margin="15"
-                                                        Width="430">
-                                                        <TabControl>
-                                                            <TabItem>
-                                                                <TabItem.Header>
-                                                                    <TextBlock FontSize="16" Text="Invoices" />
-                                                                </TabItem.Header>
-                                                                <Grid>
+                        <TextBlock
+                            FontSize="16"
+                            FontWeight="DemiBold"
+                            Text="Humidity" />
+                        <Viewbox
+                            Height="175"
+                            HorizontalAlignment="Center"
+                            Margin="0,0,0,5"
+                            VerticalAlignment="Center"
+                            Width="175">
+                            <suki:WaveProgress
+                                Value="{Binding Value, ElementName=SliderT}" />
+                        </Viewbox>
+
+                        <DockPanel VerticalAlignment="Bottom">
+                            <material:MaterialIcon
+                                DockPanel.Dock="Left"
+                                Foreground="#666666"
+                                Height="20"
+                                Kind="TemperatureLow"
+                                Width="20" />
+                            <material:MaterialIcon
+                                DockPanel.Dock="Right"
+                                Foreground="#666666"
+                                Height="20"
+                                Kind="TemperatureHigh"
+                                Width="20" />
+                            <Slider
+                                Margin="8,0"
+                                Maximum="100"
+                                Minimum="0"
+                                Name="SliderT"
+                                Value="23" />
+                        </DockPanel>
+
+                    </Grid>
+                </suki:GlassCard>
+
+                <suki:GlassCard
+                    Margin="15"
+                    VerticalAlignment="Top"
+                    Width="500">
+                    <Grid>
+                        <StackPanel>
+
+                            <StackPanel>
+                                <TextBlock
+                                    FontWeight="DemiBold"
+                                    HorizontalAlignment="Left"
+                                    Text="Notify me when .."
+                                    VerticalAlignment="Top" />
+                                <StackPanel Margin="0,8,0,0">
+                                    <StackPanel Margin="0,5,0,0"
+                                                Orientation="Horizontal">
+                                        <CheckBox IsChecked="True" />
+                                        <TextBlock
+                                            FontSize="13"
+                                            Foreground="{DynamicResource SukiLowText}"
+                                            Margin="8,0,0,0"
+                                            Text="Daily updates"
+                                            VerticalAlignment="Center" />
+                                    </StackPanel>
+                                    <StackPanel Margin="0,5,0,0"
+                                                Orientation="Horizontal">
+                                        <CheckBox IsChecked="True" />
+                                        <TextBlock
+                                            FontSize="13"
+                                            Foreground="{DynamicResource SukiLowText}"
+                                            Margin="8,0,0,0"
+                                            Text="New event"
+                                            VerticalAlignment="Center" />
+                                    </StackPanel>
+                                    <StackPanel Margin="0,5,0,0"
+                                                Orientation="Horizontal">
+                                        <CheckBox IsChecked="False" />
+                                        <TextBlock
+                                            FontSize="13"
+                                            Foreground="{DynamicResource SukiLowText}"
+                                            Margin="8,0,0,0"
+                                            Text="When added on new team"
+                                            VerticalAlignment="Center" />
+                                    </StackPanel>
+                                </StackPanel>
+                            </StackPanel>
+                            <Grid Margin="0,30,0,0">
+                                <ToggleButton
+                                    Classes="Switch"
+                                    HorizontalAlignment="Right"
+                                    IsChecked="True"
+                                    VerticalAlignment="Center" />
+                                <TextBlock
+                                    FontWeight="DemiBold"
+                                    HorizontalAlignment="Left"
+                                    Text="Mobile Notifications"
+                                    VerticalAlignment="Top" />
+
+                                <TextBlock
+                                    FontSize="13"
+                                    Foreground="{DynamicResource SukiLowText}"
+                                    HorizontalAlignment="Left"
+                                    Margin="0,22,0,0"
+                                    Text="Receive push notifications on your mobile phone."
+                                    TextWrapping="Wrap"
+                                    VerticalAlignment="Bottom"
+                                    Width="300" />
+                            </Grid>
+                            <Grid Margin="0,30,0,0">
+                                <ToggleButton
+                                    Classes="Switch"
+                                    HorizontalAlignment="Right"
+                                    IsChecked="False"
+                                    VerticalAlignment="Center" />
+                                <TextBlock
+                                    FontWeight="DemiBold"
+                                    HorizontalAlignment="Left"
+                                    Text="Desktop Notifications"
+                                    VerticalAlignment="Top" />
+
+                                <TextBlock
+                                    FontSize="13"
+                                    Foreground="{DynamicResource SukiLowText}"
+                                    HorizontalAlignment="Left"
+                                    Margin="0,22,0,0"
+                                    Text="Receive push notifications on your computer."
+                                    TextWrapping="Wrap"
+                                    VerticalAlignment="Bottom"
+                                    Width="300" />
+                            </Grid>
+                            <StackPanel Margin="0,30,0,0">
+
+                                <TextBlock
+                                    FontWeight="DemiBold"
+                                    HorizontalAlignment="Left"
+                                    Text="Language"
+                                    VerticalAlignment="Top" />
+
+                                <RadioButton Margin="0,13,0,0">
+                                    <TextBlock
+                                        FontSize="13"
+                                        Foreground="{DynamicResource SukiLowText}"
+                                        Margin="8,0,0,0"
+                                        Text="English"
+                                        VerticalAlignment="Center" />
+                                </RadioButton>
+                                <RadioButton IsChecked="True" Margin="0,5,0,0">
+                                    <TextBlock
+                                        FontSize="13"
+                                        Foreground="{DynamicResource SukiLowText}"
+                                        Margin="8,0,0,0"
+                                        Text="Chinese"
+                                        VerticalAlignment="Center" />
+                                </RadioButton>
+                                <RadioButton Margin="0,5,0,0">
+                                    <TextBlock
+                                        FontSize="13"
+                                        Foreground="{DynamicResource SukiLowText}"
+                                        Margin="8,0,0,0"
+                                        Text="Japanese"
+                                        VerticalAlignment="Center" />
+                                </RadioButton>
 
 
-                                                                    <DataGrid
-                                                                        AutoGenerateColumns="True"
-                                                                        IsReadOnly="True"
-                                                                        Margin="15,10,15,0"
-                                                                        Name="myDG"
-                                                                        VerticalAlignment="Top" />
+                            </StackPanel>
+                        </StackPanel>
+                        <Button
+                            Classes="Accent"
+                            Click="ShowDialog"
+                            HorizontalAlignment="Right"
+                            Margin="0"
+                            VerticalAlignment="Top"
+                            Content="Create Link" />
+                    </Grid>
+                </suki:GlassCard>
 
-                                                                </Grid>
-                                                            </TabItem>
-                                                            <TabItem>
-                                                                <TabItem.Header>
-                                                                    <TextBlock FontSize="16" Text="Questions" />
-                                                                </TabItem.Header>
-                                                                <StackPanel Margin="0,10,0,0">
-                                                                    <Expander>
-                                                                        <Expander.Header>
-                                                                            <StackPanel Orientation="Horizontal">
-                                                                                <material:MaterialIcon Kind="Lock" />
-                                                                                <TextBlock Text="Test Lock" />
-                                                                            </StackPanel>
-                                                                        </Expander.Header>
-
-                                                                        <TextBlock
-                                                                            FontSize="13"
-                                                                            Margin="15,15"
-                                                                            TextWrapping="Wrap">
-                                                                            We understand that things change. You can cancel your plan at any time and we'll refund you.
-                                                                        </TextBlock>
-                                                                    </Expander>
-
-                                                                    <Expander Header="Can I change my plan later ?">
-                                                                        <TextBlock Margin="20,5">Answer</TextBlock>
-                                                                    </Expander>
-
-                                                                    <Expander
-                                                                        Header="How do I change my account email ?">
-                                                                        <TextBlock Margin="20,5">Answer</TextBlock>
-                                                                    </Expander>
-
-                                                                </StackPanel>
-                                                            </TabItem>
-
-                                                        </TabControl>
-                                                    </suki:GlassCard>
-                                                    <suki:GlassCard
-                                                        Height="85"
-                                                        Margin="15"
-                                                        Width="430">
-
-                                                        <suki:Stepper Margin="0,5,-4,0" Name="stepS" />
-                                                    </suki:GlassCard>
+                <StackPanel>
+                    <suki:GlassCard
+                        Height="281"
+                        Margin="15"
+                        Width="430">
+                        <TabControl>
+                            <TabItem>
+                                <TabItem.Header>
+                                    <TextBlock FontSize="16" Text="Invoices" />
+                                </TabItem.Header>
+                                <Grid>
 
 
-                                                </StackPanel>
+                                    <DataGrid
+                                        AutoGenerateColumns="True"
+                                        IsReadOnly="True"
+                                        Margin="15,10,15,0"
+                                        Name="myDG"
+                                        VerticalAlignment="Top" />
+
+                                </Grid>
+                            </TabItem>
+                            <TabItem>
+                                <TabItem.Header>
+                                    <TextBlock FontSize="16" Text="Questions" />
+                                </TabItem.Header>
+                                <StackPanel Margin="0,10,0,0">
+                                    <Expander>
+                                        <Expander.Header>
+                                            <StackPanel Orientation="Horizontal">
+                                                <material:MaterialIcon Kind="Lock" />
+                                                <TextBlock Text="Test Lock" />
+                                            </StackPanel>
+                                        </Expander.Header>
+
+                                        <TextBlock
+                                            FontSize="13"
+                                            Margin="15,15"
+                                            TextWrapping="Wrap">
+                                            We understand that things change. You can cancel your plan at any time and we'll refund you.
+                                        </TextBlock>
+                                    </Expander>
+
+                                    <Expander Header="Can I change my plan later ?">
+                                        <TextBlock Margin="20,5">Answer</TextBlock>
+                                    </Expander>
+
+                                    <Expander
+                                        Header="How do I change my account email ?">
+                                        <TextBlock Margin="20,5">Answer</TextBlock>
+                                    </Expander>
+
+                                </StackPanel>
+                            </TabItem>
+
+                        </TabControl>
+                    </suki:GlassCard>
+                    <suki:GlassCard
+                        Height="85"
+                        Margin="15"
+                        Width="430">
+
+                        <suki:Stepper Margin="0,5,-4,0" Name="stepS" />
+                    </suki:GlassCard>
 
 
-                                                <suki:GlassCard
-                                                    Height="270"
-                                                    Margin="15"
-                                                    Width="961">
-
-                                                    <suki:GroupBox>
-                                                        <suki:GroupBox.Header>
-                                                            <StackPanel Orientation="Horizontal">
-                                                                <material:MaterialIcon
-                                                                    Foreground="{DynamicResource SukiLowText}"
-                                                                    Kind="Dollar" />
-                                                                <TextBlock Margin="5,0,0,0" Text="Change Plan" />
-                                                            </StackPanel>
-                                                        </suki:GroupBox.Header>
-                                                        <WrapPanel
-                                                            HorizontalAlignment="Center"
-                                                            Margin="0,25,0,0"
-                                                            VerticalAlignment="Center">
-                                                            <RadioButton
-                                                                Classes="GigaChips"
-                                                                Height="138"
-                                                                IsChecked="True"
-                                                                Margin="8"
-                                                                Width="210">
-                                                                <StackPanel HorizontalAlignment="Left" Margin="7">
-                                                                    <TextBlock
-                                                                        FontSize="12"
-                                                                        FontWeight="DemiBold"
-                                                                        Foreground="{DynamicResource SukiLowText}"
-                                                                        Margin="5,8,5,4"
-                                                                        Text="HOBBY" />
-                                                                    <TextBlock
-                                                                        FontSize="23"
-                                                                        FontWeight="DemiBold"
-                                                                        Margin="5,8"
-                                                                        Text="1 Gb" />
-                                                                    <TextBlock
-                                                                        FontSize="15"
-                                                                        Foreground="{DynamicResource SukiLowText}"
-                                                                        Margin="5,3"
-                                                                        Text="Plan for a moderate use as hobby."
-                                                                        TextWrapping="Wrap" />
-                                                                </StackPanel>
-                                                            </RadioButton>
-                                                            <RadioButton
-                                                                Classes="GigaChips"
-                                                                Height="138"
-                                                                Margin="8"
-                                                                Width="210">
-                                                                <StackPanel HorizontalAlignment="Left" Margin="7">
-                                                                    <TextBlock
-                                                                        FontSize="12"
-                                                                        FontWeight="DemiBold"
-                                                                        Foreground="{DynamicResource SukiLowText}"
-                                                                        Margin="5,8,5,4"
-                                                                        Text="PROFESSIONAL" />
-                                                                    <TextBlock
-                                                                        FontSize="23"
-                                                                        FontWeight="DemiBold"
-                                                                        Margin="5,8"
-                                                                        Text="5 Gb" />
-                                                                    <TextBlock
-                                                                        FontSize="15"
-                                                                        Foreground="{DynamicResource SukiLowText}"
-                                                                        Margin="5,3"
-                                                                        Text="Plan for a professional use in an application."
-                                                                        TextWrapping="Wrap" />
-                                                                </StackPanel>
-                                                            </RadioButton>
-                                                            <RadioButton
-                                                                Classes="GigaChips"
-                                                                Height="138"
-                                                                Margin="8"
-                                                                Width="210">
-                                                                <StackPanel HorizontalAlignment="Left" Margin="7">
-                                                                    <TextBlock
-                                                                        FontSize="12"
-                                                                        FontWeight="DemiBold"
-                                                                        Foreground="{DynamicResource SukiLowText}"
-                                                                        Margin="5,8,5,4"
-                                                                        Text="COMPANY" />
-                                                                    <TextBlock
-                                                                        FontSize="23"
-                                                                        FontWeight="DemiBold"
-                                                                        Margin="5,8"
-                                                                        Text="50 Gb" />
-                                                                    <TextBlock
-                                                                        FontSize="15"
-                                                                        Foreground="{DynamicResource SukiLowText}"
-                                                                        Margin="5,3"
-                                                                        Text="Plan for a industrial use in a company."
-                                                                        TextWrapping="Wrap" />
-                                                                </StackPanel>
-                                                            </RadioButton>
-                                                        </WrapPanel>
-                                                    </suki:GroupBox>
-                                                </suki:GlassCard>
-
-                                            </WrapPanel>
-
-                                        </Grid>
-                                    </ScrollViewer>
+                </StackPanel>
+                <suki:GlassCard
+                    Height="270"
+                    Margin="15"
+                    Width="961">
+                    <suki:GroupBox>
+                        <suki:GroupBox.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <material:MaterialIcon
+                                    Foreground="{DynamicResource SukiLowText}"
+                                    Kind="Dollar" />
+                                <TextBlock Margin="5,0,0,0" Text="Change Plan" />
+                            </StackPanel>
+                        </suki:GroupBox.Header>
+                        <WrapPanel
+                            HorizontalAlignment="Center"
+                            Margin="0,25,0,0"
+                            VerticalAlignment="Center">
+                            <RadioButton
+                                Classes="GigaChips"
+                                Height="138"
+                                IsChecked="True"
+                                Margin="8"
+                                Width="210">
+                                <StackPanel HorizontalAlignment="Left" Margin="7">
+                                    <TextBlock
+                                        FontSize="12"
+                                        FontWeight="DemiBold"
+                                        Foreground="{DynamicResource SukiLowText}"
+                                        Margin="5,8,5,4"
+                                        Text="HOBBY" />
+                                    <TextBlock
+                                        FontSize="23"
+                                        FontWeight="DemiBold"
+                                        Margin="5,8"
+                                        Text="1 Gb" />
+                                    <TextBlock
+                                        FontSize="15"
+                                        Foreground="{DynamicResource SukiLowText}"
+                                        Margin="5,3"
+                                        Text="Plan for a moderate use as hobby."
+                                        TextWrapping="Wrap" />
+                                </StackPanel>
+                            </RadioButton>
+                            <RadioButton
+                                Classes="GigaChips"
+                                Height="138"
+                                Margin="8"
+                                Width="210">
+                                <StackPanel HorizontalAlignment="Left" Margin="7">
+                                    <TextBlock
+                                        FontSize="12"
+                                        FontWeight="DemiBold"
+                                        Foreground="{DynamicResource SukiLowText}"
+                                        Margin="5,8,5,4"
+                                        Text="PROFESSIONAL" />
+                                    <TextBlock
+                                        FontSize="23"
+                                        FontWeight="DemiBold"
+                                        Margin="5,8"
+                                        Text="5 Gb" />
+                                    <TextBlock
+                                        FontSize="15"
+                                        Foreground="{DynamicResource SukiLowText}"
+                                        Margin="5,3"
+                                        Text="Plan for a professional use in an application."
+                                        TextWrapping="Wrap" />
+                                </StackPanel>
+                            </RadioButton>
+                            <RadioButton
+                                Classes="GigaChips"
+                                Height="138"
+                                Margin="8"
+                                Width="210">
+                                <StackPanel HorizontalAlignment="Left" Margin="7">
+                                    <TextBlock
+                                        FontSize="12"
+                                        FontWeight="DemiBold"
+                                        Foreground="{DynamicResource SukiLowText}"
+                                        Margin="5,8,5,4"
+                                        Text="COMPANY" />
+                                    <TextBlock
+                                        FontSize="23"
+                                        FontWeight="DemiBold"
+                                        Margin="5,8"
+                                        Text="50 Gb" />
+                                    <TextBlock
+                                        FontSize="15"
+                                        Foreground="{DynamicResource SukiLowText}"
+                                        Margin="5,3"
+                                        Text="Plan for a industrial use in a company."
+                                        TextWrapping="Wrap" />
+                                </StackPanel>
+                            </RadioButton>
+                        </WrapPanel>
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard Margin="15">
+                    <DockPanel LastChildFill="True">
+                        <TextBlock Classes="h3" DockPanel.Dock="Top" Text="Available Colour Themes"/>
+                        <ItemsControl ItemsSource="{x:Static sukiUi:SukiTheme.DisplaySwatches}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <StackPanel Orientation="Horizontal" Spacing="10">
+                                        <Rectangle Fill="{Binding Value}" Width="15" Height="15"/>
+                                        <TextBlock FontSize="16" Text="{Binding Key}" Foreground="{Binding Value}"/>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </DockPanel>
+                </suki:GlassCard>
+            </WrapPanel>
+        </Grid>
+    </ScrollViewer>
 </UserControl>

--- a/SukiTest/DashboardPage.axaml
+++ b/SukiTest/DashboardPage.axaml
@@ -521,12 +521,12 @@
                 <suki:GlassCard Margin="15">
                     <DockPanel LastChildFill="True">
                         <TextBlock Classes="h3" DockPanel.Dock="Top" Text="Available Colour Themes"/>
-                        <ItemsControl ItemsSource="{x:Static sukiUi:SukiTheme.DisplaySwatches}">
+                        <ItemsControl ItemsSource="{x:Static sukiUi:SukiTheme.ColorThemes}">
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>
                                     <StackPanel Orientation="Horizontal" Spacing="10">
-                                        <Rectangle Fill="{Binding Value}" Width="15" Height="15"/>
-                                        <TextBlock FontSize="16" Text="{Binding Key}" Foreground="{Binding Value}"/>
+                                        <Rectangle Fill="{Binding PrimaryBrush}" Width="15" Height="15"/>
+                                        <TextBlock FontSize="16" Text="{Binding Theme}" Foreground="{Binding PrimaryBrush}"/>
                                     </StackPanel>
                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>

--- a/SukiTest/MainWindow.axaml.cs
+++ b/SukiTest/MainWindow.axaml.cs
@@ -54,10 +54,10 @@ namespace SukiTest
 
         private void ChangeColor(object? sender, RoutedEventArgs e)
         {
-            var curr = SukiTheme.GetCurrentTheme();
+            var curr = SukiTheme.ActiveColorTheme;
             if (curr is not { } currentTheme)
                 return;
-            var newColorTheme = (SukiColorTheme)(((int)currentTheme + 1) % 3);
+            var newColorTheme = (SukiColor)(((int)currentTheme.Theme + 1) % 4);
             SukiTheme.TryChangeTheme(newColorTheme);
             SukiHost.ShowToast("Successfully Changed Color", $"Changed Color To {newColorTheme}.");
         }

--- a/SukiUI/Enums/SukiColor.cs
+++ b/SukiUI/Enums/SukiColor.cs
@@ -1,6 +1,6 @@
 namespace SukiUI.Enums;
 
-public enum SukiColorTheme
+public enum SukiColor
 {
     Blue, Green, Red, Orange
 }

--- a/SukiUI/Models/SukiColorTheme.cs
+++ b/SukiUI/Models/SukiColorTheme.cs
@@ -1,0 +1,24 @@
+using Avalonia.Media;
+using SukiUI.Enums;
+
+namespace SukiUI.Models;
+
+public record SukiColorTheme
+{
+    public SukiColor Theme { get; }
+    
+    public Color Primary { get; }
+
+    public IBrush PrimaryBrush => new SolidColorBrush(Primary);
+    
+    public Color IntBorder { get; }
+
+    public IBrush IntBorderBrush => new SolidColorBrush(IntBorder);
+    
+    public SukiColorTheme(SukiColor theme, Color primary, Color intBorder)
+    {
+        Theme = theme;
+        Primary = primary;
+        IntBorder = intBorder;
+    }
+}

--- a/SukiUI/Theme/Index.axaml.cs
+++ b/SukiUI/Theme/Index.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Avalonia;
 using Avalonia.Data;
 using Avalonia.Media;
@@ -10,14 +11,19 @@ namespace SukiUI;
 public partial class SukiTheme : Styles
 {
     public static readonly StyledProperty<SukiColorTheme> ColorThemeProperty =
-        AvaloniaProperty.Register<SukiTheme, SukiColorTheme>(nameof(ColorTheme), defaultBindingMode: BindingMode.TwoWay, defaultValue: SukiColorTheme.Blue);
+        AvaloniaProperty.Register<SukiTheme, SukiColorTheme>(nameof(ColorTheme), defaultBindingMode: BindingMode.TwoWay,
+            defaultValue: SukiColorTheme.Blue);
 
     public SukiColorTheme ColorTheme
     {
         get => GetValue(ColorThemeProperty);
-        set { SetValue(ColorThemeProperty, value); SetColorThemeResources(); }
+        set
+        {
+            SetValue(ColorThemeProperty, value);
+            SetColorThemeResources();
+        }
     }
-    
+
     /// <summary>
     /// Called whenever the application's <see cref="SukiColorTheme"/> is changed.
     /// Useful where controls cannot use "DynamicResource"
@@ -30,28 +36,20 @@ public partial class SukiTheme : Styles
     {
         _instance ??= this;
         if (Application.Current is null) return;
-        switch (ColorTheme)
-        {
-            case SukiColorTheme.Orange:
-                Application.Current.Resources["SukiPrimaryColor"] = Color.Parse("#ED8E12");
-                Application.Current.Resources["SukiIntBorderBrush"] = Color.Parse("#151271ED");
-                break;
-            case SukiColorTheme.Red:
-                Application.Current.Resources["SukiPrimaryColor"] = Colors.IndianRed;
-                Application.Current.Resources["SukiIntBorderBrush"] = Color.Parse("#15cc8888");
-                break;
-            
-            case SukiColorTheme.Green:
-                Application.Current.Resources["SukiPrimaryColor"] = Colors.ForestGreen;
-                Application.Current.Resources["SukiIntBorderBrush"] = Color.Parse("#1588cc88");
-                break;
-            
-            default:
-                Application.Current.Resources["SukiPrimaryColor"] = Color.Parse("#0A59F7");
-                Application.Current.Resources["SukiIntBorderBrush"] = Color.Parse("#158888ff");
-                break;
-        }
+        if (!Swatches.TryGetValue(ColorTheme, out var swatch))
+            throw new Exception($"{ColorTheme} has no defined swatch.");
+        Application.Current.Resources["SukiPrimaryColor"] = swatch.Primary;
+        Application.Current.Resources["SukiIntBorderBrush"] = swatch.IntBorder;
     }
+
+    public static readonly IReadOnlyDictionary<SukiColorTheme, (Color Primary, Color IntBorder)> Swatches =
+        new Dictionary<SukiColorTheme, (Color Primary, Color IntBorder)>
+        {
+            { SukiColorTheme.Orange, (Color.Parse("#ED8E12"), Color.Parse("#151271ED")) },
+            { SukiColorTheme.Red, (Colors.IndianRed, Color.Parse("#15cc8888")) },
+            { SukiColorTheme.Green, (Colors.ForestGreen, Color.Parse("#1588cc88")) },
+            { SukiColorTheme.Blue, (Color.Parse("#0A59F7"), Color.Parse("#158888ff")) }
+        };
 
     /// <summary>
     /// Attempts to change the theme to the given value.

--- a/SukiUI/Theme/Index.axaml.cs
+++ b/SukiUI/Theme/Index.axaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Avalonia;
 using Avalonia.Data;
 using Avalonia.Media;
@@ -42,6 +43,9 @@ public partial class SukiTheme : Styles
         Application.Current.Resources["SukiIntBorderBrush"] = swatch.IntBorder;
     }
 
+    /// <summary>
+    /// All available Color Themes.
+    /// </summary>
     public static readonly IReadOnlyDictionary<SukiColorTheme, (Color Primary, Color IntBorder)> Swatches =
         new Dictionary<SukiColorTheme, (Color Primary, Color IntBorder)>
         {
@@ -50,6 +54,12 @@ public partial class SukiTheme : Styles
             { SukiColorTheme.Green, (Colors.ForestGreen, Color.Parse("#1588cc88")) },
             { SukiColorTheme.Blue, (Color.Parse("#0A59F7"), Color.Parse("#158888ff")) }
         };
+
+    /// <summary>
+    /// Provides Brushes for displaying all the available color themes.
+    /// </summary>
+    public static IReadOnlyDictionary<SukiColorTheme, IBrush> DisplaySwatches =>
+        Swatches.ToDictionary(x => x.Key, y => (IBrush)new SolidColorBrush(y.Value.Primary));
 
     /// <summary>
     /// Attempts to change the theme to the given value.

--- a/SukiUI/Theme/Index.axaml.cs
+++ b/SukiUI/Theme/Index.axaml.cs
@@ -80,4 +80,11 @@ public partial class SukiTheme : Styles
         _instance.ThemeColor = sukiColor;
         OnColorThemeChanged?.Invoke(ActiveColorTheme);
     }
+
+    /// <summary>
+    /// <inheritdoc cref="TryChangeTheme(SukiUI.Enums.SukiColor)"/>
+    /// </summary>
+    /// <param name="sukiColorTheme"></param>
+    public static void TryChangeTheme(SukiColorTheme sukiColorTheme) => 
+        TryChangeTheme(sukiColorTheme.Theme);
 }


### PR DESCRIPTION
***Changes***
- Create a `SukiColorTheme` type that encapsulates all the colors/brushes necessary.
- Create a dev-accessible list of themes so that devs can list available themes for user selection.
- Provide Brushes so that color themes can be displayed in the UI by devs (Demo in SukiTest).
- API and documentation improvements for `SukiTheme`.
- Technically this _almost_ allows custom themes, but it still relies on the `SukiColor` enum which prevents that right now.

***Outstanding Issues***
- Orange theme `IntBorderBrush` is wrong, I don't know what that hex colour string should even be, Rider's guess is wrong and I'm not familiar with that long hex string for colours.