### PR TITLE
Major themeing improvements.

### DIFF
--- a/SukiTest/MainWindow.axaml.cs
+++ b/SukiTest/MainWindow.axaml.cs
@@ -39,12 +39,10 @@ namespace SukiTest
         private void ChangeTheme(object? sender, RoutedEventArgs e)
         {
             if (Application.Current is null) return;
-            var current = Application.Current.RequestedThemeVariant;
-            Application.Current.RequestedThemeVariant = current == ThemeVariant.Dark 
-                ? ThemeVariant.Light 
-                : ThemeVariant.Dark;
             
-            SukiHost.ShowToast("Successfully Changed Theme", $"Changed Theme To {Application.Current.RequestedThemeVariant}", onClicked:
+            SukiTheme.SwitchBaseTheme();
+            
+            SukiHost.ShowToast("Successfully Changed Theme", $"Changed Theme To {Application.Current.ActualThemeVariant}", onClicked:
                 () =>
                 {
                     SukiHost.ShowToast("Success!", "You Closed A Toast By Clicking On It!");
@@ -58,7 +56,7 @@ namespace SukiTest
             if (curr is not { } currentTheme)
                 return;
             var newColorTheme = (SukiColor)(((int)currentTheme.Theme + 1) % 4);
-            SukiTheme.TryChangeTheme(newColorTheme);
+            SukiTheme.TryChangeColorTheme(newColorTheme);
             SukiHost.ShowToast("Successfully Changed Color", $"Changed Color To {newColorTheme}.");
         }
     }

--- a/SukiUI/Controls/SettingsLayout.axaml
+++ b/SukiUI/Controls/SettingsLayout.axaml
@@ -109,7 +109,7 @@
 
             <Setter Property="TextBlock.FontWeight" Value="DemiBold" />
             <Setter Property="TextBlock.Foreground" Value="{DynamicResource SukiPrimaryColor}" />
-            <Setter Property="Background" Value="{DynamicResource SukiIntBorderBrush}" />
+            <Setter Property="Background" Value="{DynamicResource SukiAccentColor}" />
             <Setter Property="BorderBrush" Value="{DynamicResource SukiPrimaryColor}" />
             <Setter Property="BorderThickness" Value="0,0,0,0" />
         </Style>

--- a/SukiUI/Controls/SukiBackground.cs
+++ b/SukiUI/Controls/SukiBackground.cs
@@ -1,0 +1,103 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
+using Avalonia.Skia;
+using Avalonia.Styling;
+using SkiaSharp;
+using SukiUI.Models;
+
+namespace SukiUI.Controls;
+
+public class SukiBackground : Image, IDisposable
+{
+    private readonly WriteableBitmap _bmp = new(new PixelSize(1280,720), new Vector(96,96), PixelFormat.Rgba8888);
+    
+    private readonly SKImageFilter _blurFilter = SKImageFilter.CreateBlur(1000, 1000);
+    private readonly SKPaint _paint = new();
+
+    public SukiBackground()
+    {
+        Source = _bmp;
+        Stretch = Stretch.UniformToFill;
+    }
+    
+    public override void EndInit()
+    {
+        base.EndInit();
+        // 60 FPS Ticks...
+        Draw(SukiTheme.ActiveColorTheme, Application.Current!.ActualThemeVariant);
+        SukiTheme.OnColorThemeChanged += Draw;
+        SukiTheme.OnBaseThemeChanged += Draw;
+    }
+
+    private void Draw(SukiColorTheme theme) => Draw(theme, Application.Current!.ActualThemeVariant);
+
+    private void Draw(ThemeVariant baseTheme) => Draw(SukiTheme.ActiveColorTheme, baseTheme);
+
+    private void Draw(SukiColorTheme theme, ThemeVariant baseTheme)
+    {
+        var themeColor = theme.Primary;
+        var intBorder = theme.Accent;
+        
+        using var framebuffer = _bmp.Lock();
+        var info =  new SKImageInfo(framebuffer.Size.Width, framebuffer.Size.Height,
+            framebuffer.Format.ToSkColorType(),SKAlphaType.Premul);
+        using var surface =  SKSurface.Create(info, framebuffer.Address, framebuffer.RowBytes);
+        var canvas = surface.Canvas;
+        
+        canvas.Clear(baseTheme == ThemeVariant.Light ? SKColors.White : SKColors.Black); // Uses IntBorder as base color
+        
+        _paint.ImageFilter = _blurFilter;
+        _paint.Style = SKPaintStyle.Fill;
+        
+        _paint.Color = new SKColor(themeColor.R, themeColor.G, themeColor.B, 50);
+        canvas.DrawPath(BottomRightPath(), _paint);
+        
+        // generates a "complementary" color by just spinning the H value by 180 deg.
+        _paint.Color = new SKColor(intBorder.R, intBorder.G, intBorder.B, 40);
+        canvas.DrawPath(TopLeftPath(), _paint);
+    }
+
+
+    // Draw arbitrary looking shapes in a variety of places
+    private SKPath? _bottomRightPath;
+    private SKPath BottomRightPath()
+    {
+        if (_bottomRightPath is not null) return _bottomRightPath;
+        _bottomRightPath = new SKPath();
+        _bottomRightPath.MoveTo(1500,900);
+        _bottomRightPath.RLineTo(-700, 0);
+        _bottomRightPath.RLineTo(100, -200);
+        _bottomRightPath.RLineTo(50, -50);
+        _bottomRightPath.RLineTo(200, -100);
+        _bottomRightPath.LineTo(1500, 420);
+        _bottomRightPath.Close();
+        return _bottomRightPath;
+    }
+
+    private SKPath? _topLeftPath;
+    private SKPath TopLeftPath()
+    {
+        if (_topLeftPath is not null) return _topLeftPath;
+        _topLeftPath = new SKPath();
+        _topLeftPath.MoveTo(-200,-200);
+        _topLeftPath.RLineTo(720, 0);
+        _topLeftPath.RLineTo(150, 300);
+        _topLeftPath.RLineTo(-350, 300);
+        _topLeftPath.LineTo(-200, 400);
+        _topLeftPath.Close();
+        return _topLeftPath;
+    }
+
+    public void Dispose()
+    {
+        _bmp.Dispose();
+        _blurFilter.Dispose();
+        _paint.Dispose();
+        _bottomRightPath?.Dispose();
+        _topLeftPath?.Dispose();
+    }
+}

--- a/SukiUI/Controls/SukiWindow.axaml
+++ b/SukiUI/Controls/SukiWindow.axaml
@@ -15,14 +15,15 @@
                             <suki:SukiHost>
                                 <Grid x:Name="PART_Root">
                                     <Grid IsHitTestVisible="False">
-                                        <Image
-                                            IsVisible="{DynamicResource IsDark}"
-                                            Source="../Assets/gradient_dark_strong.png"
-                                            Stretch="UniformToFill" />
-                                        <Image
-                                            IsVisible="{DynamicResource IsLight}"
-                                            Source="../Assets/mesh-gradient (1).png"
-                                            Stretch="UniformToFill" />
+                                        <suki:SukiBackground/>
+                                        <!-- <Image -->
+                                        <!--     IsVisible="{DynamicResource IsDark}" -->
+                                        <!--     Source="../Assets/gradient_dark_strong.png" -->
+                                        <!--     Stretch="UniformToFill" /> -->
+                                        <!-- <Image -->
+                                        <!--     IsVisible="{DynamicResource IsLight}" -->
+                                        <!--     Source="../Assets/mesh-gradient (1).png" -->
+                                        <!--     Stretch="UniformToFill" /> -->
                                     </Grid>
                                     <DockPanel LastChildFill="True">
                                         <!-- Title Bar... -->

--- a/SukiUI/Models/SukiColorTheme.cs
+++ b/SukiUI/Models/SukiColorTheme.cs
@@ -11,14 +11,14 @@ public record SukiColorTheme
 
     public IBrush PrimaryBrush => new SolidColorBrush(Primary);
     
-    public Color IntBorder { get; }
+    public Color Accent { get; }
 
-    public IBrush IntBorderBrush => new SolidColorBrush(IntBorder);
+    public IBrush AccentBrush => new SolidColorBrush(Accent);
     
-    public SukiColorTheme(SukiColor theme, Color primary, Color intBorder)
+    public SukiColorTheme(SukiColor theme, Color primary, Color accent)
     {
         Theme = theme;
         Primary = primary;
-        IntBorder = intBorder;
+        Accent = accent;
     }
 }

--- a/SukiUI/SukiUI.csproj
+++ b/SukiUI/SukiUI.csproj
@@ -23,6 +23,7 @@
         <Description>https://github.com/kikipoulet/SukiUI</Description>
         <PackageVersion>5.1.2</PackageVersion>
         <Nullable>enable</Nullable>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/SukiUI/Theme/DatePicker.axaml
+++ b/SukiUI/Theme/DatePicker.axaml
@@ -230,7 +230,7 @@
                                 </ScrollViewer>
                             </Panel>
                             <Border
-                                Background="{DynamicResource SukiIntBorderBrush}"
+                                Background="{DynamicResource SukiAccentColor}"
                                 CornerRadius="8"
                                 Grid.Column="0"
                                 Grid.ColumnSpan="5"

--- a/SukiUI/Theme/Index.axaml.cs
+++ b/SukiUI/Theme/Index.axaml.cs
@@ -26,12 +26,13 @@ public partial class SukiTheme : Styles
         }
     }
     
-    
     /// <summary>
     /// Called whenever the application's <see cref="SukiColor"/> is changed.
     /// Useful where controls cannot use "DynamicResource"
     /// </summary>
     public static Action<SukiColorTheme>? OnColorThemeChanged { get; set; }
+    
+    public static Action<ThemeVariant>? OnBaseThemeChanged { get; set; }
 
     /// <summary>
     /// Currently active <see cref="SukiColorTheme"/>
@@ -51,10 +52,10 @@ public partial class SukiTheme : Styles
     {
         ColorThemes = new[]
         {
-            new SukiColorTheme(SukiColor.Orange, Color.Parse("#ED8E12"), Color.Parse("#151271ED")),
-            new SukiColorTheme(SukiColor.Red, Colors.IndianRed, Color.Parse("#15cc8888")),
-            new SukiColorTheme(SukiColor.Green, Colors.ForestGreen, Color.Parse("#1588cc88")),
-            new SukiColorTheme(SukiColor.Blue, Color.Parse("#0A59F7"), Color.Parse("#158888ff"))
+            new SukiColorTheme(SukiColor.Orange, Color.Parse("#ED8E12"), Color.Parse("#15176CE8")),
+            new SukiColorTheme(SukiColor.Red, Color.Parse("#D03A2F"), Color.Parse("#152FC5D0")),
+            new SukiColorTheme(SukiColor.Green, Color.Parse("#4DB24F"), Color.Parse("#15B24DB0")),
+            new SukiColorTheme(SukiColor.Blue, Color.Parse("#0A59F7"), Color.Parse("#15F7A80A"))
         };
         ColorThemeMap = ColorThemes.ToDictionary(x => x.Theme);
     }
@@ -66,7 +67,7 @@ public partial class SukiTheme : Styles
         if (!ColorThemeMap.TryGetValue(ThemeColor, out var colorTheme))
             throw new Exception($"{ThemeColor} has no defined color theme.");
         Application.Current.Resources["SukiPrimaryColor"] = colorTheme.Primary;
-        Application.Current.Resources["SukiIntBorderBrush"] = colorTheme.IntBorder;
+        Application.Current.Resources["SukiAccentColor"] = colorTheme.Accent;
         ActiveColorTheme = colorTheme;
     }
     
@@ -74,7 +75,7 @@ public partial class SukiTheme : Styles
     /// Attempts to change the theme to the given value.
     /// </summary>
     /// <param name="sukiColor">The <see cref="SukiColor"/> to change to.</param>
-    public static void TryChangeTheme(SukiColor sukiColor)
+    public static void TryChangeColorTheme(SukiColor sukiColor)
     {
         if (_instance is null) return;
         _instance.ThemeColor = sukiColor;
@@ -82,9 +83,34 @@ public partial class SukiTheme : Styles
     }
 
     /// <summary>
-    /// <inheritdoc cref="TryChangeTheme(SukiUI.Enums.SukiColor)"/>
+    /// <inheritdoc cref="TryChangeColorTheme(SukiUI.Enums.SukiColor)"/>
     /// </summary>
     /// <param name="sukiColorTheme"></param>
-    public static void TryChangeTheme(SukiColorTheme sukiColorTheme) => 
-        TryChangeTheme(sukiColorTheme.Theme);
+    public static void TryChangeColorTheme(SukiColorTheme sukiColorTheme) => 
+        TryChangeColorTheme(sukiColorTheme.Theme);
+
+    /// <summary>
+    /// Tries to change the base theme to the one provided, if it is different.
+    /// </summary>
+    /// <param name="baseTheme"></param>
+    public static void TryChangeBaseTheme(ThemeVariant baseTheme)
+    {
+        if (Application.Current is null) return;
+        if (Application.Current.ActualThemeVariant == baseTheme) return;
+        Application.Current!.RequestedThemeVariant = baseTheme;
+        OnBaseThemeChanged?.Invoke(baseTheme);
+    }
+
+    /// <summary>
+    /// Simply switches from Light -> Dark and visa versa.
+    /// </summary>
+    public static void SwitchBaseTheme()
+    {
+        if (Application.Current is null) return;
+        var newBase = Application.Current.ActualThemeVariant == ThemeVariant.Dark 
+            ? ThemeVariant.Light 
+            : ThemeVariant.Dark;
+        Application.Current.RequestedThemeVariant = newBase;
+        OnBaseThemeChanged?.Invoke(newBase);
+    }
 }

--- a/SukiUI/Theme/ListBoxItemStyle.axaml
+++ b/SukiUI/Theme/ListBoxItemStyle.axaml
@@ -70,7 +70,7 @@
     </Style>
 
     <Style Selector="ListBoxItem:selected /template/ Border#BorderBasicStyle">
-        <Setter Property="Background" Value="{DynamicResource SukiIntBorderBrush}" />
+        <Setter Property="Background" Value="{DynamicResource SukiAccentColor}" />
     </Style>
     <Style Selector="ListBoxItem:pointerover /template/ Border#BorderBasicStyle">
         <Setter Property="Background" Value="{DynamicResource SukiLightBackground}" />

--- a/SukiUI/Theme/RadioButtonStyles.xaml
+++ b/SukiUI/Theme/RadioButtonStyles.xaml
@@ -127,7 +127,7 @@
 
     <Style Selector="RadioButton.GigaChips:checked  Border#BigBorder">
         <Setter Property="BorderBrush" Value="{DynamicResource SukiPrimaryColor}" />
-        <Setter Property="Background" Value="{DynamicResource SukiIntBorderBrush}" />
+        <Setter Property="Background" Value="{DynamicResource SukiAccentColor}" />
         <Setter Property="BorderThickness" Value="2" />
         <Setter Property="Margin" Value="0" />
     </Style>
@@ -327,7 +327,7 @@
 
         <Setter Property="TextBlock.FontWeight" Value="DemiBold" />
         <Setter Property="TextBlock.Foreground" Value="{DynamicResource SukiPrimaryColor}" />
-        <Setter Property="Background" Value="{DynamicResource SukiIntBorderBrush}" />
+        <Setter Property="Background" Value="{DynamicResource SukiAccentColor}" />
         <Setter Property="BorderBrush" Value="{DynamicResource SukiPrimaryColor}" />
         <Setter Property="BorderThickness" Value="0,0,0,0" />
     </Style>


### PR DESCRIPTION
***Major Changes***
- Implemented a simple dynamic background that uses theme colours and Skia rendering toys to match the theme.
- Modified the base SukiThemeColor to operate on a "Primary" and "Accent" system, with the accent colour being useful for both the background and adding a little more colour into controls in the future.

***Improvements***
- Moved base theme interaction into `SukiTheme` via `TryChangeBaseTheme` and `SwitchBaseTheme` so the library can keep a track of what the currently active base theme is.

***Fixes***
- Fixed issue where clicking the button to change between light/dark wouldn't do anything on the first click.

***Outstanding Issues***
- Defining default `SukiColorTheme` instances could be cleaner.
- Colour choices need to be improved.
- Background design itself could use some work, especially in light mode.
- There might need to be `PrimaryDark` colour added to the `SukiColorTheme` which is just the primary colour but slightly darker for controls that need it.
- Removing dependency on `SukiColor` enum for themes would be a good first step to allowing custom user-defined themes.
- Old background Image assets can be removed now that they are not needed.