### PR TITLE
Minor change 

### DIFF
--- a/SukiTest/MainWindow.axaml.cs
+++ b/SukiTest/MainWindow.axaml.cs
@@ -63,6 +63,11 @@ namespace SukiTest
         private void ChangeAnimationState(object? sender, RoutedEventArgs e)
         {
             BackgroundAnimationEnabled = !BackgroundAnimationEnabled;
+            var title = BackgroundAnimationEnabled ? "Animation Enabled" : "Animation Disabled";
+            var content = BackgroundAnimationEnabled
+                ? "Background animations are now enabled."
+                : "Background animations are now disabled.";
+            SukiHost.ShowToast(title, content);
         }
     }
 }

--- a/SukiUI/Controls/SukiBackground.cs
+++ b/SukiUI/Controls/SukiBackground.cs
@@ -12,8 +12,8 @@ namespace SukiUI.Controls;
 
 public class SukiBackground : Image, IDisposable
 {
-    private const int ImageWidth = 340;
-    private const int ImageHeight = 180;
+    private const int ImageWidth = 100;
+    private const int ImageHeight = 100;
 
     private readonly WriteableBitmap _bmp = new(new PixelSize(ImageWidth, ImageHeight), new Vector(96, 96),
         PixelFormats.Bgra8888);
@@ -30,7 +30,7 @@ public class SukiBackground : Image, IDisposable
     public SukiBackground()
     {
         Source = _bmp;
-        Stretch = Stretch.Fill;
+        Stretch = Stretch.UniformToFill;
         _animationTick.Elapsed += (_, _) => _renderer.Render(_bmp);
     }
 

--- a/SukiUI/Utilities/Background/FastNoiseBackgroundRenderer.cs
+++ b/SukiUI/Utilities/Background/FastNoiseBackgroundRenderer.cs
@@ -32,7 +32,7 @@ public sealed class FastNoiseBackgroundRenderer : ISukiBackgroundRenderer
     {
         var opt = options ?? new FastNoiseRendererOptions(FastNoiseLite.NoiseType.OpenSimplex2);
         NoiseGen.SetNoiseType(opt.Type);
-        _scale = opt.NoiseScale;
+        _scale = opt.NoiseScale * 100f;
         _xAnim = opt.XAnimSpeed;
         _yAnim = opt.YAnimSpeed;
         _primaryAlpha = opt.PrimaryAlpha;
@@ -63,6 +63,7 @@ public sealed class FastNoiseBackgroundRenderer : ISukiBackgroundRenderer
         
         using var frameBuffer = bitmap.Lock();
         var frameSize = frameBuffer.Size;
+        var frameScale = (1f / frameSize.Height) * _scale;
         
         var backBuffer = (uint*)frameBuffer.Address.ToPointer();
         var stride = frameBuffer.RowBytes / 4;
@@ -72,12 +73,12 @@ public sealed class FastNoiseBackgroundRenderer : ISukiBackgroundRenderer
             var dest = backBuffer + scanline * stride + 0;
             for (var x = 0; x < frameSize.Width; x++)
             {
-                var noise = NoiseGen.GetNoise((_pOffsetX + x) * _scale, (_pOffsetY + scanline) * _scale);
+                var noise = NoiseGen.GetNoise((_pOffsetX + x) * frameScale, (_pOffsetY + scanline) * frameScale);
                 noise = (noise + 1f) / 2f * _primaryAlpha; // noise returns -1 to +1 which isn't useful.
                 var alpha = (byte)(noise * 255);
                 var firstLayer = BlendPixelOverlay(WithAlpha(_themeColor, alpha), _baseColor);
                 
-                noise = NoiseGen.GetNoise((_aOffsetX + x) * _scale, (_aOffsetY + scanline) * _scale);
+                noise = NoiseGen.GetNoise((_aOffsetX + x) * frameScale, (_aOffsetY + scanline) * frameScale);
                 noise = (noise + 1f) / 2f * _accentAlpha;
                 alpha = (byte)(noise * 255);
 

--- a/SukiUI/Utilities/Background/FastNoiseRendererOptions.cs
+++ b/SukiUI/Utilities/Background/FastNoiseRendererOptions.cs
@@ -11,7 +11,7 @@ public readonly struct FastNoiseRendererOptions
     
     public FastNoiseRendererOptions(
         FastNoiseLite.NoiseType type, 
-        float noiseScale = 0.5f, 
+        float noiseScale = 1f,
         float xAnimSpeed = 0.05f, 
         float yAnimSpeed = 0.025f, 
         float primaryAlpha = 0.75f, 


### PR DESCRIPTION
Last PR for the day, forgot that this needed to be done...
- Made a key adjustment to the background renderer so that it now runs at any arbitrarily set resolution, means it can be set high/low depending on performance/quality targets.
  - Anything above 250,000 (500x500 for reference) pixel count starts to affect performance on my machine.
- Added a toast for enabling/disabling animations to `SukiTest`.