### PR TITLE
SukiTheme API Improvements.

### DIFF
--- a/SukiTest/App.axaml
+++ b/SukiTest/App.axaml
@@ -5,7 +5,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:sukiUi="clr-namespace:SukiUI;assembly=SukiUI">
     <Application.Styles>
-        <sukiUi:SukiTheme ThemeColor="Blue" />
+        <sukiUi:SukiTheme ThemeColor="Red" />
         <avalonia:MaterialIconStyles />
     </Application.Styles>
 </Application>

--- a/SukiTest/CircleProgressBarsTestMVVM/ControlsDemo.axaml
+++ b/SukiTest/CircleProgressBarsTestMVVM/ControlsDemo.axaml
@@ -1,10 +1,8 @@
 ﻿<UserControl
     Background="{DynamicResource SukiBackground}"
-
     mc:Ignorable="d"
     x:Class="SukiTest.CircleProgressBarsTestMVVM.ControlsDemo"
     xmlns="https://github.com/avaloniaui"
-    xmlns:circleProgressBarsTestMvvm="clr-namespace:SukiTest.CircleProgressBarsTestMVVM"
     xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -12,7 +10,7 @@
     xmlns:theme="clr-namespace:SukiUI.Theme;assembly=SukiUI"
     xmlns:objectModel="clr-namespace:System.Collections.ObjectModel;assembly=System.ObjectModel"
     xmlns:system="clr-namespace:System;assembly=System.Runtime"
-    xmlns:sukiUi="clr-namespace:SukiUI;assembly=SukiUI">
+    xmlns:models="clr-namespace:SukiUI.Models;assembly=SukiUI">
     <ScrollViewer>
         <ScrollViewer.Styles>
             <Style Selector="controls|GlassCard">
@@ -196,12 +194,12 @@
             <controls:GlassCard>
                 <DockPanel LastChildFill="True">
                     <TextBlock Classes="h3" DockPanel.Dock="Top" Text="Available Colour Themes" />
-                    <ItemsControl ItemsSource="{x:Static sukiUi:SukiTheme.ColorThemes}">
+                    <ItemsControl x:Name="ThemeList">
                         <ItemsControl.ItemTemplate>
-                            <DataTemplate>
+                            <DataTemplate DataType="models:SukiColorTheme">
                                 <StackPanel Orientation="Horizontal" Spacing="10">
                                     <Rectangle Fill="{Binding PrimaryBrush}" Width="15" Height="15" />
-                                    <TextBlock FontSize="16" Text="{Binding Theme}" Foreground="{Binding PrimaryBrush}" />
+                                    <TextBlock FontSize="16" Text="{Binding DisplayName}" Foreground="{Binding PrimaryBrush}" />
                                 </StackPanel>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>

--- a/SukiTest/CircleProgressBarsTestMVVM/ControlsDemo.axaml.cs
+++ b/SukiTest/CircleProgressBarsTestMVVM/ControlsDemo.axaml.cs
@@ -1,12 +1,11 @@
-﻿using System.Collections.Generic;
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
-using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using Avalonia.Threading;
+using SukiUI;
 using SukiUI.Controls;
 
 namespace SukiTest.CircleProgressBarsTestMVVM;
@@ -22,7 +21,7 @@ public partial class ControlsDemo : UserControl
             new Invoice() { Id = 45689, BillingName = "Fantine", Amount = 82, Paid = false },
             new Invoice() { Id = 15364, BillingName = "Jean", Amount = 156, Paid = true },
         };
-
+        this.Get<ItemsControl>("ThemeList").ItemsSource = SukiTheme.GetInstance().ColorThemes;
     }
 
     private void InitializeComponent()

--- a/SukiTest/MainWindow.axaml.cs
+++ b/SukiTest/MainWindow.axaml.cs
@@ -1,73 +1,60 @@
 using Avalonia;
-using Avalonia.Controls.Notifications;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using DynamicData;
 using SukiUI.Controls;
-using Avalonia.Controls.Primitives;
-using Avalonia.Styling;
 using SukiUI;
-using SukiUI.Enums;
+using SukiUI.Models;
 
-namespace SukiTest
+namespace SukiTest;
+
+public partial class MainWindow : SukiWindow
 {
-    
-    public partial class MainWindow : SukiWindow
+    private SukiTheme? _theme;
+
+    public MainWindow()
     {
-        public WindowNotificationManager notificationManager;
-   
-
-        public MainWindow()
-        {
-            InitializeComponent();
+        InitializeComponent();
 #if DEBUG
-            this.AttachDevTools();
+        this.AttachDevTools();
 #endif
-        }
+    }
 
-        private void InitializeComponent()
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+        _theme = SukiTheme.GetInstance();
+        _theme.OnBaseThemeChanged += variant =>
         {
-            AvaloniaXamlLoader.Load(this);
-        }
-
-        protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+            SukiHost.ShowToast("Successfully Changed Theme", $"Changed Theme To {variant}",
+                onClicked: () => { SukiHost.ShowToast("Success!", "You Closed A Toast By Clicking On It!"); });
+        };
+        _theme.OnColorThemeChanged += theme =>
         {
-            base.OnApplyTemplate(e);
-            if(notificationManager == null)
-                notificationManager = new WindowNotificationManager(this);
-        }
+            SukiHost.ShowToast("Successfully Changed Color", $"Changed Color To {theme.DisplayName}.");
+        };
         
-        private void ChangeTheme(object? sender, RoutedEventArgs e)
-        {
-            if (Application.Current is null) return;
-            
-            SukiTheme.SwitchBaseTheme();
-            
-            SukiHost.ShowToast("Successfully Changed Theme", $"Changed Theme To {Application.Current.ActualThemeVariant}", onClicked:
-                () =>
-                {
-                    SukiHost.ShowToast("Success!", "You Closed A Toast By Clicking On It!");
-                });
-        }
+        _theme.AddColorTheme(new SukiColorTheme("Neon Pink", Colors.DeepPink, Colors.GreenYellow));
+    }
 
+    private void ChangeTheme(object? sender, RoutedEventArgs e)
+    {
+        _theme?.SwitchBaseTheme();
+    }
 
-        private void ChangeColor(object? sender, RoutedEventArgs e)
-        {
-            var curr = SukiTheme.ActiveColorTheme;
-            if (curr is not { } currentTheme)
-                return;
-            var newColorTheme = (SukiColor)(((int)currentTheme.Theme + 1) % 4);
-            SukiTheme.TryChangeColorTheme(newColorTheme);
-            SukiHost.ShowToast("Successfully Changed Color", $"Changed Color To {newColorTheme}.");
-        }
+    private void ChangeColor(object? sender, RoutedEventArgs e)
+    {
+        _theme?.SwitchColorTheme();
+    }
 
-        private void ChangeAnimationState(object? sender, RoutedEventArgs e)
-        {
-            BackgroundAnimationEnabled = !BackgroundAnimationEnabled;
-            var title = BackgroundAnimationEnabled ? "Animation Enabled" : "Animation Disabled";
-            var content = BackgroundAnimationEnabled
-                ? "Background animations are now enabled."
-                : "Background animations are now disabled.";
-            SukiHost.ShowToast(title, content);
-        }
+    private void ChangeAnimationState(object? sender, RoutedEventArgs e)
+    {
+        BackgroundAnimationEnabled = !BackgroundAnimationEnabled;
+        var title = BackgroundAnimationEnabled ? "Animation Enabled" : "Animation Disabled";
+        var content = BackgroundAnimationEnabled
+            ? "Background animations are now enabled."
+            : "Background animations are now disabled.";
+        SukiHost.ShowToast(title, content);
     }
 }

--- a/SukiUI/Controls/SukiBackground.cs
+++ b/SukiUI/Controls/SukiBackground.cs
@@ -28,35 +28,32 @@ public class SukiBackground : Image, IDisposable
 
     private bool _animationEnabled = false;
 
+    private readonly SukiTheme _theme;
+
     public SukiBackground()
     {
         Source = _bmp;
         Stretch = Stretch.UniformToFill;
         _animationTick.Elapsed += (_, _) => _renderer.Render(_bmp);
+        _theme = SukiTheme.GetInstance();
     }
 
     public override void EndInit()
     {
         base.EndInit();
 
-        SukiTheme.OnColorThemeChanged += theme =>
+        _theme.OnColorThemeChanged += theme =>
         {
-            _renderer.UpdateValues(theme, Dispatcher.UIThread.Invoke(() => Application.Current!.ActualThemeVariant));
+            _renderer.UpdateValues(theme, Dispatcher.UIThread.Invoke(() => _theme.ActiveBaseTheme));
             _renderer.Render(_bmp);
         };
-        SukiTheme.OnBaseThemeChanged += baseTheme =>
+        _theme.OnBaseThemeChanged += baseTheme =>
         {
-            _renderer.UpdateValues(SukiTheme.ActiveColorTheme, baseTheme);
-            _renderer.Render(_bmp);
-        };
-
-        Application.Current.ActualThemeVariantChanged += (sender, args) =>
-        {
-            _renderer.UpdateValues(SukiTheme.ActiveColorTheme, Application.Current!.ActualThemeVariant);
+            _renderer.UpdateValues(_theme.ActiveColorTheme, baseTheme);
             _renderer.Render(_bmp);
         };
 
-        _renderer.UpdateValues(SukiTheme.ActiveColorTheme, Application.Current!.RequestedThemeVariant!);
+        _renderer.UpdateValues(_theme.ActiveColorTheme, _theme.ActiveBaseTheme);
         _renderer.Render(_bmp);
         
         if(_animationEnabled) _animationTick.Start();

--- a/SukiUI/Controls/SukiBackground.cs
+++ b/SukiUI/Controls/SukiBackground.cs
@@ -63,6 +63,7 @@ public class SukiBackground : Image, IDisposable
     {
         if (_animationEnabled == value) return;
         _animationEnabled = value;
+        if (!_renderer.SupportsAnimation) return;
         if(_animationEnabled) _animationTick.Start();
         else _animationTick.Stop();
     }

--- a/SukiUI/Controls/SukiBackground.cs
+++ b/SukiUI/Controls/SukiBackground.cs
@@ -14,6 +14,7 @@ public class SukiBackground : Image, IDisposable
 {
     private const int ImageWidth = 100;
     private const int ImageHeight = 100;
+    private const float AnimFps = 5;
 
     private readonly WriteableBitmap _bmp = new(new PixelSize(ImageWidth, ImageHeight), new Vector(96, 96),
         PixelFormats.Bgra8888);
@@ -23,7 +24,7 @@ public class SukiBackground : Image, IDisposable
     /// </summary>
     private readonly ISukiBackgroundRenderer _renderer = new FastNoiseBackgroundRenderer();
     
-    private static readonly Timer _animationTick = new(1000) { AutoReset = true }; // 1 fps
+    private static readonly Timer _animationTick = new(1000 / AnimFps) { AutoReset = true }; // 1 fps
 
     private bool _animationEnabled = false;
 
@@ -41,18 +42,18 @@ public class SukiBackground : Image, IDisposable
         SukiTheme.OnColorThemeChanged += theme =>
         {
             _renderer.UpdateValues(theme, Dispatcher.UIThread.Invoke(() => Application.Current!.ActualThemeVariant));
-            if (!_animationEnabled) _renderer.Render(_bmp);
+            _renderer.Render(_bmp);
         };
         SukiTheme.OnBaseThemeChanged += baseTheme =>
         {
             _renderer.UpdateValues(SukiTheme.ActiveColorTheme, baseTheme);
-            if (!_animationEnabled) _renderer.Render(_bmp);
+            _renderer.Render(_bmp);
         };
 
         Application.Current.ActualThemeVariantChanged += (sender, args) =>
         {
             _renderer.UpdateValues(SukiTheme.ActiveColorTheme, Application.Current!.ActualThemeVariant);
-            if (!_animationEnabled) _renderer.Render(_bmp);
+            _renderer.Render(_bmp);
         };
 
         _renderer.UpdateValues(SukiTheme.ActiveColorTheme, Application.Current!.RequestedThemeVariant!);

--- a/SukiUI/Controls/WaveProgress/WaveProgress.axaml.cs
+++ b/SukiUI/Controls/WaveProgress/WaveProgress.axaml.cs
@@ -10,12 +10,13 @@ public partial class WaveProgress : UserControl
     public WaveProgress()
     {
         InitializeComponent();
-        Application.Current.ActualThemeVariantChanged += (_, _) =>
+        var theme = SukiTheme.GetInstance();
+        theme.OnBaseThemeChanged += _ =>
         {
             Value++;
             Value--;
         };
-        SukiTheme.OnColorThemeChanged += _ =>
+        theme.OnColorThemeChanged += _ =>
         {
             Value++;
             Value--;

--- a/SukiUI/Models/SukiColorTheme.cs
+++ b/SukiUI/Models/SukiColorTheme.cs
@@ -5,7 +5,7 @@ namespace SukiUI.Models;
 
 public record SukiColorTheme
 {
-    public SukiColor Theme { get; }
+    public string DisplayName { get; }
     
     public Color Primary { get; }
 
@@ -15,10 +15,38 @@ public record SukiColorTheme
 
     public IBrush AccentBrush => new SolidColorBrush(Accent);
     
-    public SukiColorTheme(SukiColor theme, Color primary, Color accent)
+    public SukiColorTheme(string displayName, Color primary, Color accent)
     {
-        Theme = theme;
+        DisplayName = displayName;
         Primary = primary;
         Accent = accent;
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = 17;
+            hash *= 31 + Primary.GetHashCode();
+            hash *= 31 + Accent.GetHashCode();
+            hash *= 31 + DisplayName.GetHashCode();
+            return hash;
+        }
+    }
+
+    public override string ToString()
+    {
+        return DisplayName;
+    }
+}
+
+internal record DefaultSukiColorTheme : SukiColorTheme
+{
+    internal SukiColor ThemeColor { get; }
+    
+    internal DefaultSukiColorTheme(SukiColor themeColor, Color primary, Color accent) 
+        : base(themeColor.ToString(), primary, accent)
+    {
+        ThemeColor = themeColor;
     }
 }

--- a/SukiUI/Theme/Index.axaml.cs
+++ b/SukiUI/Theme/Index.axaml.cs
@@ -2,9 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Avalonia;
+using Avalonia.Collections;
 using Avalonia.Data;
+using Avalonia.Markup.Xaml;
 using Avalonia.Media;
 using Avalonia.Styling;
+using DynamicData;
 using SukiUI.Enums;
 using SukiUI.Extensions;
 using SukiUI.Models;
@@ -14,113 +17,128 @@ namespace SukiUI;
 public partial class SukiTheme : Styles
 {
     public static readonly StyledProperty<SukiColor> ThemeColorProperty =
-        AvaloniaProperty.Register<SukiTheme, SukiColor>(nameof(Color), defaultBindingMode: BindingMode.TwoWay,
+        AvaloniaProperty.Register<SukiTheme, SukiColor>(nameof(Color), defaultBindingMode: BindingMode.OneTime,
             defaultValue: SukiColor.Blue);
-
+    
+    /// <summary>
+    /// Used to assign the ColorTheme at launch,
+    /// </summary>
     public SukiColor ThemeColor
     {
         get => GetValue(ThemeColorProperty);
         set
         {
             SetValue(ThemeColorProperty, value);
-            SetColorThemeResources();
+            SetColorThemeResourcesOnColorThemeChanged();
         }
     }
-    
+
     /// <summary>
-    /// Called whenever the application's <see cref="SukiColor"/> is changed.
+    /// Called whenever the application's <see cref="SukiColorTheme"/> is changed.
     /// Useful where controls cannot use "DynamicResource"
     /// </summary>
-    public static Action<SukiColorTheme>? OnColorThemeChanged { get; set; }
+    public Action<SukiColorTheme>? OnColorThemeChanged { get; set; }
     
-    public static Action<ThemeVariant>? OnBaseThemeChanged { get; set; }
+    /// <summary>
+    /// Called whenever the application's <see cref="ThemeVariant"/> is changed.
+    /// Useful where controls need to change based on light/dark.
+    /// </summary>
+    public Action<ThemeVariant>? OnBaseThemeChanged { get; set; }
 
     /// <summary>
     /// Currently active <see cref="SukiColorTheme"/>
+    /// If you want to change this please use <see cref="ChangeColorTheme(SukiUI.Models.SukiColorTheme)"/>
     /// </summary>
-    public static SukiColorTheme ActiveColorTheme { get; private set; }
-    
+    public SukiColorTheme ActiveColorTheme { get; private set; }
+
     /// <summary>
     /// All available Color Themes.
     /// </summary>
-    public static readonly IReadOnlyList<SukiColorTheme> ColorThemes;
-    
-    internal static readonly IReadOnlyDictionary<SukiColor, SukiColorTheme> ColorThemeMap;
-    
-    private static SukiTheme? _instance;
-    
-    static SukiTheme()
-    {
-        ColorThemes = new[]
-        {
-            new SukiColorTheme(SukiColor.Orange, Color.Parse("#ED8E12"), Color.Parse("#176CE8")),
-            new SukiColorTheme(SukiColor.Red, Color.Parse("#D03A2F"), Color.Parse("#2FC5D0")),
-            new SukiColorTheme(SukiColor.Green, Colors.ForestGreen, Color.Parse("#B24DB0")),
-            new SukiColorTheme(SukiColor.Blue, Color.Parse("#0A59F7"), Color.Parse("#F7A80A"))
-        };
-        ColorThemeMap = ColorThemes.ToDictionary(x => x.Theme);
-    }
-    
-    public void SetColorThemeResources()
-    {
-        _instance ??= this;
-        if (Application.Current is null) return;
-        if (!ColorThemeMap.TryGetValue(ThemeColor, out var colorTheme))
-            throw new Exception($"{ThemeColor} has no defined color theme.");
-        SetColorWithOpacities("SukiPrimaryColor", colorTheme.Primary);
-        SetColorWithOpacities("SukiAccentColor", colorTheme.Accent);
-        SetResource("SukiPrimaryColor7", colorTheme.Primary.WithAlpha(0.07));
-        SetResource("SukiPrimaryColor5", colorTheme.Primary.WithAlpha(0.05));
-        SetResource("SukiPrimaryColor2", colorTheme.Primary.WithAlpha(0.02));
-        SetResource("SukiAccentColor1", colorTheme.Accent.WithAlpha(0.01));
-        ActiveColorTheme = colorTheme;
-    }
-
-    private static void SetColorWithOpacities(string baseName, Color baseColor)
-    {
-        SetResource(baseName, baseColor);
-        SetResource($"{baseName}50", baseColor.WithAlpha(0.5));
-        SetResource($"{baseName}25", baseColor.WithAlpha(0.25));
-        SetResource($"{baseName}10", baseColor.WithAlpha(0.1));
-    }
-
-    private static void SetResource(string name, Color color) => 
-        Application.Current!.Resources[name] = color;
+    public IAvaloniaReadOnlyList<SukiColorTheme> ColorThemes => _allThemes;
 
     /// <summary>
-    /// Attempts to change the theme to the given value.
+    /// Currently active <see cref="ThemeVariant"/>
+    /// If you want to change this please use <see cref="ChangeBaseTheme"/> or <see cref="SwitchBaseTheme"/>
+    /// </summary>
+    public ThemeVariant ActiveBaseTheme => _app.ActualThemeVariant;
+    
+    private readonly Application _app;
+    
+    private readonly HashSet<SukiColorTheme> _colorThemeHashset = new();
+    private readonly AvaloniaList<SukiColorTheme> _allThemes = new();
+    
+    
+    public SukiTheme()
+    {
+        AvaloniaXamlLoader.Load(this);
+        _app = Application.Current!;
+        _app.ActualThemeVariantChanged += (_, e) => OnBaseThemeChanged?.Invoke(_app.ActualThemeVariant);
+        foreach(var theme in DefaultColorThemes)
+            AddColorTheme(theme.Value);
+    }
+
+    /// <summary>
+    /// Change the theme to one of the default themes.
     /// </summary>
     /// <param name="sukiColor">The <see cref="SukiColor"/> to change to.</param>
-    public static void TryChangeColorTheme(SukiColor sukiColor)
+    public void ChangeColorTheme(SukiColor sukiColor) => 
+        ThemeColor = sukiColor;
+
+    /// <summary>
+    /// Tries to change the theme to a specific theme, this can be either a default or a custom defined one.
+    /// </summary>
+    /// <param name="sukiColorTheme"></param>
+    public void ChangeColorTheme(SukiColorTheme sukiColorTheme) => 
+        SetColorTheme(sukiColorTheme);
+
+    /// <summary>
+    /// Blindly switches to the "next" theme available in the <see cref="ColorThemes"/> collection.
+    /// </summary>
+    public void SwitchColorTheme()
     {
-        if (_instance is null) return;
-        _instance.ThemeColor = sukiColor;
-        OnColorThemeChanged?.Invoke(ActiveColorTheme);
+        var index = ColorThemes.IndexOf(ActiveColorTheme);
+        if (index == -1) return;
+        var newIndex = (index + 1) % ColorThemes.Count;
+        var newColorTheme = ColorThemes[newIndex];
+        ChangeColorTheme(newColorTheme);
     }
 
     /// <summary>
-    /// <inheritdoc cref="TryChangeColorTheme(SukiUI.Enums.SukiColor)"/>
+    /// Add a new <see cref="SukiColorTheme"/> to the ones available, without making it active.
     /// </summary>
-    /// <param name="sukiColorTheme"></param>
-    public static void TryChangeColorTheme(SukiColorTheme sukiColorTheme) => 
-        TryChangeColorTheme(sukiColorTheme.Theme);
+    /// <param name="sukiColorTheme">New <see cref="SukiColorTheme"/> to add.</param>
+    public void AddColorTheme(SukiColorTheme sukiColorTheme)
+    {
+        if (_colorThemeHashset.Contains(sukiColorTheme))
+            throw new InvalidOperationException("This color theme has already been added.");
+        _colorThemeHashset.Add(sukiColorTheme);
+        _allThemes.Add(sukiColorTheme);
+    }
+
+    /// <summary>
+    /// Adds multiple new <see cref="SukiColorTheme"/> to the ones available, without making any active.
+    /// </summary>
+    /// <param name="sukiColorThemes">A collection of new <see cref="SukiColorTheme"/> to add.</param>
+    public void AddColorThemes(IEnumerable<SukiColorTheme> sukiColorThemes)
+    {
+        foreach(var colorTheme in sukiColorThemes) 
+            AddColorTheme(colorTheme);
+    }
 
     /// <summary>
     /// Tries to change the base theme to the one provided, if it is different.
     /// </summary>
-    /// <param name="baseTheme"></param>
-    public static void TryChangeBaseTheme(ThemeVariant baseTheme)
+    /// <param name="baseTheme"><see cref="ThemeVariant"/> to change to.</param>
+    public void ChangeBaseTheme(ThemeVariant baseTheme)
     {
-        if (Application.Current is null) return;
-        if (Application.Current.ActualThemeVariant == baseTheme) return;
-        Application.Current!.RequestedThemeVariant = baseTheme;
-        OnBaseThemeChanged?.Invoke(baseTheme);
+        if (_app.ActualThemeVariant == baseTheme) return;
+        _app.RequestedThemeVariant = baseTheme;
     }
 
     /// <summary>
     /// Simply switches from Light -> Dark and visa versa.
     /// </summary>
-    public static void SwitchBaseTheme()
+    public void SwitchBaseTheme()
     {
         if (Application.Current is null) return;
         var newBase = Application.Current.ActualThemeVariant == ThemeVariant.Dark 
@@ -129,4 +147,80 @@ public partial class SukiTheme : Styles
         Application.Current.RequestedThemeVariant = newBase;
         OnBaseThemeChanged?.Invoke(newBase);
     }
+    
+    /// <summary>
+    /// Initializes the color theme resources whenever the property is changed.
+    /// In an ideal world people wouldn't use the property 
+    /// </summary>
+    private void SetColorThemeResourcesOnColorThemeChanged()
+    {
+        if (!DefaultColorThemes.TryGetValue(ThemeColor, out var colorTheme))
+            throw new Exception($"{ThemeColor} has no defined color theme.");
+        SetColorTheme(colorTheme);
+    }
+
+    private void SetColorTheme(SukiColorTheme colorTheme)
+    {
+        SetColorWithOpacities("SukiPrimaryColor", colorTheme.Primary);
+        SetColorWithOpacities("SukiAccentColor", colorTheme.Accent);
+        
+        SetResource("SukiPrimaryColor7", colorTheme.Primary.WithAlpha(0.07));
+        SetResource("SukiPrimaryColor5", colorTheme.Primary.WithAlpha(0.05));
+        SetResource("SukiPrimaryColor2", colorTheme.Primary.WithAlpha(0.02));
+        SetResource("SukiAccentColor1", colorTheme.Accent.WithAlpha(0.01));
+        
+        ActiveColorTheme = colorTheme;
+        OnColorThemeChanged?.Invoke(ActiveColorTheme);
+    }
+
+    private void SetColorWithOpacities(string baseName, Color baseColor)
+    {
+        SetResource(baseName, baseColor);
+        SetResource($"{baseName}50", baseColor.WithAlpha(0.5));
+        SetResource($"{baseName}25", baseColor.WithAlpha(0.25));
+        SetResource($"{baseName}10", baseColor.WithAlpha(0.1));
+    }
+
+    private void SetResource(string name, Color color) => 
+        _app.Resources[name] = color;
+    
+    // Static Members...
+    
+    /// <summary>
+    /// The default Color Themes included with SukiUI.
+    /// </summary>
+    public static readonly IReadOnlyDictionary<SukiColor, SukiColorTheme> DefaultColorThemes;
+    
+    static SukiTheme()
+    {
+        var defaultThemes = new[]
+        {
+            new DefaultSukiColorTheme(SukiColor.Orange, Color.Parse("#ED8E12"), Color.Parse("#176CE8")),
+            new DefaultSukiColorTheme(SukiColor.Red, Color.Parse("#D03A2F"), Color.Parse("#2FC5D0")),
+            new DefaultSukiColorTheme(SukiColor.Green, Colors.ForestGreen, Color.Parse("#B24DB0")),
+            new DefaultSukiColorTheme(SukiColor.Blue, Color.Parse("#0A59F7"), Color.Parse("#F7A80A"))
+        };
+        DefaultColorThemes = defaultThemes.ToDictionary(x => x.ThemeColor, y => (SukiColorTheme)y);
+    }
+    
+    /// <summary>
+    /// Retrieves an instance tied to a specific instance of an application.
+    /// </summary>
+    /// <returns>A <see cref="SukiTheme"/> instance that can be used to change themes.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if no SukiTheme has been defined in App.axaml.</exception>
+    public static SukiTheme GetInstance(Application app) 
+    {
+        var theme = app.Styles.FirstOrDefault(style => style is SukiTheme);
+        if (theme is not SukiTheme sukiTheme)
+            throw new InvalidOperationException(
+                "No SukiTheme instance available. Ensure SukiTheme has been set in Application.Styles in App.axaml.");
+        return sukiTheme;
+    }
+    
+    /// <summary>
+    /// Retrieves an instance tied to the currently active application.
+    /// </summary>
+    /// <returns>A <see cref="SukiTheme"/> instance that can be used to change themes.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if no SukiTheme has been defined in App.axaml.</exception>
+    public static SukiTheme GetInstance() => GetInstance(Application.Current!);
 }

--- a/SukiUI/Utilities/Background/FastNoiseBackgroundRenderer.cs
+++ b/SukiUI/Utilities/Background/FastNoiseBackgroundRenderer.cs
@@ -10,6 +10,8 @@ namespace SukiUI.Utilities.Background;
 
 public sealed class FastNoiseBackgroundRenderer : ISukiBackgroundRenderer
 {
+    public bool SupportsAnimation => true;
+    
     private static readonly Random Rand = new();
     private static readonly FastNoiseLite NoiseGen = new();
 

--- a/SukiUI/Utilities/Background/FastNoiseBackgroundRenderer.cs
+++ b/SukiUI/Utilities/Background/FastNoiseBackgroundRenderer.cs
@@ -13,6 +13,10 @@ public sealed class FastNoiseBackgroundRenderer : ISukiBackgroundRenderer
     private static readonly Random Rand = new();
     private static readonly FastNoiseLite NoiseGen = new();
 
+    private readonly object _lockObj = new();
+
+    private bool _isRedrawing;
+
     private uint _themeColor;
     private uint _accentColor;
     private uint _baseColor;
@@ -55,38 +59,46 @@ public sealed class FastNoiseBackgroundRenderer : ISukiBackgroundRenderer
         _aOffsetX = Rand.Next(1000);
     }
     
-    public unsafe Task Render(WriteableBitmap bitmap)
+    public async Task Render(WriteableBitmap bitmap)
     {
         _pOffsetX += _xAnim;
         _pOffsetY += _yAnim;
         _aOffsetX -= _xAnim;
         _aOffsetY -= _yAnim;
-        
-        using var frameBuffer = bitmap.Lock();
-        var frameSize = frameBuffer.Size;
-        var frameScale = (1f / frameSize.Height) * _scale;
-        
-        var backBuffer = (uint*)frameBuffer.Address.ToPointer();
-        var stride = frameBuffer.RowBytes / 4;
-        
-        Parallel.For((long)0, frameSize.Height, (scanline) =>
-        {
-            var dest = backBuffer + scanline * stride + 0;
-            for (var x = 0; x < frameSize.Width; x++)
-            {
-                var noise = NoiseGen.GetNoise((_pOffsetX + x) * frameScale, (_pOffsetY + scanline) * frameScale);
-                noise = (noise + 1f) / 2f * _primaryAlpha; // noise returns -1 to +1 which isn't useful.
-                var alpha = (byte)(noise * 255);
-                var firstLayer = BlendPixelOverlay(WithAlpha(_themeColor, alpha), _baseColor);
-                
-                noise = NoiseGen.GetNoise((_aOffsetX + x) * frameScale, (_aOffsetY + scanline) * frameScale);
-                noise = (noise + 1f) / 2f * _accentAlpha;
-                alpha = (byte)(noise * 255);
 
-                dest[x] = BlendPixel(WithAlpha(_accentColor, alpha), firstLayer);
+        if (_isRedrawing) return;
+        lock (_lockObj) { _isRedrawing = true; }
+        
+        await Task.Run(() =>
+        {
+            using var frameBuffer = bitmap.Lock();
+            var frameSize = frameBuffer.Size;
+            var frameScale = (1f / frameSize.Height) * _scale;
+            unsafe
+            {
+                var backBuffer = (uint*)frameBuffer.Address.ToPointer();
+                var stride = frameBuffer.RowBytes / 4;
+
+                Parallel.For((long)0, frameSize.Height, (scanline) =>
+                {
+                    var dest = backBuffer + scanline * stride + 0;
+                    for (var x = 0; x < frameSize.Width; x++)
+                    {
+                        var noise = NoiseGen.GetNoise((_pOffsetX + x) * frameScale, (_pOffsetY + scanline) * frameScale);
+                        noise = (noise + 1f) / 2f * _primaryAlpha; // noise returns -1 to +1 which isn't useful.
+                        var alpha = (byte)(noise * 255);
+                        var firstLayer = BlendPixelOverlay(WithAlpha(_themeColor, alpha), _baseColor);
+
+                        noise = NoiseGen.GetNoise((_aOffsetX + x) * frameScale, (_aOffsetY + scanline) * frameScale);
+                        noise = (noise + 1f) / 2f * _accentAlpha;
+                        alpha = (byte)(noise * 255);
+
+                        dest[x] = BlendPixel(WithAlpha(_accentColor, alpha), firstLayer);
+                    }
+                });
             }
         });
-        return Task.CompletedTask;
+        lock (_lockObj) { _isRedrawing = false; }
     }
 
     private static uint GetBackgroundColor(Color input)

--- a/SukiUI/Utilities/Background/ISukiBackgroundRenderer.cs
+++ b/SukiUI/Utilities/Background/ISukiBackgroundRenderer.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using Avalonia.Media.Imaging;
 using Avalonia.Styling;
+using SukiUI.Controls;
 using SukiUI.Models;
 
 namespace SukiUI.Utilities.Background;
@@ -10,6 +11,11 @@ namespace SukiUI.Utilities.Background;
 /// </summary>
 public interface ISukiBackgroundRenderer
 {
+    /// <summary>
+    /// Tells the <see cref="SukiBackground"/> control if this renderer should be animated.
+    /// </summary>
+    public bool SupportsAnimation { get; }
+    
     /// <summary>
     /// Updates the values from the main thread, allowing the generator to keep drawing in the background.
     /// </summary>


### PR DESCRIPTION
***Major Changes***
- `SukiTheme` now fully supports custom themes.
- API improvements to make it more comfortable to deal with.
- Now subscribes to and propagates `ActualThemeVariant` changes instead of manually tracking.

***Fixes***
- Fully moved `FastNoiseBackgroundRenderer` off the main thread.
- Add locks to `FastNoiseBackgroundRenderer` so it now prevents deadlocking.
- Modify `SukiBackground` re-draw behaviour so that it requests a redraw any time the theme changes, the locks prevent this from causing deadlocks now.
- Add `SupportsAnimation` property to `ISukiBackgroundRenderer`, necessary for future custom renderers.

***Outstanding Issues***
- Toast sizing still seems a bit weird.
- Need to start working to convert all existing styles to `ControlTheme`
- I will look to create a brand new demo app with MVVM and `ShowMeTheXaml.Avalonia` that is a bit easier to maintain and more useful to devs.
- Would be nice to support custom dev-defined `ISukiBackgroundRenderer` but that can be a post 6.0 feature.