### PR TITLE
New accent buttons

### DIFF
--- a/SukiTest/DashboardPage.axaml
+++ b/SukiTest/DashboardPage.axaml
@@ -11,8 +11,6 @@
     <ScrollViewer VerticalScrollBarVisibility="Hidden">
         <Grid Margin="15">
             <WrapPanel Orientation="Horizontal">
-
-
                 <Grid Margin="15">
                     <suki:GlassCard Margin="0,0,0,25" Width="300">
                         <suki:BusyArea Name="BusySignIn"

--- a/SukiUI.Demo/Features/ControlsLibrary/ButtonsLibraryView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/ButtonsLibraryView.axaml
@@ -49,5 +49,40 @@
                 </showMeTheXaml:XamlDisplay>
             </controls:GroupBox>
         </controls:GlassCard>
+        <controls:GlassCard>
+            <controls:GroupBox Header="Standard Accent Button">
+                <showMeTheXaml:XamlDisplay UniqueId="Button6">
+                    <Button Classes="Accent"/>
+                </showMeTheXaml:XamlDisplay>
+            </controls:GroupBox>
+        </controls:GlassCard>
+        <controls:GlassCard>
+            <controls:GroupBox Header="Basic Accent Button">
+                <showMeTheXaml:XamlDisplay UniqueId="Button7">
+                    <Button Classes="Basic Accent"/>
+                </showMeTheXaml:XamlDisplay>
+            </controls:GroupBox>
+        </controls:GlassCard>
+        <controls:GlassCard>
+            <controls:GroupBox Header="Flat Accent Button">
+                <showMeTheXaml:XamlDisplay UniqueId="Button8">
+                    <Button Classes="Flat Accent"/>
+                </showMeTheXaml:XamlDisplay>
+            </controls:GroupBox>
+        </controls:GlassCard>
+        <controls:GlassCard>
+            <controls:GroupBox Header="Flat Rounded Accent Button">
+                <showMeTheXaml:XamlDisplay UniqueId="Button9">
+                    <Button Classes="Rounded Flat Accent"/>
+                </showMeTheXaml:XamlDisplay>
+            </controls:GroupBox>
+        </controls:GlassCard>
+        <controls:GlassCard>
+            <controls:GroupBox Header="Outlined Accent Button">
+                <showMeTheXaml:XamlDisplay UniqueId="Button10">
+                    <Button Classes="Outlined Accent"/>
+                </showMeTheXaml:XamlDisplay>
+            </controls:GroupBox>
+        </controls:GlassCard>
     </WrapPanel>
 </UserControl>

--- a/SukiUI.Demo/Features/ControlsLibrary/ButtonsLibraryView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/ButtonsLibraryView.axaml
@@ -10,79 +10,82 @@
              x:DataType="controlsLibrary:ButtonsLibraryViewModel">
     <UserControl.Styles>
         <Style Selector="Button">
-            <Setter Property="Content" Value="Button"/>
+            <Setter Property="Content" Value="Button" />
         </Style>
     </UserControl.Styles>
-    <WrapPanel Classes="PageContainer">
-        <controls:GlassCard>
-            <controls:GroupBox Header="Standard Button">
-                <showMeTheXaml:XamlDisplay UniqueId="Button1">
-                    <Button/>
-                </showMeTheXaml:XamlDisplay>
-            </controls:GroupBox>
-        </controls:GlassCard>
-        <controls:GlassCard>
-            <controls:GroupBox Header="Basic Button">
-                <showMeTheXaml:XamlDisplay UniqueId="Button2">
-                    <Button Classes="Basic"/>
-                </showMeTheXaml:XamlDisplay>
-            </controls:GroupBox>
-        </controls:GlassCard>
-        <controls:GlassCard>
-            <controls:GroupBox Header="Flat Button">
-                <showMeTheXaml:XamlDisplay UniqueId="Button3">
-                    <Button Classes="Flat"/>
-                </showMeTheXaml:XamlDisplay>
-            </controls:GroupBox>
-        </controls:GlassCard>
-        <controls:GlassCard>
-            <controls:GroupBox Header="Flat Rounded Button">
-                <showMeTheXaml:XamlDisplay UniqueId="Button4">
-                    <Button Classes="Rounded Flat"/>
-                </showMeTheXaml:XamlDisplay>
-            </controls:GroupBox>
-        </controls:GlassCard>
-        <controls:GlassCard>
-            <controls:GroupBox Header="Outlined Button">
-                <showMeTheXaml:XamlDisplay UniqueId="Button5">
-                    <Button Classes="Outlined"/>
-                </showMeTheXaml:XamlDisplay>
-            </controls:GroupBox>
-        </controls:GlassCard>
-        <controls:GlassCard>
-            <controls:GroupBox Header="Standard Accent Button">
-                <showMeTheXaml:XamlDisplay UniqueId="Button6">
-                    <Button Classes="Accent"/>
-                </showMeTheXaml:XamlDisplay>
-            </controls:GroupBox>
-        </controls:GlassCard>
-        <controls:GlassCard>
-            <controls:GroupBox Header="Basic Accent Button">
-                <showMeTheXaml:XamlDisplay UniqueId="Button7">
-                    <Button Classes="Basic Accent"/>
-                </showMeTheXaml:XamlDisplay>
-            </controls:GroupBox>
-        </controls:GlassCard>
-        <controls:GlassCard>
-            <controls:GroupBox Header="Flat Accent Button">
-                <showMeTheXaml:XamlDisplay UniqueId="Button8">
-                    <Button Classes="Flat Accent"/>
-                </showMeTheXaml:XamlDisplay>
-            </controls:GroupBox>
-        </controls:GlassCard>
-        <controls:GlassCard>
-            <controls:GroupBox Header="Flat Rounded Accent Button">
-                <showMeTheXaml:XamlDisplay UniqueId="Button9">
-                    <Button Classes="Rounded Flat Accent"/>
-                </showMeTheXaml:XamlDisplay>
-            </controls:GroupBox>
-        </controls:GlassCard>
-        <controls:GlassCard>
-            <controls:GroupBox Header="Outlined Accent Button">
-                <showMeTheXaml:XamlDisplay UniqueId="Button10">
-                    <Button Classes="Outlined Accent"/>
-                </showMeTheXaml:XamlDisplay>
-            </controls:GroupBox>
-        </controls:GlassCard>
-    </WrapPanel>
+    <ScrollViewer HorizontalScrollBarVisibility="Disabled">
+        <WrapPanel Classes="PageContainer">
+            <controls:GlassCard>
+                <controls:GroupBox Header="Standard Button">
+                    <showMeTheXaml:XamlDisplay UniqueId="Button1">
+                        <Button />
+                    </showMeTheXaml:XamlDisplay>
+                </controls:GroupBox>
+            </controls:GlassCard>
+            <controls:GlassCard>
+                <controls:GroupBox Header="Basic Button">
+                    <showMeTheXaml:XamlDisplay UniqueId="Button2">
+                        <Button Classes="Basic" />
+                    </showMeTheXaml:XamlDisplay>
+                </controls:GroupBox>
+            </controls:GlassCard>
+            <controls:GlassCard>
+                <controls:GroupBox Header="Flat Button">
+                    <showMeTheXaml:XamlDisplay UniqueId="Button3">
+                        <Button Classes="Flat" />
+                    </showMeTheXaml:XamlDisplay>
+                </controls:GroupBox>
+            </controls:GlassCard>
+            <controls:GlassCard>
+                <controls:GroupBox Header="Flat Rounded Button">
+                    <showMeTheXaml:XamlDisplay UniqueId="Button4">
+                        <Button Classes="Rounded Flat" />
+                    </showMeTheXaml:XamlDisplay>
+                </controls:GroupBox>
+            </controls:GlassCard>
+            <controls:GlassCard>
+                <controls:GroupBox Header="Outlined Button">
+                    <showMeTheXaml:XamlDisplay UniqueId="Button5">
+                        <Button Classes="Outlined" />
+                    </showMeTheXaml:XamlDisplay>
+                </controls:GroupBox>
+            </controls:GlassCard>
+            <controls:GlassCard>
+                <controls:GroupBox Header="Standard Accent Button">
+                    <showMeTheXaml:XamlDisplay UniqueId="Button6">
+                        <Button Classes="Accent" />
+                    </showMeTheXaml:XamlDisplay>
+                </controls:GroupBox>
+            </controls:GlassCard>
+            <controls:GlassCard>
+                <controls:GroupBox Header="Basic Accent Button">
+                    <showMeTheXaml:XamlDisplay UniqueId="Button7">
+                        <Button Classes="Basic Accent" />
+                    </showMeTheXaml:XamlDisplay>
+                </controls:GroupBox>
+            </controls:GlassCard>
+            <controls:GlassCard>
+                <controls:GroupBox Header="Flat Accent Button">
+                    <showMeTheXaml:XamlDisplay UniqueId="Button8">
+                        <Button Classes="Flat Accent" />
+                    </showMeTheXaml:XamlDisplay>
+                </controls:GroupBox>
+            </controls:GlassCard>
+            <controls:GlassCard>
+                <controls:GroupBox Header="Flat Rounded Accent Button">
+                    <showMeTheXaml:XamlDisplay UniqueId="Button9">
+                        <Button Classes="Rounded Flat Accent" />
+                    </showMeTheXaml:XamlDisplay>
+                </controls:GroupBox>
+            </controls:GlassCard>
+            <controls:GlassCard>
+                <controls:GroupBox Header="Outlined Accent Button">
+                    <showMeTheXaml:XamlDisplay UniqueId="Button10">
+                        <Button Classes="Outlined Accent" />
+                    </showMeTheXaml:XamlDisplay>
+                </controls:GroupBox>
+            </controls:GlassCard>
+        </WrapPanel>
+    </ScrollViewer>
+
 </UserControl>

--- a/SukiUI.Demo/Features/ControlsLibrary/IconsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/IconsView.axaml
@@ -30,10 +30,10 @@
         </controls:GlassCard>
         <ScrollViewer Grid.Row="1" HorizontalScrollBarVisibility="Disabled">
             <ItemsControl
-                ItemsSource="{Binding AllIcons}">
+                ItemsSource="{Binding AllIcons}" x:CompileBindings="False">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <controls:GlassCard Margin="0,0,15,15" x:DataType="generic:KeyValuePair">
+                        <controls:GlassCard Margin="0,0,15,15">
                             <controls:GroupBox Header="{Binding Key}">
                                 <PathIcon Data="{Binding Value}" Width="25" Height="25" />
                             </controls:GroupBox>

--- a/SukiUI.Demo/Features/ControlsLibrary/IconsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/IconsView.axaml
@@ -1,0 +1,52 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controlsLibrary="clr-namespace:SukiUI.Demo.Features.ControlsLibrary"
+             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:showMeTheXaml="clr-namespace:ShowMeTheXaml;assembly=ShowMeTheXaml.Avalonia"
+             xmlns:content="clr-namespace:SukiUI.Content;assembly=SukiUI"
+             xmlns:generic="clr-namespace:System.Collections.Generic;assembly=System.Runtime"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:DataType="controlsLibrary:IconsViewModel"
+             x:Class="SukiUI.Demo.Features.ControlsLibrary.IconsView">
+    <Grid RowDefinitions="Auto, *">
+        <controls:GlassCard Margin="15">
+            <controls:GroupBox Header="Icons">
+                <StackPanel Spacing="10">
+                    <TextBlock TextWrapping="Wrap">
+                        SukiUI contains definitions for some basic icons that are used for a variety of controls. You may wish to use these icons in your app and controls to maintain consistency with SukiUI.
+                        <LineBreak/>
+                        The icons can be used in the following way:
+                    </TextBlock>
+                    <showMeTheXaml:XamlDisplay UniqueId="Icon" HorizontalAlignment="Left">
+                        <PathIcon Data="{x:Static content:Icons.Plus}"/>
+                    </showMeTheXaml:XamlDisplay>
+                    <TextBlock>
+                        Here is the full list of available icons:
+                    </TextBlock>
+                </StackPanel>
+            </controls:GroupBox>
+        </controls:GlassCard>
+        <ScrollViewer Grid.Row="1" HorizontalScrollBarVisibility="Disabled">
+            <ItemsControl
+                ItemsSource="{Binding AllIcons}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <controls:GlassCard Margin="0,0,15,15" x:DataType="generic:KeyValuePair">
+                            <controls:GroupBox Header="{Binding Key}">
+                                <PathIcon Data="{Binding Value}" Width="25" Height="25" />
+                            </controls:GroupBox>
+                        </controls:GlassCard>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <WrapPanel Classes="PageContainer" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+            </ItemsControl>
+        </ScrollViewer>
+        
+    </Grid>
+</UserControl>

--- a/SukiUI.Demo/Features/ControlsLibrary/IconsView.axaml.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/IconsView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace SukiUI.Demo.Features.ControlsLibrary;
+
+public partial class IconsView : UserControl
+{
+    public IconsView()
+    {
+        InitializeComponent();
+    }
+}

--- a/SukiUI.Demo/Features/ControlsLibrary/IconsViewModel.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/IconsViewModel.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Avalonia.Media;
+using Material.Icons;
+using SukiUI.Content;
+
+namespace SukiUI.Demo.Features.ControlsLibrary;
+
+public class IconsViewModel : DemoPageBase
+{
+    public Dictionary<string, StreamGeometry> AllIcons { get; }
+    
+    public IconsViewModel() : base("Icons", MaterialIconKind.SimpleIcons, int.MaxValue)
+    {
+        AllIcons = typeof(Icons)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(x => x.FieldType == typeof(StreamGeometry))
+            .ToDictionary(x => x.Name, y => (StreamGeometry)y.GetValue(null));
+    }
+}

--- a/SukiUI.Demo/Features/ControlsLibrary/IconsViewModel.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/IconsViewModel.cs
@@ -16,6 +16,7 @@ public class IconsViewModel : DemoPageBase
         AllIcons = typeof(Icons)
             .GetFields(BindingFlags.Public | BindingFlags.Static)
             .Where(x => x.FieldType == typeof(StreamGeometry))
+            .OrderBy(x => x.Name)
             .ToDictionary(x => x.Name, y => (StreamGeometry)y.GetValue(null));
     }
 }

--- a/SukiUI.Demo/Features/CustomTheme/CustomThemeDialogView.axaml
+++ b/SukiUI.Demo/Features/CustomTheme/CustomThemeDialogView.axaml
@@ -3,13 +3,16 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:customTheme="clr-namespace:SukiUI.Demo.Features.CustomTheme"
+             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:DataType="customTheme:CustomThemeDialogViewModel"
              x:Class="SukiUI.Demo.Features.CustomTheme.CustomThemeDialogView">
-    <StackPanel Spacing="20">
-        <TextBox Text="{Binding DisplayName}"/>
-        <ColorPicker Color="{Binding PrimaryColor}"/>
-        <ColorPicker Color="{Binding AccentColor}"/>
-        <Button Content="Create" Command="{Binding TryCreateTheme}"/>
-    </StackPanel>
+    <controls:GroupBox Header="Create Custom Theme">
+        <StackPanel Spacing="20">
+            <TextBox Text="{Binding DisplayName}"/>
+            <ColorPicker Color="{Binding PrimaryColor}"/>
+            <ColorPicker Color="{Binding AccentColor}"/>
+            <Button Content="Create" Command="{Binding TryCreateTheme}"/>
+        </StackPanel>
+    </controls:GroupBox>
 </UserControl>

--- a/SukiUI.Demo/Features/CustomTheme/CustomThemeDialogViewModel.cs
+++ b/SukiUI.Demo/Features/CustomTheme/CustomThemeDialogViewModel.cs
@@ -1,5 +1,6 @@
 using Avalonia.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
+using SukiUI.Controls;
 using SukiUI.Models;
 
 namespace SukiUI.Demo.Features.CustomTheme;
@@ -26,5 +27,6 @@ public partial class CustomThemeDialogViewModel : ObservableObject
         var theme = new SukiColorTheme(DisplayName, PrimaryColor, AccentColor);
         _theme.AddColorTheme(theme);
         _theme.ChangeColorTheme(theme);
+        SukiHost.CloseDialog();
     }
 }

--- a/SukiUI.Demo/Features/Dashboard/DashboardView.axaml
+++ b/SukiUI.Demo/Features/Dashboard/DashboardView.axaml
@@ -2,7 +2,506 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:suki="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
+             xmlns:theme="clr-namespace:SukiUI.Theme;assembly=SukiUI"
+             xmlns:dashboard="clr-namespace:SukiUI.Demo.Features.Dashboard"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:DataType="dashboard:DashboardViewModel"
              x:Class="SukiUI.Demo.Features.Dashboard.DashboardView">
-    Dashboard View!
+    <ScrollViewer VerticalScrollBarVisibility="Hidden">
+        <Grid Margin="15">
+            <WrapPanel Orientation="Horizontal">
+                <Grid Margin="15">
+                    <suki:GlassCard Margin="0,0,0,25" Width="300">
+                        <suki:BusyArea Name="BusySignIn"
+                                       IsBusy="{Binding IsLoggingIn}"
+                                       BusyText="Signing In...">
+                            <StackPanel>
+                                <avalonia:MaterialIcon
+                                    Foreground="{DynamicResource SukiPrimaryColor}"
+                                    Height="30"
+                                    HorizontalAlignment="Center"
+                                    Kind="MicrosoftEdge"
+                                    Margin="10"
+                                    Width="30" />
+                                <TextBlock
+                                    FontSize="18"
+                                    FontWeight="DemiBold"
+                                    HorizontalAlignment="Center"
+                                    Margin="0,5,0,27"
+                                    Text="Sign-in to your account" />
+                                <TextBlock
+                                    FontWeight="DemiBold"
+                                    Margin="6,0,0,3"
+                                    Text="Username" />
+                                <TextBox Watermark="Username"
+                                         theme:TextBoxExtensions.Prefix="" />
+                                <TextBlock
+                                    FontWeight="DemiBold"
+                                    Margin="6,18,0,3"
+                                    Text="Password" />
+                                <TextBox
+                                    Margin="0,0,0,25"
+                                    Name="PasswordTextBox"
+                                    PasswordChar="*"
+                                    theme:TextBoxExtensions.AddDeleteButton="False" />
+                            </StackPanel>
+                        </suki:BusyArea>
+                    </suki:GlassCard>
+                    <Button Classes="Flat Rounded"
+                            Command="{Binding Login}"
+                            theme:ButtonExtensions.ShowProgress="{Binding IsLoggingIn}"
+                            HorizontalAlignment="Center"
+                            Name="ButtonSignIn"
+                            VerticalAlignment="Bottom" Margin="0,0,0,7"
+                            Width="160" Height="40"
+                            FontWeight="DemiBold">
+                        Sign In
+                    </Button>
+                </Grid>
+                <StackPanel>
+                    <suki:GlassCard
+                        Height="80"
+                        Margin="15"
+                        Width="300">
+                        <Grid>
+                            <StackPanel
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Top">
+                                <TextBlock
+                                    FontSize="16"
+                                    FontWeight="DemiBold"
+                                    Text="Uploading File .." />
+                                <TextBlock
+                                    FontSize="12"
+                                    Foreground="{DynamicResource SukiLowText}"
+                                    Margin="2,4,0,0"
+                                    Text="Presentation.pdf" />
+                            </StackPanel>
+                            <suki:CircleProgressBar
+                                Height="37"
+                                HorizontalAlignment="Right"
+                                Margin="-55,-65,-10,-65"
+                                StrokeWidth="4"
+                                Value="67"
+                                VerticalAlignment="Center"
+                                Width="37">
+                                <TextBlock
+                                    FontSize="13"
+                                    FontWeight="DemiBold"
+                                    HorizontalAlignment="Center"
+                                    Margin="1,1,0,0"
+                                    Text="67"
+                                    VerticalAlignment="Center" />
+                            </suki:CircleProgressBar>
+                        </Grid>
+                    </suki:GlassCard>
+                    <suki:GlassCard
+                        Classes="Card"
+                        Margin="15"
+                        Width="300">
+                        <StackPanel>
+                            <TextBlock
+                                FontSize="16"
+                                FontWeight="DemiBold"
+                                HorizontalAlignment="Left"
+                                Text="Daily Progress" />
+                            <Grid Margin="0,18,0,0">
+                                <TextBlock
+                                    FontSize="12"
+                                    FontWeight="DemiBold"
+                                    Foreground="{DynamicResource SukiLowText}"
+                                    HorizontalAlignment="Left"
+                                    Text="Project Workforce" />
+                                <StackPanel HorizontalAlignment="Right"
+                                            Orientation="Horizontal">
+                                    <TextBlock
+                                        FontSize="13"
+                                        Foreground="Green"
+                                        Text="32.21%" />
+                                    <avalonia:MaterialIcon
+                                        Foreground="Green"
+                                        Kind="ArrowUp"
+                                        Margin="5,0,0,0" />
+                                </StackPanel>
+                            </Grid>
+                            <ProgressBar Margin="0,1,0,0" Value="16" />
+                            <Grid Margin="0,13,0,0">
+                                <TextBlock
+                                    FontSize="12"
+                                    FontWeight="DemiBold"
+                                    Foreground="{DynamicResource SukiLowText}"
+                                    HorizontalAlignment="Left"
+                                    Text="Project Velocity" />
+                                <StackPanel HorizontalAlignment="Right"
+                                            Orientation="Horizontal">
+                                    <TextBlock
+                                        FontSize="13"
+                                        Foreground="Red"
+                                        Text="7.18%" />
+                                    <avalonia:MaterialIcon
+                                        Foreground="Red"
+                                        Kind="ArrowDown"
+                                        Margin="5,0,0,0" />
+                                </StackPanel>
+                            </Grid>
+                            <ProgressBar Margin="0,1,0,0" Value="62" />
+
+                            <Grid Margin="0,13,0,0">
+                                <TextBlock
+                                    FontSize="12"
+                                    FontWeight="DemiBold"
+                                    Foreground="{DynamicResource SukiLowText}"
+                                    HorizontalAlignment="Left"
+                                    Text="Critical Hours" />
+                                <StackPanel HorizontalAlignment="Right"
+                                            Orientation="Horizontal">
+                                    <TextBlock
+                                        FontSize="13"
+                                        Foreground="Green"
+                                        Text="16.89%" />
+                                    <avalonia:MaterialIcon
+                                        Foreground="Green"
+                                        Kind="ArrowUp"
+                                        Margin="5,0,0,0" />
+                                </StackPanel>
+                            </Grid>
+                            <ProgressBar Margin="0,1,0,0" Value="34" />
+
+                        </StackPanel>
+                    </suki:GlassCard>
+                </StackPanel>
+
+                <suki:GlassCard
+                    Height="320"
+                    Margin="15"
+                    VerticalAlignment="Top"
+                    Width="300">
+                    <Grid>
+                        <TextBlock
+                            FontSize="16"
+                            FontWeight="DemiBold"
+                            Text="Humidity" />
+                        <Viewbox
+                            Height="175"
+                            HorizontalAlignment="Center"
+                            Margin="0,0,0,5"
+                            VerticalAlignment="Center"
+                            Width="175">
+                            <suki:WaveProgress
+                                Value="{Binding Value, ElementName=SliderT}" />
+                        </Viewbox>
+                        <DockPanel VerticalAlignment="Bottom">
+                            <avalonia:MaterialIcon
+                                DockPanel.Dock="Left"
+                                Foreground="#666666"
+                                Height="20"
+                                Kind="TemperatureLow"
+                                Width="20" />
+                            <avalonia:MaterialIcon
+                                DockPanel.Dock="Right"
+                                Foreground="#666666"
+                                Height="20"
+                                Kind="TemperatureHigh"
+                                Width="20" />
+                            <Slider
+                                Margin="8,0"
+                                Maximum="100"
+                                Minimum="0"
+                                Name="SliderT"
+                                Value="23" />
+                        </DockPanel>
+                    </Grid>
+                </suki:GlassCard>
+
+                <suki:GlassCard
+                    Margin="15"
+                    VerticalAlignment="Top"
+                    Width="500">
+                    <Grid>
+                        <StackPanel>
+                            <StackPanel>
+                                <TextBlock
+                                    FontWeight="DemiBold"
+                                    HorizontalAlignment="Left"
+                                    Text="Notify me when .."
+                                    VerticalAlignment="Top" />
+                                <StackPanel Margin="0,8,0,0">
+                                    <StackPanel Margin="0,5,0,0"
+                                                Orientation="Horizontal">
+                                        <CheckBox IsChecked="True" />
+                                        <TextBlock
+                                            FontSize="13"
+                                            Foreground="{DynamicResource SukiLowText}"
+                                            Margin="8,0,0,0"
+                                            Text="Daily updates"
+                                            VerticalAlignment="Center" />
+                                    </StackPanel>
+                                    <StackPanel Margin="0,5,0,0"
+                                                Orientation="Horizontal">
+                                        <CheckBox IsChecked="True" />
+                                        <TextBlock
+                                            FontSize="13"
+                                            Foreground="{DynamicResource SukiLowText}"
+                                            Margin="8,0,0,0"
+                                            Text="New event"
+                                            VerticalAlignment="Center" />
+                                    </StackPanel>
+                                    <StackPanel Margin="0,5,0,0"
+                                                Orientation="Horizontal">
+                                        <CheckBox IsChecked="False" />
+                                        <TextBlock
+                                            FontSize="13"
+                                            Foreground="{DynamicResource SukiLowText}"
+                                            Margin="8,0,0,0"
+                                            Text="When added on new team"
+                                            VerticalAlignment="Center" />
+                                    </StackPanel>
+                                </StackPanel>
+                            </StackPanel>
+                            <Grid Margin="0,30,0,0">
+                                <ToggleButton
+                                    Classes="Switch"
+                                    HorizontalAlignment="Right"
+                                    IsChecked="True"
+                                    VerticalAlignment="Center" />
+                                <TextBlock
+                                    FontWeight="DemiBold"
+                                    HorizontalAlignment="Left"
+                                    Text="Mobile Notifications"
+                                    VerticalAlignment="Top" />
+
+                                <TextBlock
+                                    FontSize="13"
+                                    Foreground="{DynamicResource SukiLowText}"
+                                    HorizontalAlignment="Left"
+                                    Margin="0,22,0,0"
+                                    Text="Receive push notifications on your mobile phone."
+                                    TextWrapping="Wrap"
+                                    VerticalAlignment="Bottom"
+                                    Width="300" />
+                            </Grid>
+                            <Grid Margin="0,30,0,0">
+                                <ToggleButton
+                                    Classes="Switch"
+                                    HorizontalAlignment="Right"
+                                    IsChecked="False"
+                                    VerticalAlignment="Center" />
+                                <TextBlock
+                                    FontWeight="DemiBold"
+                                    HorizontalAlignment="Left"
+                                    Text="Desktop Notifications"
+                                    VerticalAlignment="Top" />
+                                <TextBlock
+                                    FontSize="13"
+                                    Foreground="{DynamicResource SukiLowText}"
+                                    HorizontalAlignment="Left"
+                                    Margin="0,22,0,0"
+                                    Text="Receive push notifications on your computer."
+                                    TextWrapping="Wrap"
+                                    VerticalAlignment="Bottom"
+                                    Width="300" />
+                            </Grid>
+                            <StackPanel Margin="0,30,0,0">
+                                <TextBlock
+                                    FontWeight="DemiBold"
+                                    HorizontalAlignment="Left"
+                                    Text="Language"
+                                    VerticalAlignment="Top" />
+
+                                <RadioButton Margin="0,13,0,0">
+                                    <TextBlock
+                                        FontSize="13"
+                                        Foreground="{DynamicResource SukiLowText}"
+                                        Margin="8,0,0,0"
+                                        Text="English"
+                                        VerticalAlignment="Center" />
+                                </RadioButton>
+                                <RadioButton IsChecked="True" Margin="0,5,0,0">
+                                    <TextBlock
+                                        FontSize="13"
+                                        Foreground="{DynamicResource SukiLowText}"
+                                        Margin="8,0,0,0"
+                                        Text="Chinese"
+                                        VerticalAlignment="Center" />
+                                </RadioButton>
+                                <RadioButton Margin="0,5,0,0">
+                                    <TextBlock
+                                        FontSize="13"
+                                        Foreground="{DynamicResource SukiLowText}"
+                                        Margin="8,0,0,0"
+                                        Text="Japanese"
+                                        VerticalAlignment="Center" />
+                                </RadioButton>
+                            </StackPanel>
+                        </StackPanel>
+                        <Button
+                            Classes="Basic"
+                            Command="{Binding ShowDialog}"
+                            HorizontalAlignment="Right"
+                            Margin="0"
+                            VerticalAlignment="Top"
+                            Content="Create Link" />
+                    </Grid>
+                </suki:GlassCard>
+                <StackPanel>
+                    <suki:GlassCard
+                        Height="281"
+                        Margin="15"
+                        Width="430">
+                        <TabControl>
+                            <TabItem>
+                                <TabItem.Header>
+                                    <TextBlock FontSize="16" Text="Invoices" />
+                                </TabItem.Header>
+                                <Grid>
+                                    <DataGrid
+                                        AutoGenerateColumns="True"
+                                        IsReadOnly="True"
+                                        Margin="15,10,15,0"
+                                        ItemsSource="{Binding Invoices}"
+                                        VerticalAlignment="Top" />
+                                </Grid>
+                            </TabItem>
+                            <TabItem>
+                                <TabItem.Header>
+                                    <TextBlock FontSize="16" Text="Questions" />
+                                </TabItem.Header>
+                                <StackPanel Margin="0,10,0,0">
+                                    <Expander>
+                                        <Expander.Header>
+                                            <StackPanel Orientation="Horizontal">
+                                                <avalonia:MaterialIcon Kind="Lock" Foreground="{DynamicResource SukiText}"/>
+                                                <TextBlock Text="Test Lock" />
+                                            </StackPanel>
+                                        </Expander.Header>
+
+                                        <TextBlock
+                                            FontSize="13"
+                                            Margin="15,15"
+                                            TextWrapping="Wrap">
+                                            We understand that things change. You can cancel your plan at any time and we'll refund you.
+                                        </TextBlock>
+                                    </Expander>
+
+                                    <Expander Header="Can I change my plan later ?">
+                                        <TextBlock Margin="20,5">Answer</TextBlock>
+                                    </Expander>
+
+                                    <Expander
+                                        Header="How do I change my account email ?">
+                                        <TextBlock Margin="20,5">Answer</TextBlock>
+                                    </Expander>
+
+                                </StackPanel>
+                            </TabItem>
+                        </TabControl>
+                    </suki:GlassCard>
+                    <suki:GlassCard
+                        Height="85"
+                        Margin="15"
+                        Width="430">
+                        <suki:Stepper Margin="0,5,-4,0" Steps="{Binding Steps}" Index="{Binding StepperIndex}" />
+                    </suki:GlassCard>
+                </StackPanel>
+                <suki:GlassCard
+                    Height="270"
+                    Margin="15"
+                    Width="961">
+                    <suki:GroupBox>
+                        <suki:GroupBox.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <avalonia:MaterialIcon
+                                    Foreground="{DynamicResource SukiLowText}"
+                                    Kind="Dollar" />
+                                <TextBlock Margin="5,0,0,0" Text="Change Plan" />
+                            </StackPanel>
+                        </suki:GroupBox.Header>
+                        <WrapPanel
+                            HorizontalAlignment="Center"
+                            Margin="0,25,0,0"
+                            VerticalAlignment="Center">
+                            <RadioButton
+                                Classes="GigaChips"
+                                Height="138"
+                                IsChecked="True"
+                                Margin="8"
+                                Width="210">
+                                <StackPanel HorizontalAlignment="Left" Margin="7">
+                                    <TextBlock
+                                        FontSize="12"
+                                        FontWeight="DemiBold"
+                                        Foreground="{DynamicResource SukiLowText}"
+                                        Margin="5,8,5,4"
+                                        Text="HOBBY" />
+                                    <TextBlock
+                                        FontSize="23"
+                                        FontWeight="DemiBold"
+                                        Margin="5,8"
+                                        Text="1 Gb" />
+                                    <TextBlock
+                                        FontSize="15"
+                                        Foreground="{DynamicResource SukiLowText}"
+                                        Margin="5,3"
+                                        Text="Plan for a moderate use as hobby."
+                                        TextWrapping="Wrap" />
+                                </StackPanel>
+                            </RadioButton>
+                            <RadioButton
+                                Classes="GigaChips"
+                                Height="138"
+                                Margin="8"
+                                Width="210">
+                                <StackPanel HorizontalAlignment="Left" Margin="7">
+                                    <TextBlock
+                                        FontSize="12"
+                                        FontWeight="DemiBold"
+                                        Foreground="{DynamicResource SukiLowText}"
+                                        Margin="5,8,5,4"
+                                        Text="PROFESSIONAL" />
+                                    <TextBlock
+                                        FontSize="23"
+                                        FontWeight="DemiBold"
+                                        Margin="5,8"
+                                        Text="5 Gb" />
+                                    <TextBlock
+                                        FontSize="15"
+                                        Foreground="{DynamicResource SukiLowText}"
+                                        Margin="5,3"
+                                        Text="Plan for a professional use in an application."
+                                        TextWrapping="Wrap" />
+                                </StackPanel>
+                            </RadioButton>
+                            <RadioButton
+                                Classes="GigaChips"
+                                Height="138"
+                                Margin="8"
+                                Width="210">
+                                <StackPanel HorizontalAlignment="Left" Margin="7">
+                                    <TextBlock
+                                        FontSize="12"
+                                        FontWeight="DemiBold"
+                                        Foreground="{DynamicResource SukiLowText}"
+                                        Margin="5,8,5,4"
+                                        Text="COMPANY" />
+                                    <TextBlock
+                                        FontSize="23"
+                                        FontWeight="DemiBold"
+                                        Margin="5,8"
+                                        Text="50 Gb" />
+                                    <TextBlock
+                                        FontSize="15"
+                                        Foreground="{DynamicResource SukiLowText}"
+                                        Margin="5,3"
+                                        Text="Plan for a industrial use in a company."
+                                        TextWrapping="Wrap" />
+                                </StackPanel>
+                            </RadioButton>
+                        </WrapPanel>
+                    </suki:GroupBox>
+                </suki:GlassCard>
+            </WrapPanel>
+        </Grid>
+    </ScrollViewer>
 </UserControl>

--- a/SukiUI.Demo/Features/Dashboard/DashboardView.axaml
+++ b/SukiUI.Demo/Features/Dashboard/DashboardView.axaml
@@ -399,10 +399,22 @@
                         </TabControl>
                     </suki:GlassCard>
                     <suki:GlassCard
-                        Height="85"
                         Margin="15"
                         Width="430">
-                        <suki:Stepper Margin="0,5,-4,0" Steps="{Binding Steps}" Index="{Binding StepperIndex}" />
+                        <StackPanel>
+                            <suki:Stepper Steps="{Binding Steps}" Index="{Binding StepperIndex}" />
+                            <DockPanel LastChildFill="True">
+                                <Button DockPanel.Dock="Left"
+                                        Classes="Accent Basic"
+                                        Content="-"
+                                        Command="{Binding DecrementIndex}"/>
+                                <Button DockPanel.Dock="Right"
+                                        Classes="Accent Basic"
+                                        Content="+"
+                                        Command="{Binding IncrementIndex}"/>
+                                <Grid/>
+                            </DockPanel>
+                        </StackPanel>
                     </suki:GlassCard>
                 </StackPanel>
                 <suki:GlassCard

--- a/SukiUI.Demo/Features/Dashboard/DashboardViewModel.cs
+++ b/SukiUI.Demo/Features/Dashboard/DashboardViewModel.cs
@@ -1,8 +1,51 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
 using Material.Icons;
+using SukiUI.Controls;
+using SukiUI.Demo.Models.Dashboard;
 
 namespace SukiUI.Demo.Features.Dashboard;
 
-public class DashboardViewModel() : DemoPageBase("Dashboard", MaterialIconKind.CircleOutline, -100)
+public partial class DashboardViewModel : DemoPageBase
 {
-    
+    [ObservableProperty] private bool _isLoggingIn;
+    [ObservableProperty] private int _stepperIndex;
+
+    public IReadOnlyList<Invoice> Invoices { get; } = new[]
+    {
+        new Invoice(15364, "Jean", 156, true),
+        new Invoice(45689, "Fantine", 82, false),
+        new Invoice(15364, "Jean", 156, true),
+        new Invoice(45689, "Fantine", 82, false),
+        new Invoice(15364, "Jean", 156, true),
+        new Invoice(45689, "Fantine", 82, false),
+    };
+
+    public IReadOnlyList<string> Steps { get; } = new[]
+    {
+        "Dispatched", "En-Route", "Delivered"
+    };
+
+    public DashboardViewModel() : base("Dashboard", MaterialIconKind.CircleOutline, -100)
+    {
+        StepperIndex = 1;
+    }
+
+    public void Login()
+    {
+        IsLoggingIn = true;
+        Task.Run(() =>
+        {
+            Thread.Sleep(3000);
+            Dispatcher.UIThread.Invoke(() => { IsLoggingIn = false; });
+        });
+    }
+
+    public void ShowDialog()
+    {
+        SukiHost.ShowDialog(new DialogViewModel(), allowBackgroundClose: true);
+    }
 }

--- a/SukiUI.Demo/Features/Dashboard/DashboardViewModel.cs
+++ b/SukiUI.Demo/Features/Dashboard/DashboardViewModel.cs
@@ -48,4 +48,10 @@ public partial class DashboardViewModel : DemoPageBase
     {
         SukiHost.ShowDialog(new DialogViewModel(), allowBackgroundClose: true);
     }
+
+    public void IncrementIndex() => 
+        StepperIndex += StepperIndex >= Steps.Count - 1 ? 0 : 1;
+
+    public void DecrementIndex() => 
+        StepperIndex -= StepperIndex <= 0 ? 0 : 1;
 }

--- a/SukiUI.Demo/Features/Dashboard/DialogView.axaml
+++ b/SukiUI.Demo/Features/Dashboard/DialogView.axaml
@@ -1,0 +1,52 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:dashboard="clr-namespace:SukiUI.Demo.Features.Dashboard"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="SukiUI.Demo.Features.Dashboard.DialogView"
+             x:DataType="dashboard:DialogViewModel">
+    <StackPanel Margin="2" Width="450">
+        <TextBlock
+            FontSize="18"
+            FontWeight="DemiBold"
+            Text="Create Link" />
+
+        <TextBlock FontWeight="DemiBold"
+                   Margin="0,27,0,0"
+                   Text="Expiry date" />
+        <DatePicker Margin="0,10,0,0" />
+
+        <DockPanel>
+            <TextBlock
+                DockPanel.Dock="Left"
+                FontWeight="DemiBold"
+                Margin="0,20,0,0"
+                Text="Temporary access"
+                VerticalAlignment="Top" />
+            <ToggleButton
+                Classes="Switch"
+                DockPanel.Dock="Right"
+                IsChecked="True"
+                Margin="0,12,-8,0"
+                VerticalAlignment="Bottom" />
+            <Grid />
+        </DockPanel>
+        <TextBlock FontSize="13"
+                   Foreground="DarkGray"
+                   HorizontalAlignment="Left"
+                   Margin="0,1,0,0"
+                   Text="Members are automatically removed from campaign after closing tab or log out."
+                   TextWrapping="Wrap"
+                   Width="320" />
+
+        <StackPanel Spacing="15"
+                    HorizontalAlignment="Right"
+                    Margin="0,35,0,0"
+                    Orientation="Horizontal">
+            <Button Classes="Rounded" Command="{Binding CloseDialog}" Content="Cancel" />
+            <Button Classes="Flat Rounded" Command="{Binding CloseDialog}" Content="Generate" />
+        </StackPanel>
+
+    </StackPanel>
+</UserControl>

--- a/SukiUI.Demo/Features/Dashboard/DialogView.axaml.cs
+++ b/SukiUI.Demo/Features/Dashboard/DialogView.axaml.cs
@@ -1,0 +1,13 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace SukiUI.Demo.Features.Dashboard;
+
+public partial class DialogView : UserControl
+{
+    public DialogView()
+    {
+        InitializeComponent();
+    }
+}

--- a/SukiUI.Demo/Features/Dashboard/DialogViewModel.cs
+++ b/SukiUI.Demo/Features/Dashboard/DialogViewModel.cs
@@ -1,0 +1,12 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using SukiUI.Controls;
+
+namespace SukiUI.Demo.Features.Dashboard;
+
+public class DialogViewModel : ObservableObject
+{
+    public void CloseDialog()
+    {
+        SukiHost.CloseDialog();
+    }
+}

--- a/SukiUI.Demo/Models/Dashboard/Invoice.cs
+++ b/SukiUI.Demo/Models/Dashboard/Invoice.cs
@@ -1,0 +1,3 @@
+namespace SukiUI.Demo.Models.Dashboard;
+
+public record Invoice(int Id, string BillingName, int AmountPaid, bool Paid);

--- a/SukiUI.Demo/SukiUIDemoView.axaml
+++ b/SukiUI.Demo/SukiUIDemoView.axaml
@@ -35,7 +35,7 @@
             Kind="MicrosoftXaml"
             Width="25" />
     </suki:SukiWindow.LogoContent>
-    <suki:SukiSideMenu ItemsSource="{Binding Features}">
+    <suki:SukiSideMenu ItemsSource="{Binding DemoPages}">
         <suki:SukiSideMenu.ItemTemplate>
             <DataTemplate>
                 <suki:SukiSideMenuItem Header="{Binding DisplayName}">

--- a/SukiUI.Demo/SukiUIDemoViewModel.cs
+++ b/SukiUI.Demo/SukiUIDemoViewModel.cs
@@ -13,7 +13,7 @@ namespace SukiUI.Demo;
 
 public partial class SukiUIDemoViewModel : ViewAwareObservableObject
 {
-    public AvaloniaList<DemoPageBase> Features { get; } = [];
+    public AvaloniaList<DemoPageBase> DemoPages { get; } = [];
     
     public IAvaloniaReadOnlyList<SukiColorTheme> Themes { get; }
 
@@ -22,9 +22,9 @@ public partial class SukiUIDemoViewModel : ViewAwareObservableObject
 
     private readonly SukiTheme _theme;
     
-    public SukiUIDemoViewModel(IEnumerable<DemoPageBase> features)
+    public SukiUIDemoViewModel(IEnumerable<DemoPageBase> demoPages)
     {
-        Features.AddRange(features.OrderBy(x => x.Index));
+        DemoPages.AddRange(demoPages.OrderBy(x => x.Index).ThenBy(x => x.DisplayName));
         _theme = SukiTheme.GetInstance();
         Themes = _theme.ColorThemes;
         BaseTheme = _theme.ActiveBaseTheme;

--- a/SukiUI/Content/Icons.cs
+++ b/SukiUI/Content/Icons.cs
@@ -18,10 +18,13 @@ public static class Icons
     public static readonly StreamGeometry WindowMaximize = Parse("M4,4H20V20H4V4M6,8V18H18V8H6Z");
 
     // Material Icons
-    public static readonly StreamGeometry WindowClose = Parse("M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z");
+    public static readonly StreamGeometry WindowClose = Parse("M13.46,12L19,17.54V19H17.54L12,13.46L6.46,19H5V17.54L10.54,12L5,6.46V5H6.46L12,10.54L17.54,5H19V6.46L13.46,12Z");
     
     // Material Icons
     public static readonly StreamGeometry Check = Parse("M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z");
+    
+    // Material Icons
+    public static readonly StreamGeometry Cross = Parse("M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z");
 
     // Material Icons
     public static readonly StreamGeometry Calendar = Parse("M19,19H5V8H19M16,1V3H8V1H6V3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3H18V1M17,12H12V17H17V12Z");
@@ -81,9 +84,6 @@ public static class Icons
     public static readonly StreamGeometry CheckboxMarkedCircle = Parse("M10,17L5,12L6.41,10.58L10,14.17L17.59,6.58L19,8M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z");
     
     // Material Icons
-    public static readonly StreamGeometry CloseCircle = Parse("M12,2C17.53,2 22,6.47 22,12C22,17.53 17.53,22 12,22C6.47,22 2,17.53 2,12C2,6.47 6.47,2 12,2M15.59,7L12,10.59L8.41,7L7,8.41L10.59,12L7,15.59L8.41,17L12,13.41L15.59,17L17,15.59L13.41,12L17,8.41L15.59,7Z");
-    
-    // Material Icons
     public static readonly StreamGeometry KeyboardCaps = Parse("M6,18H18V16H6M12,8.41L16.59,13L18,11.58L12,5.58L6,11.58L7.41,13L12,8.41Z");
     
     // Material Icons
@@ -91,6 +91,9 @@ public static class Icons
     
     // Material Icons
     public static readonly StreamGeometry ArrowLeft = Parse("M20,11V13H8L13.5,18.5L12.08,19.92L4.16,12L12.08,4.08L13.5,5.5L8,11H20Z");
+    
+    // Material Icons
+    public static readonly StreamGeometry ArrowRight = Parse("M4,11V13H16L10.5,18.5L11.92,19.92L19.84,12L11.92,4.08L10.5,5.5L16,11H4Z");
     
     // Material Icons
     public static readonly StreamGeometry Menu = Parse("M3,6H21V8H3V6M3,11H21V13H3V11M3,16H21V18H3V16Z");

--- a/SukiUI/Controls/Stepper.axaml
+++ b/SukiUI/Controls/Stepper.axaml
@@ -1,14 +1,12 @@
-<UserControl
-    d:DesignHeight="450"
-    d:DesignWidth="800"
-    mc:Ignorable="d"
-    x:Class="SukiUI.Controls.Stepper"
-    xmlns="https://github.com/avaloniaui"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:suki="clr-namespace:SukiUI.Controls"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-
-    <Grid Name="gridStepper" Margin="0,0,-45,0" />
-
-</UserControl>
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:controls="clr-namespace:SukiUI.Controls">
+    <ControlTheme x:Key="SukiStepperStyle" TargetType="controls:Stepper">
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Grid Name="PART_GridStepper"/>
+            </ControlTemplate>
+        </Setter>
+    </ControlTheme>
+    <ControlTheme x:Key="{x:Type controls:Stepper}" TargetType="controls:Stepper" BasedOn="{StaticResource SukiStepperStyle}"/>
+</ResourceDictionary>

--- a/SukiUI/Controls/Stepper.axaml.cs
+++ b/SukiUI/Controls/Stepper.axaml.cs
@@ -1,140 +1,148 @@
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
 using System;
-using Avalonia.Data;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
 using Avalonia.Layout;
 using Avalonia.Media;
-using System.Collections.ObjectModel;
+using System.Reactive.Linq;
+using Avalonia.Controls.Primitives;
 using Avalonia.Markup.Xaml.MarkupExtensions;
+using Avalonia.Threading;
 using SukiUI.Content;
 
 namespace SukiUI.Controls
 {
-    public partial class Stepper : UserControl
+    public class Stepper : TemplatedControl
     {
-        public Stepper()
-        {
-            InitializeComponent();
-            Update();
-        }
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-            
-        }
-        
-        
-        private int _index;
-    
-        public static readonly DirectProperty<Stepper, int> IndexProperty =
-            AvaloniaProperty.RegisterDirect<Stepper, int>(nameof(Index), numpicker => numpicker.Index,
-                (numpicker, v) => numpicker.Index = v, defaultBindingMode: BindingMode.TwoWay, enableDataValidation: true);
+        public static readonly StyledProperty<int> IndexProperty =
+            AvaloniaProperty.Register<Stepper, int>(nameof(Index));
 
         public int Index
         {
-            get { return _index; }
-            set
-            {
-                SetAndRaise(IndexProperty, ref _index, value);
-                Update();
-            }
+            get => GetValue(IndexProperty);
+            set => SetValue(IndexProperty, value);
         }
 
+        public static readonly StyledProperty<IEnumerable?> StepsProperty =
+            AvaloniaProperty.Register<Stepper, IEnumerable?>(nameof(Steps));
 
-
-        private ObservableCollection<string> _steps;
-
-        public static readonly DirectProperty<Stepper, ObservableCollection<string>> StepsProperty =
-            AvaloniaProperty.RegisterDirect<Stepper, ObservableCollection<string>>(nameof(Steps), numpicker => numpicker.Steps,
-                (numpicker, v) => numpicker.Steps = v, defaultBindingMode: BindingMode.TwoWay, enableDataValidation: true);
-
-        public ObservableCollection<string> Steps
+        public IEnumerable? Steps
         {
-            get { return _steps; }
-            set
-            {
-                SetAndRaise(StepsProperty, ref _steps, value);
-                Update();
-            }
+            get => GetValue(StepsProperty);
+            set => SetValue(StepsProperty, value);
         }
 
+        private Grid? _grid;
 
-        public void Update()
+        private static readonly IBrush DisabledColor = new SolidColorBrush(Color.FromArgb(100, 150, 150, 150));
+
+        protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
         {
-            try
-            {
-                Grid grid = this.FindControl<Grid>("gridStepper");
-                grid.Children.Clear();
-
-                SetColumnDefinitions(grid);
-
-                for (var i = 0; i < Steps.Count; i++)
-                {
-                    AddStep(Steps[i], i, grid);
-                }
-            }catch(Exception exc) { }
+            base.OnApplyTemplate(e);
+            if (e.NameScope.Get<Grid>("PART_GridStepper") is not { } grid) return;
+            _grid = grid;
+            this.GetObservable(StepsProperty)
+                .ObserveOn(new AvaloniaSynchronizationContext())
+                .Subscribe(StepsChangedHandler);
         }
 
-        private void SetColumnDefinitions(Grid grid)
+        private void StepsChangedHandler(IEnumerable? newSteps)
+        {
+            if (newSteps is null) return;
+            if (newSteps is not IEnumerable<object> stepsEnumerable) return;
+            var steps = stepsEnumerable.ToArray();
+            Update(steps);
+            if (newSteps is INotifyCollectionChanged notify)
+                notify.CollectionChanged += (_, _) => Update(steps);
+        }
+
+        private void Update(object[] steps)
+        {
+            if (_grid is null) return;
+            _grid.Children.Clear();
+
+            SetColumnDefinitions(_grid, steps);
+
+            for (var i = 0; i < steps.Length; i++)
+                AddStep(steps[i], i, _grid, steps.Length);
+        }
+
+        private void SetColumnDefinitions(Grid grid, object[] steps)
         {
             var columns = new ColumnDefinitions();
-            foreach(var s in Steps)
+            foreach (var s in steps)
                 columns.Add(new ColumnDefinition());
             grid.ColumnDefinitions = columns;
         }
 
-        private void AddStep(string step, int index,Grid grid)
+        private void AddStep(object step, int index, Grid grid, int stepCount)
         {
-            Brush DisabledColor = new SolidColorBrush(Color.FromArgb(100,150,150,150)); 
+            var griditem = new Grid()
+            {
+                ColumnDefinitions = new ColumnDefinitions()
+                    { new(GridLength.Auto), new(GridLength.Star), new(GridLength.Auto) }
+            };
 
-            var griditem = new Grid(){ ColumnDefinitions = new ColumnDefinitions(){new ColumnDefinition( GridLength.Auto), new ColumnDefinition(GridLength.Star), new ColumnDefinition(GridLength.Auto)}};
-
-            var icon = new PathIcon() { Height = 10, Width = 10, Data = Icons.ChevronRight, Margin = new Thickness(0,0,20,0)};
-            if (index == Steps.Count - 1)
+            var icon = new PathIcon()
+                { Height = 10, Width = 10, Data = Icons.ChevronRight, Margin = new Thickness(0, 0, 20, 0) };
+            if (index == stepCount - 1)
                 icon.IsVisible = false;
-   
-            Grid.SetColumn(icon,2);
+
+            Grid.SetColumn(icon, 2);
             griditem.Children.Add(icon);
 
-            var gridBorder = new Grid();
-            
             var circle = new Border()
-                { Margin = new Thickness(0,0,0,2), Height = 24, Width = 24, CornerRadius = new CornerRadius(25), HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
+            {
+                Margin = new Thickness(0, 0, 0, 2), Height = 24, Width = 24, CornerRadius = new CornerRadius(25),
+                HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center
+            };
 
             if (index <= Index)
             {
                 circle[!BackgroundProperty] = new DynamicResourceExtension("SukiPrimaryColor");
-                
+
                 circle.BorderThickness = new Thickness(0);
-                circle.Child = new TextBlock() {VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Text = (index + 1).ToString(), FontSize = 13, Foreground = Brushes.White};
+                circle.Child = new TextBlock()
+                {
+                    VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center,
+                    Text = (index + 1).ToString(), FontSize = 13, Foreground = Brushes.White
+                };
             }
             else
             {
                 circle.Background = DisabledColor;
-                
-                circle.BorderThickness = new Thickness(0);
-                circle.Child = new TextBlock() {VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Text = (index + 1).ToString(), FontSize = 13, Foreground = Brushes.White};
-            }
-            
-            Grid.SetColumn(circle,0);
-            griditem.Children.Add(circle);
 
-            var t = new TextBlock()
+                circle.BorderThickness = new Thickness(0);
+                circle.Child = new TextBlock()
+                {
+                    VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center,
+                    Text = (index + 1).ToString(), FontSize = 13, Foreground = Brushes.White
+                };
+            }
+
+            Grid.SetColumn(circle, 0);
+            griditem.Children.Add(circle);
+            Control content = step switch
             {
-                FontWeight = index <= Index ? FontWeight.DemiBold : FontWeight.Normal, Margin = new Thickness(10,0,0,0),
-                Text = step, VerticalAlignment = VerticalAlignment.Center,
-                HorizontalAlignment = HorizontalAlignment.Left, 
+                string s => new TextBlock()
+                {
+                    FontWeight = index <= Index ? FontWeight.DemiBold : FontWeight.Normal,
+                    Margin = new Thickness(10, 0, 0, 0),
+                    Text = s, VerticalAlignment = VerticalAlignment.Center,
+                    HorizontalAlignment = HorizontalAlignment.Left,
+                },
+                _ => new ContentControl() { Content = step }
             };
-            
-            Grid.SetColumn(t,1);
-            griditem.Children.Add(t);
-            
-            Grid.SetColumn(griditem,index);
-           
+
+            Grid.SetColumn(content, 1);
+            griditem.Children.Add(content);
+
+            Grid.SetColumn(griditem, index);
+
             grid.Children.Add(griditem);
-         
         }
     }
 }

--- a/SukiUI/Controls/Stepper.axaml.cs
+++ b/SukiUI/Controls/Stepper.axaml.cs
@@ -44,6 +44,9 @@ namespace SukiUI.Controls
             base.OnApplyTemplate(e);
             if (e.NameScope.Get<Grid>("PART_GridStepper") is not { } grid) return;
             _grid = grid;
+            this.GetObservable(IndexProperty)
+                .ObserveOn(new AvaloniaSynchronizationContext())
+                .Subscribe(_ => StepsChangedHandler(Steps));
             this.GetObservable(StepsProperty)
                 .ObserveOn(new AvaloniaSynchronizationContext())
                 .Subscribe(StepsChangedHandler);

--- a/SukiUI/Helpers/FastNoiseLite.cs
+++ b/SukiUI/Helpers/FastNoiseLite.cs
@@ -47,6 +47,8 @@
 // VERSION: 1.1.0
 // https://github.com/Auburn/FastNoiseLite
 
+#pragma warning disable CS1591
+
 using System;
 using System.Runtime.CompilerServices;
 
@@ -2504,3 +2506,5 @@ public class FastNoiseLite
         zr += vz * warpAmp;
     }
 }
+
+#pragma warning restore CS1591

--- a/SukiUI/MessageBox/MessageBox.axaml.cs
+++ b/SukiUI/MessageBox/MessageBox.axaml.cs
@@ -53,7 +53,7 @@ namespace SukiUI.MessageBox
         {
             var mbox = new MessageBox(Title, Message);
             if (mbox.FindControl<PathIcon>("InfoIcon") is not { } icon) return;
-            icon.Data = Icons.CloseCircle;
+            icon.Data = Icons.CircleClose;
             icon.Foreground = Brushes.DarkRed;
             mbox.WindowStartupLocation = startupLocation;
             mbox.ShowDialog(owner);

--- a/SukiUI/Theme/ButtonStyles.axaml
+++ b/SukiUI/Theme/ButtonStyles.axaml
@@ -112,16 +112,6 @@
         
         <!-- Classes -->
         <Style Selector="^.Accent">
-            <Style Selector="^ /template/ TextBlock">
-                <Setter Property="Foreground" Value="{DynamicResource SukiAccentColor}" />
-            </Style>
-            <Style Selector="^ /template/ ContentPresenter">
-                <Setter Property="Foreground" Value="{DynamicResource SukiAccentColor}" />
-            </Style>
-        
-            <Style Selector="^ /template/ Border">
-                <Setter Property="BorderBrush" Value="{DynamicResource SukiAccentColor}" />
-            </Style>
             <Style Selector="^:pointerover">
                 <Style Selector="^ /template/ TextBlock">
                     <Setter Property="Foreground" Value="{DynamicResource SukiAccentColor}" />

--- a/SukiUI/Theme/ButtonStyles.axaml
+++ b/SukiUI/Theme/ButtonStyles.axaml
@@ -49,41 +49,16 @@
                 <BrushTransition Duration="0:0:0.35" Property="Background" />
             </Transitions>
         </Setter>
-
+        
+        <!-- Nested Selectors For Basic Button -->
         <Style Selector="^ /template/ TextBlock">
             <Setter Property="FontSize" Value="15"></Setter>
+            <Setter Property="FontWeight" Value="DemiBold" />
             <Setter Property="Transitions">
                 <Transitions>
                     <BrushTransition Duration="0:0:0.3" Property="Foreground" />
                 </Transitions>
             </Setter>
-        </Style>
-
-        <Style Selector="^:pointerover /template/ TextBlock">
-            <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
-        </Style>
-
-        <Style Selector="^:pressed /template/ TextBlock">
-            <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
-        </Style>
-
-        <Style Selector="^ /template/ ContentPresenter">
-            <Setter Property="Foreground" Value="{DynamicResource SukiText}" />
-            <Setter Property="FontSize" Value="15"></Setter>
-            <Setter Property="Transitions">
-                <Transitions>
-                    <BrushTransition Duration="0:0:0.3" Property="Foreground" />
-                </Transitions>
-            </Setter>
-        </Style>
-
-        <Style Selector="^:pointerover /template/ ContentPresenter">
-            <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
-        </Style>
-
-        <Style Selector="^:pressed /template/ ContentPresenter">
-            <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
-
         </Style>
 
         <Style Selector="^ /template/ Border">
@@ -93,22 +68,86 @@
                 </Transitions>
             </Setter>
         </Style>
-
-        <Style Selector="^:pointerover /template/ Border">
-            <Setter Property="BorderBrush" Value="{DynamicResource SukiPrimaryColor}" />
+        
+        <Style Selector="^ /template/ ContentPresenter">
+            <Setter Property="Foreground" Value="{DynamicResource SukiText}" />
+            <Setter Property="FontSize" Value="15"></Setter>
+            <Setter Property="Transitions">
+                <Transitions>
+                    <BrushTransition Duration="0:0:0.3" Property="Foreground" />
+                </Transitions>
+            </Setter>
         </Style>
-
-        <Style Selector="^:pressed /template/ Border">
-            <Setter Property="Background" Value="{DynamicResource SukiCardBackground}" />
-            <Setter Property="BorderBrush" Value="{DynamicResource SukiPrimaryColor}" />
+        <!-- Events For Basic Button -->
+        <Style Selector="^:pointerover">
+            <Style Selector="^ /template/ TextBlock">
+                <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
+            </Style>
+            <Style Selector="^ /template/ ContentPresenter">
+                <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
+            </Style>
+        
+            <Style Selector="^ /template/ Border">
+                <Setter Property="BorderBrush" Value="{DynamicResource SukiPrimaryColor}" />
+            </Style>
         </Style>
-
+        <Style Selector="^:pressed">
+            <Style Selector="^ /template/ TextBlock">
+                <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
+            </Style>
+            <Style Selector="^ /template/ Border">
+                <Setter Property="Background" Value="{DynamicResource SukiCardBackground}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource SukiPrimaryColor}" />
+                <Setter Property="RenderTransform">
+                    <Setter.Value>
+                        <ScaleTransform ScaleX="0.97" ScaleY="0.97" />
+                    </Setter.Value>
+                </Setter>
+            </Style>
+            <Style Selector="^ /template/ ContentPresenter">
+                <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
+            </Style>
+        </Style>
+        
+        
+        <!-- Classes -->
         <Style Selector="^.Basic">
             <Setter Property="BorderThickness" Value="0" />
             <Setter Property="BorderBrush" Value="Transparent" />
             <Setter Property="Padding" Value="11,8" />
             <Setter Property="CornerRadius" Value="5" />
             <Setter Property="Background" Value="Transparent" />
+            <!-- Nested Selectors -->
+            <Style Selector="^ /template/ TextBlock">
+                <Setter Property="Foreground">
+                    <Setter.Value>
+                        <LinearGradientBrush EndPoint="50%,100%" StartPoint="48%,0%">
+                            <GradientStop Color="{DynamicResource SukiPrimaryColor}" Offset="0.8" />
+                            <GradientStop Color="{DynamicResource SukiPrimaryColor}" Offset="1" />
+                        </LinearGradientBrush>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+            <Style Selector="^ /template/ Border">
+                <Setter Property="BoxShadow" Value="0 0 0 0 Transparent" />
+            </Style>
+            <Style Selector="^ /template/ ContentPresenter">
+                <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
+            </Style>
+            <!-- Events -->
+            <Style Selector="^:pointerover">
+                <Setter Property="Background" Value="Transparent" />
+                <Style Selector="^ /template/ Border">
+                    <Setter Property="RenderTransform">
+                        <Setter.Value>
+                            <ScaleTransform ScaleX="1.03" ScaleY="1.03" />
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+            </Style>
+            <Style Selector="^:pressed /template/ Border">
+                <Setter Property="Background" Value="Transparent" />
+            </Style>
         </Style>
 
         <Style Selector="^.Void">
@@ -118,199 +157,123 @@
             <Setter Property="CornerRadius" Value="5" />
             <Setter Property="Margin" Value="0" />
             <Setter Property="Background" Value="Transparent" />
-        </Style>
-
-        <Style Selector="^.Basic /template/ TextBlock">
-            <Setter Property="Foreground">
-                <Setter.Value>
-                    <LinearGradientBrush EndPoint="50%,100%" StartPoint="48%,0%">
-                        <GradientStop Color="{DynamicResource SukiPrimaryColor}" Offset="0.8" />
-                        <GradientStop Color="{DynamicResource SukiPrimaryColor}" Offset="1" />
-                    </LinearGradientBrush>
-                </Setter.Value>
-            </Setter>
-        </Style>
-
-        <Style Selector="^.Basic /template/ ContentPresenter">
-            <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}">
-            </Setter>
-        </Style>
-
-        <Style Selector="^.Basic:pointerover">
-            <Setter Property="Background" Value="Transparent" />
-
-        </Style>
-
-        <Style Selector="^.Basic:pointerover /template/ Border">
-
-            <Setter Property="RenderTransform">
-                <Setter.Value>
-                    <ScaleTransform ScaleX="1.03" ScaleY="1.03" />
-                </Setter.Value>
-            </Setter>
-        </Style>
-
-        <Style Selector="^.Void:pointerover /template/ Border">
-
-            <Setter Property="RenderTransform">
-                <Setter.Value>
-                    <ScaleTransform ScaleX="1.03" ScaleY="1.03" />
-                </Setter.Value>
-            </Setter>
-        </Style>
-
-
-        <Style Selector="^.Basic:pressed /template/ Border">
-            <Setter Property="Background" Value="Transparent" />
-        </Style>
-
-
-        <Style Selector="^ /template/ TextBlock">
-            <Setter Property="FontWeight" Value="DemiBold" />
-        </Style>
-
-
-        <Style Selector="^:pressed /template/ Border">
-
-            <Setter Property="RenderTransform">
-                <Setter.Value>
-                    <ScaleTransform ScaleX="0.97" ScaleY="0.97" />
-                </Setter.Value>
-            </Setter>
+            <!-- Nested Selectors -->
+            <Style Selector="^ /template/ Border">
+                <Setter Property="BoxShadow" Value="0 0 0 0 Transparent" />
+            </Style>
+            <!-- Events -->
+            <Style Selector="^:pointerover /template/ Border">
+                <Setter Property="RenderTransform">
+                    <Setter.Value>
+                        <ScaleTransform ScaleX="1.03" ScaleY="1.03" />
+                    </Setter.Value>
+                </Setter>
+            </Style>
         </Style>
 
         <Style Selector="^.Flat">
             <Setter Property="Padding" Value="20,8,20,8"></Setter>
             <Setter Property="BorderThickness" Value="0" />
-            <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor}">
-
-            </Setter>
+            <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor}"/>
             <Setter Property="BorderBrush" Value="#2948c5" />
-
             <Setter Property="Transitions">
                 <Transitions>
                     <BrushTransition Duration="0:0:0.2" Property="Background" />
                 </Transitions>
             </Setter>
+            <!-- Nested Selectors -->
+            <Style Selector="^ /template/ TextBlock">
+                <Setter Property="Foreground" Value="White" />
+            </Style>
+            <Style Selector="^ /template/ ContentPresenter">
+                <Setter Property="Foreground" Value="White" />
+            </Style>
+            <Style Selector="^ /template/ Border">
+                <Setter Property="BoxShadow" Value="{DynamicResource SukiLowShadow}" />
+            </Style>
+            <!-- Events -->
+            <Style Selector="^:pointerover">
+                <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor}" />
+            </Style>
+            <Style Selector="^:pressed /template/ Border">
+                <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor}" />
+            </Style>
         </Style>
-
-        <Style Selector="^.Flat /template/ TextBlock">
-            <Setter Property="Foreground" Value="White" />
-
-        </Style>
-
-        <Style Selector="^.Flat /template/ ContentPresenter">
-            <Setter Property="Foreground" Value="White" />
-        </Style>
-
-        <Style Selector="^.Flat:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor}" />
-        </Style>
-
-
-        <Style Selector="^.Flat:pressed /template/ Border">
-            <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor}" />
-        </Style>
-
 
         <Style Selector="^.Outlined">
             <Setter Property="BorderThickness" Value="1" />
             <Setter Property="BorderBrush" Value="{DynamicResource SukiPrimaryColor}" />
             <Setter Property="Background" Value="Transparent" />
-
             <Setter Property="Transitions">
                 <Transitions>
                     <BrushTransition Duration="0:0:0.3" Property="Background" />
                     <BrushTransition Duration="0:0:0.3" Property="BorderBrush" />
                 </Transitions>
             </Setter>
-        </Style>
-
-        <Style Selector="^.Outlined /template/ TextBlock">
-            <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
-            <Setter Property="Transitions">
-                <Transitions>
-                    <BrushTransition Duration="0:0:0.3" Property="Foreground" />
-                </Transitions>
-            </Setter>
-        </Style>
-
-        <Style Selector="^.Outlined:pointerover /template/ TextBlock">
-            <Setter Property="Foreground" Value="White" />
-
-        </Style>
-
-        <Style Selector="^.Outlined /template/ ContentPresenter">
-            <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
-            <Setter Property="Transitions">
-                <Transitions>
-                    <BrushTransition Duration="0:0:0.3" Property="Foreground" />
-                </Transitions>
-            </Setter>
-        </Style>
-
-        <Style Selector="^.Outlined:pointerover /template/ ContentPresenter">
-            <Setter Property="Foreground" Value="White" />
-        </Style>
-
-
-        <Style Selector="^.Outlined:pointerover">
-            <Setter Property="BorderBrush" Value="Transparent" />
-            <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor}">
-
-            </Setter>
-        </Style>
-
-
-        <Style Selector="^.Outlined:pressed /template/ Border">
-            <Setter Property="BorderBrush" Value="Transparent" />
-            <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor}">
-
-            </Setter>
+            <!-- Nested Selectors -->
+            <Style Selector="^ /template/ TextBlock">
+                <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
+                <Setter Property="Transitions">
+                    <Transitions>
+                        <BrushTransition Duration="0:0:0.3" Property="Foreground" />
+                    </Transitions>
+                </Setter>
+            </Style>
+            <Style Selector="^ /template/ ContentPresenter">
+                <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
+                <Setter Property="Transitions">
+                    <Transitions>
+                        <BrushTransition Duration="0:0:0.3" Property="Foreground" />
+                    </Transitions>
+                </Setter>
+            </Style>
+            <!-- Events -->
+            <Style Selector="^:pointerover">
+                <Setter Property="BorderBrush" Value="Transparent" />
+                <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor}"/>
+                <Style Selector="^ /template/ ContentPresenter">
+                    <Setter Property="Foreground" Value="White" />
+                </Style>
+                <Style Selector="^ /template/ TextBlock">
+                    <Setter Property="Foreground" Value="White" />
+                </Style>
+            </Style>
+            <Style Selector="^:pressed /template/ Border">
+                <Setter Property="BorderBrush" Value="Transparent" />
+                <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor}"/>
+            </Style>
         </Style>
 
         <Style Selector="^.Success">
             <Setter Property="Background" Value="#cdf2ca" />
             <Setter Property="BorderBrush" Value="#b2e1ae" />
+            <Style Selector="^ /template/ TextBlock">
+                <Setter Property="Foreground" Value="#13831c" />
+            </Style>
+            <Style Selector="^:pointerover /template/ Border">
+                <Setter Property="Background" Value="#d7f5db" />
+            </Style>
+            <Style Selector="^:pressed /template/ Border">
+                <Setter Property="Background" Value="#d7f5db" />
+            </Style>
         </Style>
-        <Style Selector="^.Success /template/ TextBlock">
-            <Setter Property="Foreground" Value="#13831c" />
-        </Style>
-        <Style Selector="^.Success:pointerover /template/ Border">
-            <Setter Property="Background" Value="#d7f5db" />
-        </Style>
-        <Style Selector="^.Success:pressed /template/ Border">
-            <Setter Property="Background" Value="#d7f5db" />
-        </Style>
-
+        
         <Style Selector="^.Danger">
             <Setter Property="Background" Value="#f2caca" />
             <Setter Property="BorderBrush" Value="#e4b5b5" />
-        </Style>
-        <Style Selector="^.Danger /template/ TextBlock">
-            <Setter Property="Foreground" Value="#831313" />
-        </Style>
-        <Style Selector="^.Danger:pointerover /template/ Border">
-            <Setter Property="Background" Value="#f5d7d7" />
-        </Style>
-        <Style Selector="^.Danger:pressed /template/ Border">
-            <Setter Property="Background" Value="#f5d7d7" />
+            <Style Selector="^ /template/ TextBlock">
+                <Setter Property="Foreground" Value="#831313" />
+            </Style>
+            <Style Selector="^:pointerover /template/ Border">
+                <Setter Property="Background" Value="#f5d7d7" />
+            </Style>
+            <Style Selector="^:pressed /template/ Border">
+                <Setter Property="Background" Value="#f5d7d7" />
+            </Style>
         </Style>
 
         <Style Selector="^.Rounded">
             <Setter Property="CornerRadius" Value="100" />
-        </Style>
-
-        <Style Selector="^.Basic /template/ Border">
-            <Setter Property="BoxShadow" Value="0 0 0 0 Transparent" />
-        </Style>
-
-        <Style Selector="^.Void /template/ Border">
-            <Setter Property="BoxShadow" Value="0 0 0 0 Transparent" />
-        </Style>
-
-        <Style Selector="^.Flat /template/ Border">
-            <Setter Property="BoxShadow" Value="{DynamicResource SukiLowShadow}" />
         </Style>
 
         <Style Selector="^.Card">

--- a/SukiUI/Theme/ButtonStyles.axaml
+++ b/SukiUI/Theme/ButtonStyles.axaml
@@ -111,6 +111,48 @@
         
         
         <!-- Classes -->
+        <Style Selector="^.Accent">
+            <Style Selector="^ /template/ TextBlock">
+                <Setter Property="Foreground" Value="{DynamicResource SukiAccentColor}" />
+            </Style>
+            <Style Selector="^ /template/ ContentPresenter">
+                <Setter Property="Foreground" Value="{DynamicResource SukiAccentColor}" />
+            </Style>
+        
+            <Style Selector="^ /template/ Border">
+                <Setter Property="BorderBrush" Value="{DynamicResource SukiAccentColor}" />
+            </Style>
+            <Style Selector="^:pointerover">
+                <Style Selector="^ /template/ TextBlock">
+                    <Setter Property="Foreground" Value="{DynamicResource SukiAccentColor}" />
+                </Style>
+                <Style Selector="^ /template/ ContentPresenter">
+                    <Setter Property="Foreground" Value="{DynamicResource SukiAccentColor}" />
+                </Style>
+        
+                <Style Selector="^ /template/ Border">
+                    <Setter Property="BorderBrush" Value="{DynamicResource SukiAccentColor}" />
+                </Style>
+            </Style>
+            <Style Selector="^:pressed">
+                <Style Selector="^ /template/ TextBlock">
+                    <Setter Property="Foreground" Value="{DynamicResource SukiAccentColor}" />
+                </Style>
+                <Style Selector="^ /template/ Border">
+                    <Setter Property="Background" Value="{DynamicResource SukiCardBackground}" />
+                    <Setter Property="BorderBrush" Value="{DynamicResource SukiAccentColor}" />
+                    <Setter Property="RenderTransform">
+                        <Setter.Value>
+                            <ScaleTransform ScaleX="0.97" ScaleY="0.97" />
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+                <Style Selector="^ /template/ ContentPresenter">
+                    <Setter Property="Foreground" Value="{DynamicResource SukiAccentColor}" />
+                </Style>
+            </Style>
+        </Style>
+        
         <Style Selector="^.Basic">
             <Setter Property="BorderThickness" Value="0" />
             <Setter Property="BorderBrush" Value="Transparent" />
@@ -147,6 +189,22 @@
             </Style>
             <Style Selector="^:pressed /template/ Border">
                 <Setter Property="Background" Value="Transparent" />
+            </Style>
+            <!-- Color Variants -->
+            <Style Selector="^.Accent">
+                <Style Selector="^ /template/ TextBlock">
+                    <Setter Property="Foreground">
+                        <Setter.Value>
+                            <LinearGradientBrush EndPoint="50%,100%" StartPoint="48%,0%">
+                                <GradientStop Color="{DynamicResource SukiAccentColor}" Offset="0.8" />
+                                <GradientStop Color="{DynamicResource SukiAccentColor}" Offset="1" />
+                            </LinearGradientBrush>
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+                <Style Selector="^ /template/ ContentPresenter">
+                    <Setter Property="Foreground" Value="{DynamicResource SukiAccentColor}" />
+                </Style>
             </Style>
         </Style>
 
@@ -198,6 +256,16 @@
             <Style Selector="^:pressed /template/ Border">
                 <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor}" />
             </Style>
+            <!-- Color Variants -->
+            <Style Selector="^.Accent">
+                <Setter Property="Background" Value="{DynamicResource SukiAccentColor}"/>
+                <Style Selector="^:pointerover">
+                    <Setter Property="Background" Value="{DynamicResource SukiAccentColor}" />
+                </Style>
+                <Style Selector="^:pressed /template/ Border">
+                    <Setter Property="Background" Value="{DynamicResource SukiAccentColor}" />
+                </Style>
+            </Style>
         </Style>
 
         <Style Selector="^.Outlined">
@@ -241,6 +309,22 @@
             <Style Selector="^:pressed /template/ Border">
                 <Setter Property="BorderBrush" Value="Transparent" />
                 <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor}"/>
+            </Style>
+            <!-- Color Variants -->
+            <Style Selector="^.Accent">
+                <Setter Property="BorderBrush" Value="{DynamicResource SukiAccentColor}"/>
+                <Style Selector="^ /template/ TextBlock">
+                    <Setter Property="Foreground" Value="{DynamicResource SukiAccentColor}" />
+                </Style>
+                <Style Selector="^ /template/ ContentPresenter">
+                    <Setter Property="Foreground" Value="{DynamicResource SukiAccentColor}" />
+                </Style>
+                <Style Selector="^:pointerover">
+                    <Setter Property="Background" Value="{DynamicResource SukiAccentColor}"/>
+                </Style>
+                <Style Selector="^:pressed /template/ Border">
+                    <Setter Property="Background" Value="{DynamicResource SukiAccentColor}"/>
+                </Style>
             </Style>
         </Style>
 

--- a/SukiUI/Theme/Index.axaml
+++ b/SukiUI/Theme/Index.axaml
@@ -60,6 +60,7 @@
                 <ResourceInclude Source="avares://sukiUI/Controls/SukiToast.axaml"/>
                 <ResourceInclude Source="avares://sukiUI/Controls/SukiSideMenu.axaml"/>
                 <ResourceInclude Source="avares://sukiUI/Controls/SukiSideMenuItem.axaml"/>
+                <ResourceInclude Source="avares://sukiUI/Controls/Stepper.axaml"/>
                 <ResourceInclude Source="../ColorTheme/Light.axaml"  />
             </ResourceDictionary.MergedDictionaries>
             


### PR DESCRIPTION
So my phone number was just banned from telegram out of nowhere, I never used the app before this week and I only used it to talk to you and in the Avalonia channel, so that's good.

If you have Discord I'm `doombox.` if you want to add me to chat.

***Added***
- Full new set of accented button styles, all nested within existing styles so they can be easily modified.
- Icons page has been added to the new demo app.
- Dashboard has been ported from the old app to the new one.
- A small number of icons for completeness.

***Fixed***
- Reorganised and fully nested `Button` styles so they are a bit easier to maintain.
- Rewrote the internals of `Stepper` so it now supports binding.
- Duplicate icon `CloseCircle` was removed. 

***Outstanding Issues***
- `MenuItem` clips overly long text.
- Haven't fully tested interactivity with `Stepper` yet so there might be some improvements that could be made to prevent fully redrawing the control each time.
- `GigaChips` text still flickering quite clearly when selected.
- Error messages on `TextBox` aren't MVVM friendly, will need to investigate a proper solution that works with standard validation patterns.
- The Dashboard page's first draw is ***very*** sluggish compared to other pages, hopefully as I build out the control demo pages it will become clearer what control in particular is the culprit.