### PR TITLE
Minor fixes.

### DIFF
--- a/SukiUI.Demo/App.axaml.cs
+++ b/SukiUI.Demo/App.axaml.cs
@@ -8,6 +8,7 @@ using Avalonia.Markup.Xaml;
 using Microsoft.Extensions.DependencyInjection;
 using SukiUI.Demo.Common;
 using SukiUI.Demo.Features;
+using SukiUI.Demo.Services;
 
 namespace SukiUI.Demo;
 
@@ -39,6 +40,7 @@ public partial class App : Application
         var services = new ServiceCollection();
 
         services.AddSingleton(Current.DataTemplates.First(x => x is ViewLocator));
+        services.AddSingleton<PageNavigationService>();
         
         // Viewmodels
         services.AddSingleton<SukiUIDemoViewModel>();

--- a/SukiUI.Demo/Features/ControlsLibrary/IconsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/IconsView.axaml
@@ -19,9 +19,17 @@
                         <LineBreak/>
                         The icons can be used in the following way:
                     </TextBlock>
-                    <showMeTheXaml:XamlDisplay UniqueId="Icon" HorizontalAlignment="Left">
-                        <PathIcon Data="{x:Static content:Icons.Plus}"/>
-                    </showMeTheXaml:XamlDisplay>
+                    <StackPanel Orientation="Horizontal" Spacing="15">
+                        <showMeTheXaml:XamlDisplay UniqueId="Icon1">
+                            <PathIcon Data="{x:Static content:Icons.Plus}"/>
+                        </showMeTheXaml:XamlDisplay>
+                        <showMeTheXaml:XamlDisplay UniqueId="Icon2">
+                            <PathIcon Data="{x:Static content:Icons.Plus}" Classes="Primary"/>
+                        </showMeTheXaml:XamlDisplay>
+                        <showMeTheXaml:XamlDisplay UniqueId="Icon3">
+                            <PathIcon Data="{x:Static content:Icons.Plus}" Classes="Accent"/>
+                        </showMeTheXaml:XamlDisplay>
+                    </StackPanel>
                     <TextBlock>
                         Here is the full list of available icons:
                     </TextBlock>

--- a/SukiUI.Demo/Features/Splash/SplashViewModel.cs
+++ b/SukiUI.Demo/Features/Splash/SplashViewModel.cs
@@ -1,11 +1,13 @@
 using Material.Icons;
+using SukiUI.Demo.Features.Dashboard;
+using SukiUI.Demo.Services;
 
 namespace SukiUI.Demo.Features.Splash;
 
-public class SplashViewModel() : DemoPageBase("Welcome", MaterialIconKind.Hand, int.MinValue)
+public class SplashViewModel(PageNavigationService nav) : DemoPageBase("Welcome", MaterialIconKind.Hand, int.MinValue)
 {
     public void OpenDashboard()
     {
-        
+        nav.RequestNavigation<DashboardViewModel>();
     }
 }

--- a/SukiUI.Demo/Features/Theming/ThemingView.axaml
+++ b/SukiUI.Demo/Features/Theming/ThemingView.axaml
@@ -24,7 +24,10 @@
                                     HorizontalAlignment="Center"
                                     Orientation="Horizontal"
                                     Spacing="20">
-                                    <RadioButton IsChecked="{Binding IsLightTheme}" Command="{Binding SwitchToLightTheme}" Classes="GigaChips" GroupName="RadioBaseTheme">
+                                    <RadioButton 
+                                        IsChecked="{Binding IsLightTheme}"
+                                        Classes="GigaChips"
+                                        GroupName="RadioBaseTheme">
                                         <Border
                                             Background="#fafafa"
                                             CornerRadius="{DynamicResource MediumCornerRadius}"
@@ -42,7 +45,10 @@
                                         </Border>
                                     </RadioButton>
 
-                                    <RadioButton IsChecked="{Binding !IsLightTheme}" Command="{Binding SwitchToDarkTheme}" Classes="GigaChips" GroupName="RadioBaseTheme">
+                                    <RadioButton
+                                        IsChecked="{Binding !IsLightTheme}"
+                                        Classes="GigaChips"
+                                        GroupName="RadioBaseTheme">
                                         <Border
                                             Background="#222222"
                                             CornerRadius="{DynamicResource MediumCornerRadius}"
@@ -77,12 +83,11 @@
                                     <ItemsControl.ItemTemplate>
                                         <DataTemplate x:DataType="models:SukiColorTheme">
 
-                                            <RadioButton CommandParameter="{Binding }" 
-                                                         Command="{Binding ((theming:ThemingViewModel)DataContext).SwitchToColorTheme, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type theming:ThemingView}}}" 
-
-                                                Classes="GigaChips"
-                                                CornerRadius="50"
-                                                GroupName="RadioColorTheme">
+                                            <RadioButton CommandParameter="{Binding }"
+                                                         Command="{Binding ((theming:ThemingViewModel)DataContext).SwitchToColorTheme, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type theming:ThemingView}}}"
+                                                         Classes="GigaChips"
+                                                         CornerRadius="50"
+                                                         GroupName="RadioColorTheme">
                                                 <Border
                                                     Background="{Binding PrimaryBrush}"
                                                     CornerRadius="50"
@@ -99,11 +104,10 @@
                             <controls:SettingsLayoutItem.Content>
                                 <controls:GlassCard Margin="15">
                                     <DockPanel>
-                                        <ToggleButton Command="{Binding ChangeAnimated}" IsChecked="{Binding IsBackgroundAnimated}"
-                                            Classes="Switch"
-                                            DockPanel.Dock="Right"
-                                            VerticalAlignment="Top" 
-                                            IsChecked="{Binding AnimationsEnabled}"/>
+                                        <ToggleButton IsChecked="{Binding IsBackgroundAnimated}"
+                                                      Classes="Switch"
+                                                      DockPanel.Dock="Right"
+                                                      VerticalAlignment="Top" />
                                         <StackPanel HorizontalAlignment="Left">
                                             <TextBlock
                                                 FontSize="16"

--- a/SukiUI.Demo/Features/Theming/ThemingView.axaml
+++ b/SukiUI.Demo/Features/Theming/ThemingView.axaml
@@ -24,7 +24,10 @@
                                     HorizontalAlignment="Center"
                                     Orientation="Horizontal"
                                     Spacing="20">
-                                    <RadioButton Classes="GigaChips" GroupName="RadioBaseTheme">
+                                    <RadioButton
+                                        Classes="GigaChips"
+                                        GroupName="RadioBaseTheme"
+                                        IsChecked="{Binding !IsDark}">
                                         <Border
                                             Background="#fafafa"
                                             CornerRadius="{DynamicResource MediumCornerRadius}"
@@ -42,7 +45,10 @@
                                         </Border>
                                     </RadioButton>
 
-                                    <RadioButton Classes="GigaChips" GroupName="RadioBaseTheme">
+                                    <RadioButton
+                                        Classes="GigaChips"
+                                        GroupName="RadioBaseTheme"
+                                        IsChecked="{Binding IsDark}">
                                         <Border
                                             Background="#222222"
                                             CornerRadius="{DynamicResource MediumCornerRadius}"
@@ -65,7 +71,7 @@
 
                         <controls:SettingsLayoutItem Header="Color Theme">
                             <controls:SettingsLayoutItem.Content>
-                                <ItemsControl HorizontalAlignment="Center" ItemsSource="{Binding AvailablesColors}">
+                                <ItemsControl HorizontalAlignment="Center" ItemsSource="{Binding AvailableColors}">
                                     <ItemsControl.ItemsPanel>
                                         <ItemsPanelTemplate>
                                             <StackPanel
@@ -76,7 +82,6 @@
                                     </ItemsControl.ItemsPanel>
                                     <ItemsControl.ItemTemplate>
                                         <DataTemplate x:DataType="models:SukiColorTheme">
-
                                             <RadioButton
                                                 Classes="GigaChips"
                                                 CornerRadius="50"
@@ -100,7 +105,8 @@
                                         <ToggleButton
                                             Classes="Switch"
                                             DockPanel.Dock="Right"
-                                            VerticalAlignment="Top" />
+                                            VerticalAlignment="Top" 
+                                            IsChecked="{Binding AnimationsEnabled}"/>
                                         <StackPanel HorizontalAlignment="Left">
                                             <TextBlock
                                                 FontSize="16"

--- a/SukiUI.Demo/Features/Theming/ThemingViewModel.cs
+++ b/SukiUI.Demo/Features/Theming/ThemingViewModel.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.ObjectModel;
 using Avalonia;
 using Avalonia.Collections;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -11,28 +9,43 @@ using SukiUI.Models;
 
 namespace SukiUI.Demo.Features.Theming;
 
-public partial class ThemingViewModel() : DemoPageBase("Theming", MaterialIconKind.PaletteOutline, -200)
+public partial class ThemingViewModel : DemoPageBase
 {
-    public IAvaloniaReadOnlyList<SukiColorTheme> AvailablesColors { get; } = SukiTheme.GetInstance().ColorThemes;
+    public IAvaloniaReadOnlyList<SukiColorTheme> AvailableColors { get; }
 
-    public void SwitchToLightTheme() => SukiTheme.GetInstance().ChangeBaseTheme(ThemeVariant.Light);
-    public void SwitchToDarkTheme() => SukiTheme.GetInstance().ChangeBaseTheme(ThemeVariant.Dark);
-   
-    public bool IsLightTheme
-    {
-        get { return SukiTheme.GetInstance().ActiveBaseTheme == ThemeVariant.Light; }
-    }
-
-
-    public void SwitchToColorTheme(SukiColorTheme colorTheme) => SukiTheme.GetInstance().ChangeColorTheme(colorTheme);
+    private readonly SukiTheme _theme = SukiTheme.GetInstance();
     
-    [ObservableProperty] private bool _isBackgroundAnimated ;
+    [ObservableProperty] private bool _isBackgroundAnimated;
+    [ObservableProperty] private bool _isLightTheme;
 
-    public void ChangeAnimated()
+    // TODO: This is very bad.
+    private SukiWindow Window =>
+        ((SukiWindow)((IClassicDesktopStyleApplicationLifetime)Application.Current!.ApplicationLifetime!).MainWindow!);
+    
+    public ThemingViewModel() : base("Theming", MaterialIconKind.PaletteOutline, -200)
     {
-        ((SukiWindow)((IClassicDesktopStyleApplicationLifetime)Application.Current.ApplicationLifetime).MainWindow)
-            .BackgroundAnimationEnabled = _isBackgroundAnimated;
+        AvailableColors = _theme.ColorThemes;
+        IsLightTheme = _theme.ActiveBaseTheme == ThemeVariant.Light;
+        _theme.OnBaseThemeChanged += variant =>
+        {
+            IsLightTheme = variant == ThemeVariant.Light;
+        };
+        _theme.OnColorThemeChanged += theme =>
+        {
+            // TODO: Implement a way to make the correct, might need to wrap the thing in a VM, this isn't ideal.
+        };
     }
 
+    partial void OnIsLightThemeChanged(bool value)
+    {
+        _theme.ChangeBaseTheme(value ? ThemeVariant.Light : ThemeVariant.Dark);
+    }
 
+    partial void OnIsBackgroundAnimatedChanged(bool value)
+    {
+        Window.BackgroundAnimationEnabled = value;
+    }
+
+    public void SwitchToColorTheme(SukiColorTheme colorTheme) => 
+        _theme.ChangeColorTheme(colorTheme);
 }

--- a/SukiUI.Demo/Features/Theming/ThemingViewModel.cs
+++ b/SukiUI.Demo/Features/Theming/ThemingViewModel.cs
@@ -1,10 +1,7 @@
-using Avalonia;
 using Avalonia.Collections;
-using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Styling;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Material.Icons;
-using SukiUI.Controls;
 using SukiUI.Models;
 
 namespace SukiUI.Demo.Features.Theming;
@@ -17,34 +14,27 @@ public partial class ThemingViewModel : DemoPageBase
     
     [ObservableProperty] private bool _isBackgroundAnimated;
     [ObservableProperty] private bool _isLightTheme;
-
-    // TODO: This is very bad.
-    private SukiWindow Window =>
-        ((SukiWindow)((IClassicDesktopStyleApplicationLifetime)Application.Current!.ApplicationLifetime!).MainWindow!);
     
     public ThemingViewModel() : base("Theming", MaterialIconKind.PaletteOutline, -200)
     {
         AvailableColors = _theme.ColorThemes;
         IsLightTheme = _theme.ActiveBaseTheme == ThemeVariant.Light;
-        _theme.OnBaseThemeChanged += variant =>
-        {
+        IsBackgroundAnimated = _theme.IsBackgroundAnimated;
+        _theme.OnBaseThemeChanged += variant => 
             IsLightTheme = variant == ThemeVariant.Light;
-        };
         _theme.OnColorThemeChanged += theme =>
         {
             // TODO: Implement a way to make the correct, might need to wrap the thing in a VM, this isn't ideal.
         };
+        _theme.OnBackgroundAnimationChanged += value => 
+            IsBackgroundAnimated = value;
     }
 
-    partial void OnIsLightThemeChanged(bool value)
-    {
+    partial void OnIsLightThemeChanged(bool value) => 
         _theme.ChangeBaseTheme(value ? ThemeVariant.Light : ThemeVariant.Dark);
-    }
 
-    partial void OnIsBackgroundAnimatedChanged(bool value)
-    {
-        Window.BackgroundAnimationEnabled = value;
-    }
+    partial void OnIsBackgroundAnimatedChanged(bool value) => 
+        _theme.SetBackgroundAnimationsEnabled(value);
 
     public void SwitchToColorTheme(SukiColorTheme colorTheme) => 
         _theme.ChangeColorTheme(colorTheme);

--- a/SukiUI.Demo/Features/Theming/ThemingViewModel.cs
+++ b/SukiUI.Demo/Features/Theming/ThemingViewModel.cs
@@ -1,12 +1,44 @@
-﻿using System.Collections.ObjectModel;
-using Avalonia.Collections;
+﻿using Avalonia.Collections;
+using Avalonia.Styling;
+using CommunityToolkit.Mvvm.ComponentModel;
 using Material.Icons;
 using SukiUI.Models;
 
 namespace SukiUI.Demo.Features.Theming;
 
-public class ThemingViewModel() : DemoPageBase("Theming", MaterialIconKind.PaletteOutline, -200)
+public partial class ThemingViewModel : DemoPageBase
 {
-    public IAvaloniaReadOnlyList<SukiColorTheme> AvailablesColors { get; } =  SukiTheme.GetInstance().ColorThemes;
+    public IAvaloniaReadOnlyList<SukiColorTheme> AvailableColors { get; }
+    
+    [ObservableProperty] private bool _isDark;
+    [ObservableProperty] private SukiColorTheme _activeTheme;
+    [ObservableProperty] private bool _animationsEnabled;
+    
+    private readonly SukiTheme _theme;
+    
+    public ThemingViewModel() : base("Theming", MaterialIconKind.PaletteOutline, -200)
+    {
+        _theme = SukiTheme.GetInstance();
+        AvailableColors = _theme.ColorThemes;
+        IsDark = _theme.ActiveBaseTheme == ThemeVariant.Dark;
+        _activeTheme = _theme.ActiveColorTheme;
+        _theme.OnBaseThemeChanged += variant =>
+        { 
+            IsDark = variant == ThemeVariant.Dark;
+        };
+        _theme.OnColorThemeChanged += theme =>
+        {
+            _activeTheme = theme;
+        };
+    }
 
+    partial void OnIsDarkChanged(bool value)
+    {
+        _theme.ChangeBaseTheme(value ? ThemeVariant.Dark : ThemeVariant.Light);
+    }
+
+    partial void OnActiveThemeChanged(SukiColorTheme value)
+    {
+        _theme.ChangeColorTheme(value);
+    }
 }

--- a/SukiUI.Demo/Services/PageNavigationService.cs
+++ b/SukiUI.Demo/Services/PageNavigationService.cs
@@ -1,0 +1,14 @@
+using System;
+using SukiUI.Demo.Features;
+
+namespace SukiUI.Demo.Services;
+
+public class PageNavigationService
+{
+    public Action<Type>? NavigationRequested { get; set; }
+    
+    public void RequestNavigation<T>() where T : DemoPageBase
+    {
+        NavigationRequested?.Invoke(typeof(T));
+    }
+}

--- a/SukiUI.Demo/SukiUIDemoView.axaml
+++ b/SukiUI.Demo/SukiUIDemoView.axaml
@@ -33,7 +33,7 @@
             <MenuItem Header="Create Custom Theme" Command="{Binding CreateCustomTheme}"/>
         </MenuItem>
     </suki:SukiWindow.MenuItems>
-    <suki:SukiSideMenu ItemsSource="{Binding DemoPages}">
+    <suki:SukiSideMenu ItemsSource="{Binding DemoPages}" SelectedItem="{Binding ActivePage}">
         <suki:SukiSideMenu.ItemTemplate>
             <DataTemplate>
                 <suki:SukiSideMenuItem Header="{Binding DisplayName}">

--- a/SukiUI.Demo/SukiUIDemoView.axaml
+++ b/SukiUI.Demo/SukiUIDemoView.axaml
@@ -15,62 +15,68 @@
                  BackgroundAnimationEnabled="{Binding AnimationsEnabled}">
     <suki:SukiWindow.LogoContent>
         <PathIcon Data="{x:Static content:Icons.SukiLogo}"
-                  Foreground="{DynamicResource SukiAccentColor}"/>
+                  Foreground="{DynamicResource SukiAccentColor}" />
     </suki:SukiWindow.LogoContent>
     <suki:SukiWindow.MenuItems>
         <MenuItem Header="Toggles">
-            <MenuItem Header="{Binding BaseTheme}" Command="{Binding ToggleBaseTheme}"/>
-            <MenuItem Header="Animations" Command="{Binding ToggleAnimations}"/>
+            <MenuItem Header="{Binding BaseTheme}" Command="{Binding ToggleBaseTheme}" />
+            <MenuItem Header="Animations" Command="{Binding ToggleAnimations}" />
         </MenuItem>
         <MenuItem ItemsSource="{Binding Themes}" Header="Themes" Click="MenuItem_OnClick">
             <MenuItem.DataTemplates>
                 <DataTemplate DataType="{x:Type models:SukiColorTheme}">
-                    <TextBlock Text="{Binding DisplayName}" Foreground="{Binding PrimaryBrush}"/>
+                    <TextBlock Text="{Binding DisplayName}" Foreground="{Binding PrimaryBrush}" />
                 </DataTemplate>
             </MenuItem.DataTemplates>
         </MenuItem>
         <MenuItem Header="Other">
-            <MenuItem Header="Create Custom Theme" Command="{Binding CreateCustomTheme}"/>
+            <MenuItem Header="Create Custom Theme" Command="{Binding CreateCustomTheme}" />
         </MenuItem>
     </suki:SukiWindow.MenuItems>
-    <suki:SukiSideMenu ItemsSource="{Binding DemoPages}" SelectedItem="{Binding ActivePage}">
+    <suki:SukiSideMenu ItemsSource="{Binding DemoPages}" SelectedItem="{Binding ActivePage}"
+                       HeaderContentOverlapsToggleButton="True">
         <suki:SukiSideMenu.ItemTemplate>
             <DataTemplate>
                 <suki:SukiSideMenuItem Header="{Binding DisplayName}">
                     <suki:SukiSideMenuItem.Icon>
-                        <avalonia:MaterialIcon Kind="{Binding Icon}" Foreground="{DynamicResource SukiText}"/>
+                        <avalonia:MaterialIcon Kind="{Binding Icon}" Foreground="{DynamicResource SukiText}" />
                     </suki:SukiSideMenuItem.Icon>
                 </suki:SukiSideMenuItem>
             </DataTemplate>
         </suki:SukiSideMenu.ItemTemplate>
         <suki:SukiSideMenu.HeaderContent>
-            <TextBlock Text="Hello, world header!"/>
+            <PathIcon
+                Data="{x:Static content:Icons.SukiLogo}" 
+                Foreground="{DynamicResource SukiPrimaryColor25}" 
+                Width="30"
+                Height="30" 
+                Margin="25" />
         </suki:SukiSideMenu.HeaderContent>
         <suki:SukiSideMenu.FooterContent>
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                 <StackPanel.Styles>
                     <Style Selector="Button">
-                        <Setter Property="Command" Value="{Binding OpenURL}"/>
+                        <Setter Property="Command" Value="{Binding OpenURL}" />
                     </Style>
                     <Style Selector="avalonia|MaterialIcon">
-                        <Setter Property="Width" Value="25"/>
-                        <Setter Property="Height" Value="25"/>
+                        <Setter Property="Width" Value="25" />
+                        <Setter Property="Height" Value="25" />
                     </Style>
                 </StackPanel.Styles>
-                <Button Classes="Basic" 
+                <Button Classes="Basic"
                         CommandParameter="https://github.com/kikipoulet/SukiUI"
                         ToolTip.Tip="Open On GitHub.">
-                    <avalonia:MaterialIcon Kind="Github"/>
+                    <avalonia:MaterialIcon Kind="Github" />
                 </Button>
-                <Button Classes="Basic" 
+                <Button Classes="Basic"
                         CommandParameter="https://www.nuget.org/packages/SukiUI"
                         ToolTip.Tip="View On NuGet.">
-                    <avalonia:MaterialIcon Kind="Package"/>
+                    <avalonia:MaterialIcon Kind="Package" />
                 </Button>
-                <Button Classes="Basic" 
+                <Button Classes="Basic"
                         CommandParameter="https://github.com/kikipoulet/CherylUI"
                         ToolTip.Tip="CheryUI - For Mobile">
-                    <avalonia:MaterialIcon Kind="Cat"/>
+                    <avalonia:MaterialIcon Kind="Cat" />
                 </Button>
             </StackPanel>
         </suki:SukiSideMenu.FooterContent>

--- a/SukiUI.Demo/SukiUIDemoViewModel.cs
+++ b/SukiUI.Demo/SukiUIDemoViewModel.cs
@@ -43,10 +43,10 @@ public partial class SukiUIDemoViewModel : ViewAwareObservableObject
             BaseTheme = variant;
             SukiHost.ShowToast("Successfully Changed Theme", $"Changed Theme To {variant}");
         };
-        _theme.OnColorThemeChanged += theme =>
-        {
+        _theme.OnColorThemeChanged += theme => 
             SukiHost.ShowToast("Successfully Changed Color", $"Changed Color To {theme.DisplayName}.");
-        };
+        _theme.OnBackgroundAnimationChanged += 
+            value => AnimationsEnabled = value;
     }
 
     public void ToggleAnimations()

--- a/SukiUI.Demo/SukiUIDemoViewModel.cs
+++ b/SukiUI.Demo/SukiUIDemoViewModel.cs
@@ -9,6 +9,7 @@ using SukiUI.Controls;
 using SukiUI.Demo.Common;
 using SukiUI.Demo.Features;
 using SukiUI.Demo.Features.CustomTheme;
+using SukiUI.Demo.Services;
 using SukiUI.Models;
 
 namespace SukiUI.Demo;
@@ -21,13 +22,20 @@ public partial class SukiUIDemoViewModel : ViewAwareObservableObject
 
     [ObservableProperty] private ThemeVariant _baseTheme;
     [ObservableProperty] private bool _animationsEnabled;
+    [ObservableProperty] private DemoPageBase _activePage;
 
     private readonly SukiTheme _theme;
 
-    public SukiUIDemoViewModel(IEnumerable<DemoPageBase> demoPages)
+    public SukiUIDemoViewModel(IEnumerable<DemoPageBase> demoPages, PageNavigationService nav)
     {
         DemoPages.AddRange(demoPages.OrderBy(x => x.Index).ThenBy(x => x.DisplayName));
         _theme = SukiTheme.GetInstance();
+        nav.NavigationRequested += t =>
+        {
+            var page = DemoPages.FirstOrDefault(x => x.GetType() == t);
+            if (page is null || ActivePage.GetType() == t) return;
+            ActivePage = page;
+        };
         Themes = _theme.ColorThemes;
         BaseTheme = _theme.ActiveBaseTheme;
         _theme.OnBaseThemeChanged += variant =>

--- a/SukiUI/Controls/SukiBackground.cs
+++ b/SukiUI/Controls/SukiBackground.cs
@@ -26,7 +26,7 @@ public class SukiBackground : Image, IDisposable
     
     private static readonly Timer _animationTick = new(1000 / AnimFps) { AutoReset = true }; // 1 fps
 
-    private bool _animationEnabled = false;
+    public bool AnimationEnabled { get; private set; } = false;
 
     private readonly SukiTheme _theme;
 
@@ -36,6 +36,7 @@ public class SukiBackground : Image, IDisposable
         Stretch = Stretch.UniformToFill;
         _animationTick.Elapsed += (_, _) => _renderer.Render(_bmp);
         _theme = SukiTheme.GetInstance();
+        _theme.RegisterBackground(this);
     }
 
     public override void EndInit()
@@ -56,15 +57,16 @@ public class SukiBackground : Image, IDisposable
         _renderer.UpdateValues(_theme.ActiveColorTheme, _theme.ActiveBaseTheme);
         _renderer.Render(_bmp);
         
-        if(_animationEnabled) _animationTick.Start();
+        if(AnimationEnabled) _animationTick.Start();
     }
 
     public void SetAnimationEnabled(bool value)
     {
-        if (_animationEnabled == value) return;
-        _animationEnabled = value;
+        if (AnimationEnabled == value) return;
+        AnimationEnabled = value;
         if (!_renderer.SupportsAnimation) return;
-        if(_animationEnabled) _animationTick.Start();
+        _theme.OnBackgroundAnimationChanged?.Invoke(AnimationEnabled);
+        if(AnimationEnabled) _animationTick.Start();
         else _animationTick.Stop();
     }
 

--- a/SukiUI/Controls/SukiWindow.axaml.cs
+++ b/SukiUI/Controls/SukiWindow.axaml.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
 using System.Runtime.InteropServices;
-using System.Threading;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;

--- a/SukiUI/Theme/Index.axaml
+++ b/SukiUI/Theme/Index.axaml
@@ -54,6 +54,7 @@
                 <ResourceInclude Source="avares://SukiUI/Theme/DatePicker.axaml" />
                 <ResourceInclude Source="avares://sukiUI/Theme/ToolTipStyle.axaml"/>
                 <ResourceInclude Source="avares://sukiUI/Theme/ButtonStyles.axaml"/>
+                <ResourceInclude Source="avares://sukiUI/Theme/PathIconStyles.axaml"/>
                 
                 <ResourceInclude Source="avares://sukiUI/Controls/SukiWindow.axaml"/>
                 <ResourceInclude Source="avares://sukiUI/Controls/SukiHost.axaml"/>

--- a/SukiUI/Theme/Index.axaml.cs
+++ b/SukiUI/Theme/Index.axaml.cs
@@ -8,6 +8,7 @@ using Avalonia.Markup.Xaml;
 using Avalonia.Media;
 using Avalonia.Styling;
 using DynamicData;
+using SukiUI.Controls;
 using SukiUI.Enums;
 using SukiUI.Extensions;
 using SukiUI.Models;
@@ -44,6 +45,12 @@ public partial class SukiTheme : Styles
     /// Useful where controls need to change based on light/dark.
     /// </summary>
     public Action<ThemeVariant>? OnBaseThemeChanged { get; set; }
+    
+    /// <summary>
+    /// Called whenever the application's Background animation state changes.
+    /// Useful where controls need to adapt to the change in background state.
+    /// </summary>
+    public Action<bool> OnBackgroundAnimationChanged { get; set; }
 
     /// <summary>
     /// Currently active <see cref="SukiColorTheme"/>
@@ -61,12 +68,18 @@ public partial class SukiTheme : Styles
     /// If you want to change this please use <see cref="ChangeBaseTheme"/> or <see cref="SwitchBaseTheme"/>
     /// </summary>
     public ThemeVariant ActiveBaseTheme => _app.ActualThemeVariant;
+
+    /// <summary>
+    /// Tells you if the background is currently animated, if one has been registered.
+    /// </summary>
+    public bool IsBackgroundAnimated => _background != null && _background.AnimationEnabled;
     
     private readonly Application _app;
     
     private readonly HashSet<SukiColorTheme> _colorThemeHashset = new();
     private readonly AvaloniaList<SukiColorTheme> _allThemes = new();
-    
+
+    private SukiBackground? _background;
     
     public SukiTheme()
     {
@@ -146,7 +159,26 @@ public partial class SukiTheme : Styles
             : ThemeVariant.Dark;
         Application.Current.RequestedThemeVariant = newBase;
     }
-    
+
+    /// <summary>
+    /// Attempts to switch the currently active background animation state to a specific value.
+    /// </summary>
+    /// <param name="value"></param>
+    public void SetBackgroundAnimationsEnabled(bool value) => 
+        _background?.SetAnimationEnabled(value);
+
+    /// <summary>
+    /// Attempts to switch the currently active background animation state from whatever it is, to the opposite.
+    /// </summary>
+    public void SwitchBackgroundAnimationsEnabled() => 
+        _background?.SetAnimationEnabled(_background.AnimationEnabled);
+
+    /// <summary>
+    /// Registers a background with the instance, if one hasn't already been registered.
+    /// </summary>
+    internal void RegisterBackground(SukiBackground background) => 
+        _background ??= background;
+
     /// <summary>
     /// Initializes the color theme resources whenever the property is changed.
     /// In an ideal world people wouldn't use the property 

--- a/SukiUI/Theme/PathIconStyles.axaml
+++ b/SukiUI/Theme/PathIconStyles.axaml
@@ -1,0 +1,25 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <ControlTheme x:Key="SukiPathIconStyle" TargetType="PathIcon">
+        <Setter Property="Foreground" Value="{DynamicResource SukiText}" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Height" Value="{DynamicResource IconElementThemeHeight}" />
+        <Setter Property="Width" Value="{DynamicResource IconElementThemeWidth}" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Border Background="{TemplateBinding Background}">
+                    <Viewbox Height="{TemplateBinding Height}" Width="{TemplateBinding Width}">
+                        <Path Fill="{TemplateBinding Foreground}" Data="{TemplateBinding Data}" Stretch="Uniform" />
+                    </Viewbox>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+        <Style Selector="^.Primary">
+            <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}"/>
+        </Style>
+        <Style Selector="^.Accent">
+            <Setter Property="Foreground" Value="{DynamicResource SukiAccentColor}"/>
+        </Style>
+    </ControlTheme>
+    <ControlTheme x:Key="{x:Type PathIcon}" TargetType="PathIcon" BasedOn="{StaticResource SukiPathIconStyle}"/>
+</ResourceDictionary>

--- a/SukiUI/Theme/TextBlockStyles.xaml
+++ b/SukiUI/Theme/TextBlockStyles.xaml
@@ -54,8 +54,4 @@
     <Style Selector="TextBlock.Accent">
         <Setter Property="Foreground" Value="{DynamicResource SukiAccentColor}" />
     </Style>
-
-    <Style Selector="PathIcon">
-        <Setter Property="Foreground" Value="{DynamicResource SukiText}" />
-    </Style>
 </Styles>


### PR DESCRIPTION
***Changes*** 
- Introduced `PathIcon` styles.
- Rewrote the `ThemingViewModel` to be a little more sane.
- Very basic navigation service for the demo app so that pages can request other pages be opened.
- Rolled the background controls into `SukiTheme` so now everything visual is in one place, stops the horrendous mess of trying to get the root `SukiWindow` just to manually modify a property on that.

***Outstanding Issues***
- The current way of displaying and toggling between themes in the theming view doesn't allow for easy updates based on changes, there are `TODO` in the file marking where the issue is.
- `ShowMeTheXaml` doesn't seem to like displaying multi-line text at all, must be an issue with `TextBox`, a bit annoying.
- `TextBlock` which have a `<LineBreak/>` in them don't correctly update when the theme changes, this is however seems to be an Avalonia bug and I don't know that there's much we can do about it from our end.
  - https://github.com/AvaloniaUI/Avalonia/issues/12404