### PR TITLE
Implement progress bars page, fix broken progress bar style.

### DIFF
--- a/SukiUI.Demo/Common/IViewAware.cs
+++ b/SukiUI.Demo/Common/IViewAware.cs
@@ -1,7 +1,0 @@
-﻿using Avalonia.Controls;
-
-namespace SukiUI.Demo.Common;
-
-public interface IViewAware
-{
-}

--- a/SukiUI.Demo/Common/ViewAwareObservableObject.cs
+++ b/SukiUI.Demo/Common/ViewAwareObservableObject.cs
@@ -1,7 +1,0 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
-
-namespace SukiUI.Demo.Common;
-
-public abstract class ViewAwareObservableObject : ObservableObject, IViewAware
-{
-}

--- a/SukiUI.Demo/Features/ControlsLibrary/IconsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/IconsView.axaml
@@ -37,9 +37,9 @@
             </controls:GroupBox>
         </controls:GlassCard>
         <ScrollViewer Grid.Row="1" HorizontalScrollBarVisibility="Disabled">
-            <ItemsControl x:CompileBindings="False" ItemsSource="{Binding AllIcons}">
+            <ItemsControl ItemsSource="{Binding AllIcons}">
                 <ItemsControl.ItemTemplate>
-                    <DataTemplate>
+                    <DataTemplate x:CompileBindings="False">
                         <controls:GlassCard Margin="15,15,15,15">
                             <controls:GroupBox Header="{Binding Key}">
                                 <PathIcon Width="25"

--- a/SukiUI.Demo/Features/ControlsLibrary/ProgressView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/ProgressView.axaml
@@ -44,16 +44,29 @@
 
                 <controls:GlassCard>
                     <controls:GroupBox Header="Circle Progress">
-                        <showMeTheXaml:XamlDisplay UniqueId="CircleProgress">
-                            <controls:CircleProgressBar Width="130"
-                                                        Height="130"
-                                                        StrokeWidth="11"
-                                                        Value="{Binding ProgressValue}">
-                                <TextBlock Classes="h3"
-                                           IsVisible="{Binding IsTextVisible}"
-                                           Text="{Binding ProgressValue, StringFormat={}{0:#0}%}" />
-                            </controls:CircleProgressBar>
-                        </showMeTheXaml:XamlDisplay>
+                        <StackPanel Spacing="15">
+                            <showMeTheXaml:XamlDisplay UniqueId="CircleProgress1">
+                                <controls:CircleProgressBar Width="130"
+                                                            Height="130"
+                                                            StrokeWidth="11"
+                                                            Value="{Binding ProgressValue}">
+                                    <TextBlock Classes="h3"
+                                               IsVisible="{Binding IsTextVisible}"
+                                               Text="{Binding ProgressValue, StringFormat={}{0:#0}%}" />
+                                </controls:CircleProgressBar>
+                            </showMeTheXaml:XamlDisplay>
+                            <showMeTheXaml:XamlDisplay UniqueId="CircleProgress2">
+                                <controls:CircleProgressBar Width="130"
+                                                            Height="130"
+                                                            Classes="Accent"
+                                                            StrokeWidth="11"
+                                                            Value="{Binding ProgressValue}">
+                                    <TextBlock Classes="h3"
+                                               IsVisible="{Binding IsTextVisible}"
+                                               Text="{Binding ProgressValue, StringFormat={}{0:#0}%}" />
+                                </controls:CircleProgressBar>
+                            </showMeTheXaml:XamlDisplay>
+                        </StackPanel>
                     </controls:GroupBox>
                 </controls:GlassCard>
 

--- a/SukiUI.Demo/Features/ControlsLibrary/ProgressView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/ProgressView.axaml
@@ -1,0 +1,121 @@
+<UserControl x:Class="SukiUI.Demo.Features.ControlsLibrary.ProgressView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:controlsLibrary="clr-namespace:SukiUI.Demo.Features.ControlsLibrary"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:showMeTheXaml="clr-namespace:ShowMeTheXaml;assembly=ShowMeTheXaml.Avalonia"
+             d:DesignHeight="450"
+             d:DesignWidth="800"
+             x:DataType="controlsLibrary:ProgressViewModel"
+             mc:Ignorable="d">
+    <Grid RowDefinitions="Auto,*">
+        <controls:GlassCard Margin="30">
+            <controls:GroupBox Header="Progress Indicators">
+                <StackPanel Spacing="15">
+                    <TextBlock TextWrapping="Wrap">
+                        Here is a demo of all the available progress indicators in SukiUI, including the stepper.<LineBreak />
+                        The progress bars can be controlled with the controls below except the stepper which has it's own logic.</TextBlock>
+                    <DockPanel>
+                        <CheckBox DockPanel.Dock="Left" IsChecked="{Binding IsTextVisible}" />
+                        <TextBlock Text="Text Enabled?" />
+                    </DockPanel>
+                    <Slider MinWidth="200"
+                            MaxWidth="400"
+                            HorizontalAlignment="Left"
+                            Maximum="100"
+                            Minimum="0"
+                            Value="{Binding ProgressValue}" />
+                </StackPanel>
+            </controls:GroupBox>
+        </controls:GlassCard>
+        <ScrollViewer Grid.Row="1" HorizontalScrollBarVisibility="Disabled">
+            <WrapPanel Classes="PageContainer">
+                <controls:GlassCard Margin="20">
+                    <controls:GroupBox Header="Wave Progress">
+                        <StackPanel>
+                            <showMeTheXaml:XamlDisplay UniqueId="WaveProgress">
+                                <controls:WaveProgress IsTextVisible="{Binding IsTextVisible}" Value="{Binding ProgressValue}" />
+                            </showMeTheXaml:XamlDisplay>
+                        </StackPanel>
+                    </controls:GroupBox>
+                </controls:GlassCard>
+
+                <controls:GlassCard>
+                    <controls:GroupBox Header="Circle Progress">
+                        <showMeTheXaml:XamlDisplay UniqueId="CircleProgress">
+                            <controls:CircleProgressBar Width="130"
+                                                        Height="130"
+                                                        StrokeWidth="11"
+                                                        Value="{Binding ProgressValue}">
+                                <TextBlock Classes="h3"
+                                           IsVisible="{Binding IsTextVisible}"
+                                           Text="{Binding ProgressValue, StringFormat={}{0:#0}%}" />
+                            </controls:CircleProgressBar>
+                        </showMeTheXaml:XamlDisplay>
+                    </controls:GroupBox>
+                </controls:GlassCard>
+
+                <controls:GlassCard>
+                    <controls:GroupBox Header="Standard Progress Bar">
+                        <controls:GroupBox.Styles>
+                            <Style Selector="ProgressBar">
+                                <Setter Property="Value" Value="{Binding ProgressValue}" />
+                                <Setter Property="ShowProgressText" Value="{Binding IsTextVisible}" />
+                            </Style>
+                        </controls:GroupBox.Styles>
+                        <StackPanel Spacing="15">
+                            <showMeTheXaml:XamlDisplay UniqueId="Progress1">
+                                <ProgressBar />
+                            </showMeTheXaml:XamlDisplay>
+                            <showMeTheXaml:XamlDisplay UniqueId="Progress2">
+                                <ProgressBar Classes="Accent" />
+                            </showMeTheXaml:XamlDisplay>
+                            <StackPanel VerticalAlignment="Stretch"
+                                        Orientation="Horizontal"
+                                        Spacing="15">
+                                <showMeTheXaml:XamlDisplay UniqueId="Progress3">
+                                    <ProgressBar Orientation="Vertical" />
+                                </showMeTheXaml:XamlDisplay>
+                                <showMeTheXaml:XamlDisplay UniqueId="Progress4">
+                                    <ProgressBar Classes="Accent" Orientation="Vertical" />
+                                </showMeTheXaml:XamlDisplay>
+                            </StackPanel>
+
+                        </StackPanel>
+                    </controls:GroupBox>
+                </controls:GlassCard>
+
+                <controls:GlassCard>
+                    <controls:GroupBox Header="Loading Indicator">
+                        <showMeTheXaml:XamlDisplay UniqueId="Loading">
+                            <controls:Loading />
+                        </showMeTheXaml:XamlDisplay>
+                    </controls:GroupBox>
+                </controls:GlassCard>
+
+                <controls:GlassCard Width="500">
+                    <controls:GroupBox Header="Stepper">
+                        <StackPanel Spacing="15">
+                            <showMeTheXaml:XamlDisplay UniqueId="Stepper">
+                                <controls:Stepper Index="{Binding StepIndex}" Steps="{Binding Steps}" />
+                            </showMeTheXaml:XamlDisplay>
+                            <!--  Ignore your IDE, x:True and x:False are absolutely valid intrinsics in Avalonia.  -->
+                            <Grid ColumnDefinitions="Auto,*,Auto">
+                                <Button Grid.Column="0"
+                                        Command="{Binding ChangeStepCommand}"
+                                        CommandParameter="{x:False}"
+                                        Content="Decrement" />
+                                <Button Grid.Column="2"
+                                        Command="{Binding ChangeStepCommand}"
+                                        CommandParameter="{x:True}"
+                                        Content="Increment" />
+                            </Grid>
+                        </StackPanel>
+                    </controls:GroupBox>
+                </controls:GlassCard>
+            </WrapPanel>
+        </ScrollViewer>
+    </Grid>
+</UserControl>

--- a/SukiUI.Demo/Features/ControlsLibrary/ProgressView.axaml.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/ProgressView.axaml.cs
@@ -1,0 +1,13 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace SukiUI.Demo.Features.ControlsLibrary;
+
+public partial class ProgressView : UserControl
+{
+    public ProgressView()
+    {
+        InitializeComponent();
+    }
+}

--- a/SukiUI.Demo/Features/ControlsLibrary/ProgressViewModel.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/ProgressViewModel.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Material.Icons;
+
+namespace SukiUI.Demo.Features.ControlsLibrary
+{
+    public partial class ProgressViewModel() : DemoPageBase("Progress", MaterialIconKind.ProgressUpload)
+    {
+        public IEnumerable<string> Steps { get; } =
+        [
+            "First Step", "Second Step", "Third Step"
+        ];
+
+        [ObservableProperty] private int _stepIndex = 1;
+        [ObservableProperty] [Range(0d, 100d)] private double _progressValue = 50;
+        [ObservableProperty] private bool _isTextVisible = true;
+
+        [RelayCommand]
+        public void ChangeStep(bool isIncrement)
+        {
+            switch (isIncrement)
+            {
+                case true when StepIndex >= Steps.Count() - 1:
+                case false when StepIndex <= 0:
+                    return;
+                default:
+                    StepIndex += isIncrement ? 1 : -1;
+                    break;
+            }
+        }
+    }
+}

--- a/SukiUI.Demo/Features/DemoPageBase.cs
+++ b/SukiUI.Demo/Features/DemoPageBase.cs
@@ -4,7 +4,7 @@ using SukiUI.Demo.Common;
 
 namespace SukiUI.Demo.Features;
 
-public abstract partial class DemoPageBase(string displayName, MaterialIconKind icon, int index = 0) : ViewAwareObservableObject
+public abstract partial class DemoPageBase(string displayName, MaterialIconKind icon, int index = 0) : ObservableValidator
 {
     [ObservableProperty] private string _displayName = displayName;
     [ObservableProperty] private MaterialIconKind _icon = icon;

--- a/SukiUI.Demo/SukiUIDemoViewModel.cs
+++ b/SukiUI.Demo/SukiUIDemoViewModel.cs
@@ -15,7 +15,7 @@ using System.Runtime.InteropServices;
 
 namespace SukiUI.Demo;
 
-public partial class SukiUIDemoViewModel : ViewAwareObservableObject
+public partial class SukiUIDemoViewModel : ObservableObject
 {
     public IAvaloniaReadOnlyList<DemoPageBase> DemoPages { get; }
 

--- a/SukiUI/Controls/CircleProgressBar.axaml
+++ b/SukiUI/Controls/CircleProgressBar.axaml
@@ -19,7 +19,8 @@
                              Stroke="{DynamicResource SukiLightBorderBrush}"
                              StrokeThickness="{TemplateBinding StrokeWidth}"
                              SweepAngle="360" />
-                        <Arc Width="{TemplateBinding Width}"
+                        <Arc Name="PART_ArcFill"
+                             Width="{TemplateBinding Width}"
                              Height="{TemplateBinding Height}"
                              StartAngle="270"
                              Stretch="None"
@@ -45,6 +46,9 @@
                     </Grid>
                 </ControlTemplate>
             </Setter>
+            <Style Selector="^.Accent /template/ Arc#PART_ArcFill">
+                <Setter Property="Stroke" Value="{DynamicResource SukiAccentColor}" />
+            </Style>
         </Style>
     </UserControl.Styles>
 

--- a/SukiUI/Controls/CircleProgressBar.axaml.cs
+++ b/SukiUI/Controls/CircleProgressBar.axaml.cs
@@ -17,9 +17,9 @@ namespace SukiUI.Controls
             AvaloniaXamlLoader.Load(this);
         }
 
-        private int _value = 50;
+        private double _value = 50;
 
-        public int Value
+        public double Value
         {
             get => _value;
             set
@@ -31,8 +31,8 @@ namespace SukiUI.Controls
         /// <summary>
         /// Defines the <see cref="Value"/> property.
         /// </summary>
-        public static readonly DirectProperty<CircleProgressBar, int> ValueProperty =
-            AvaloniaProperty.RegisterDirect<CircleProgressBar, int>(
+        public static readonly DirectProperty<CircleProgressBar, double> ValueProperty =
+            AvaloniaProperty.RegisterDirect<CircleProgressBar, double>(
                 nameof(Value),
                 o => o.Value,
                 (o, v) => o.Value = v,

--- a/SukiUI/Controls/WaveProgress/WaveProgress.axaml.cs
+++ b/SukiUI/Controls/WaveProgress/WaveProgress.axaml.cs
@@ -28,9 +28,9 @@ public partial class WaveProgress : UserControl
         AvaloniaXamlLoader.Load(this);
     }
 
-    private int _value = 50;
+    private double _value = 50;
 
-    public int Value
+    public double Value
     {
         get => _value;
         set
@@ -42,8 +42,8 @@ public partial class WaveProgress : UserControl
         }
     }
 
-    public static readonly DirectProperty<WaveProgress, int> ValueProperty =
-        AvaloniaProperty.RegisterDirect<WaveProgress, int>(
+    public static readonly DirectProperty<WaveProgress, double> ValueProperty =
+        AvaloniaProperty.RegisterDirect<WaveProgress, double>(
             nameof(Value),
             o => o.Value,
             (o, v) => o.Value = v,

--- a/SukiUI/Controls/WaveProgress/WaveProgressValueConverter.cs
+++ b/SukiUI/Controls/WaveProgress/WaveProgressValueConverter.cs
@@ -14,7 +14,7 @@ public class WaveProgressValueConverter : IValueConverter
 
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        if (value is not int i) return 0;
+        if (value is not double i) return 0;
         return 155 - i * 2.1;
     }
 
@@ -30,8 +30,8 @@ public class WaveProgressValueColorConverter : IValueConverter
 
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        if (value is not int i) return Brushes.Black;
-        if (i > 50) return Brushes.GhostWhite;
+        if (value is not double d) return Brushes.Black;
+        if (d > 50) return Brushes.GhostWhite;
         return Application.Current?.ActualThemeVariant == ThemeVariant.Dark ? Brushes.GhostWhite : Brushes.Black;
     }
 
@@ -47,7 +47,7 @@ public class WaveProgressValueTextConverter : IValueConverter
 
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        return value is not int i ? "0%" : $"{i}%";
+        return value is not double d ? "0%" : $"{d:#0}%";
     }
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
@@ -62,7 +62,7 @@ public class WaveProgressGradientOffsetConverter : IValueConverter
 
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        if (value is not int)
+        if (value is not double v)
             return Brushes.Blue;
 
         Color PrimaryColor = Colors.DodgerBlue;
@@ -75,7 +75,6 @@ public class WaveProgressGradientOffsetConverter : IValueConverter
         }
         catch { }
 
-        double v = System.Convert.ToDouble(value);
         v /= 100;
         v += Application.Current.RequestedThemeVariant == ThemeVariant.Light ? 0.2 : 0.4;
         if (v > 1)

--- a/SukiUI/Theme/ProgressBarStyles.xaml
+++ b/SukiUI/Theme/ProgressBarStyles.xaml
@@ -16,6 +16,8 @@
             <ControlTemplate>
                 <Grid>
                     <Border Height="8"
+                            MinWidth="{TemplateBinding MinWidth}"
+                            MinHeight="{TemplateBinding MinHeight}"
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
@@ -47,7 +49,7 @@
                                             HorizontalAlignment="Center"
                                             VerticalAlignment="Center"
                                             IsVisible="{Binding ShowProgressText, RelativeSource={RelativeSource TemplatedParent}}">
-                        <TextBlock Foreground="{DynamicResource ThemeForegroundBrush}" Text="{Binding Value, RelativeSource={RelativeSource TemplatedParent}, StringFormat={}{0:0}%}" />
+                        <TextBlock Foreground="{DynamicResource SukiText}" Text="{Binding Value, RelativeSource={RelativeSource TemplatedParent}, StringFormat={}{0:0}%}" />
                     </LayoutTransformControl>
                 </Grid>
             </ControlTemplate>
@@ -63,10 +65,10 @@
     </Style>
     <Style Selector="ProgressBar:horizontal">
         <Setter Property="MinWidth" Value="200" />
-        <Setter Property="MinHeight" Value="16" />
+        <Setter Property="MinHeight" Value="20" />
     </Style>
     <Style Selector="ProgressBar:vertical">
-        <Setter Property="MinWidth" Value="16" />
+        <Setter Property="MinWidth" Value="20" />
         <Setter Property="MinHeight" Value="200" />
     </Style>
     <Style Selector="ProgressBar:vertical /template/ LayoutTransformControl#PART_LayoutTransformControl">
@@ -106,5 +108,9 @@
             </Animation>
         </Style.Animations>
         <Setter Property="Height" Value="{Binding TemplateProperties.ContainerWidth, RelativeSource={RelativeSource TemplatedParent}}" />
+    </Style>
+
+    <Style Selector="ProgressBar.Accent">
+        <Setter Property="Foreground" Value="{DynamicResource SukiAccentColor}" />
     </Style>
 </Styles>


### PR DESCRIPTION
***Changes***
- Added a page demoing the progress controls.
- Standard `Progress` bar style was not functioning properly in vertical/horizontal orientations and with text enabled/disabled, the look of the control has changed slightly but this can be adjusted now that it's working properly and it's being properly tested in the demo app.
- `WaveProgress` and `CircleProgress` use `double` internally instead of `int` now in line with the standard progress control.
- Added an accent variant of both `CircleProgress` and standard `Progress` controls.

***Fixed***
- Removed `IViewAware` references from the Demo app which are no longer used.

***Outstanding Issues***
- `WaveProgress` and `CircleProgress` could do with a rewrite internally to improve their behaviour and performance, but this won't affect the API at all so it can be done whenever.
- Inderminate offset properties of the standard `Progress` style don't seem to exist causing binding errors, despite actually existing.
- `Stepper` doesn't like strings above a certain length.