### PR TITLE
Use a simple workaround to fix text.

### DIFF
--- a/SukiUI.Demo/App.axaml
+++ b/SukiUI.Demo/App.axaml
@@ -14,6 +14,7 @@
         <sukiUi:SukiTheme ThemeColor="Red" />
         <StyleInclude Source="avares://SukiUI.Demo/Styles/ShowMeTheXamlStyles.axaml" />
         <StyleInclude Source="avares://SukiUI.Demo/Styles/WrapPanelStyles.axaml" />
+        <StyleInclude Source="avares://SukiUI.Demo/Styles/TextStyles.axaml" />
         <avalonia:MaterialIconStyles />
     </Application.Styles>
 </Application>

--- a/SukiUI.Demo/Features/ControlsLibrary/ButtonsLibraryView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/ButtonsLibraryView.axaml
@@ -21,9 +21,14 @@
     <Grid RowDefinitions="Auto,*">
         <controls:GlassCard Margin="30">
             <controls:GroupBox Header="Buttons">
-                <TextBlock TextWrapping="Wrap">
-                    SukiUI has a handful of button styles, available in both the standard primary color, but also in the theme's accent color.<LineBreak />
-                    Clicking on any one of the buttons will make them all "Busy" for 3 seconds, and how this is achieved can be seen in the XAML for the Busy Button.</TextBlock>
+                <StackPanel Classes="HeaderContent">
+                    <TextBlock>
+                        SukiUI has a handful of button styles, available in both the standard primary color, but also in the theme's accent color.
+                    </TextBlock>
+                    <TextBlock>
+                        Clicking on any one of the buttons will make them all "Busy" for 3 seconds, and how this is achieved can be seen in the XAML for the Busy Button.
+                    </TextBlock>
+                </StackPanel>
             </controls:GroupBox>
         </controls:GlassCard>
         <ScrollViewer Grid.Row="1" HorizontalScrollBarVisibility="Disabled">

--- a/SukiUI.Demo/Features/ControlsLibrary/IconsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/IconsView.axaml
@@ -15,10 +15,13 @@
     <Grid RowDefinitions="Auto, *">
         <controls:GlassCard Margin="30">
             <controls:GroupBox Header="Icons">
-                <StackPanel Spacing="10">
+                <StackPanel Classes="HeaderContent">
                     <TextBlock TextWrapping="Wrap">
-                        SukiUI contains definitions for some basic icons that are used for a variety of controls. You may wish to use these icons in your app and controls to maintain consistency with SukiUI.<LineBreak />
-                        The icons can be used in the following way:</TextBlock>
+                        SukiUI contains definitions for some basic icons that are used for a variety of controls. You may wish to use these icons in your app and controls to maintain consistency with SukiUI.
+                    </TextBlock>
+                    <TextBlock>
+                        The icons can be used in the following way:
+                    </TextBlock>
                     <StackPanel Orientation="Horizontal" Spacing="15">
                         <showMeTheXaml:XamlDisplay UniqueId="Icon1">
                             <PathIcon Data="{x:Static content:Icons.Plus}" />

--- a/SukiUI.Demo/Features/ControlsLibrary/ProgressView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/ProgressView.axaml
@@ -13,11 +13,14 @@
     <Grid RowDefinitions="Auto,*">
         <controls:GlassCard Margin="30">
             <controls:GroupBox Header="Progress Indicators">
-                <StackPanel Spacing="15">
-                    <TextBlock TextWrapping="Wrap">
-                        Here is a demo of all the available progress indicators in SukiUI, including the stepper.<LineBreak />
-                        The progress bars can be controlled with the controls below except the stepper which has it's own logic.</TextBlock>
-                    <DockPanel>
+                <StackPanel Classes="HeaderContent">
+                    <TextBlock>
+                        Here is a demo of all the available progress indicators in SukiUI, including the stepper.
+                    </TextBlock>
+                    <TextBlock>
+                        The progress bars can be controlled with the controls below except the stepper which has it's own logic.
+                    </TextBlock>
+                    <DockPanel Margin="0,10,0,0">
                         <CheckBox DockPanel.Dock="Left" IsChecked="{Binding IsTextVisible}" />
                         <TextBlock Text="Text Enabled?" />
                     </DockPanel>

--- a/SukiUI.Demo/Features/ControlsLibrary/TextView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/TextView.axaml
@@ -12,7 +12,7 @@
              x:DataType="controlsLibrary:TextViewModel"
              mc:Ignorable="d">
     <UserControl.Styles>
-        <Style Selector="showMeTheXaml|XamlDisplay > TextBox">
+        <Style Selector="showMeTheXaml|XamlDisplay &gt; TextBox">
             <Setter Property="Text" Value="{Binding TextBoxValue}" />
         </Style>
         <Style Selector="TextBlock">
@@ -25,9 +25,14 @@
             <controls:GlassCard>
                 <controls:GroupBox Header="Text Styles">
                     <StackPanel Spacing="15">
-                        <TextBlock>
-                            SukiUI defines some basic text classes that you can use in your application.<LineBreak />
-                            The h and color styles can be combined.</TextBlock>
+                        <StackPanel Classes="HeaderContent">
+                            <TextBlock>
+                                SukiUI defines some basic text classes that you can use in your application.
+                            </TextBlock>
+                            <TextBlock>
+                                The h and color styles can be combined.
+                            </TextBlock>
+                        </StackPanel>
                         <showMeTheXaml:XamlDisplay UniqueId="TextHyperlink">
                             <TextBlock>
                                 Text With A<InlineUIContainer>
@@ -68,7 +73,7 @@
             </controls:GlassCard>
             <controls:GlassCard>
                 <controls:GroupBox Header="Text Input">
-                    <StackPanel Spacing="15">
+                    <StackPanel Classes="HeaderContent">
                         <TextBlock>
                             There are a few helpers available to make textboxes simpler and more powerful to use.
                         </TextBlock>

--- a/SukiUI.Demo/Features/Splash/SplashView.axaml
+++ b/SukiUI.Demo/Features/Splash/SplashView.axaml
@@ -14,12 +14,12 @@
                         HorizontalAlignment="Center"
                         VerticalAlignment="Center">
         <controls:GroupBox Header="Welcome to the SukiUI Demo App.">
-            <StackPanel Spacing="15">
+            <StackPanel Classes="HeaderContent">
                 <PathIcon Width="75"
                           Height="75"
                           HorizontalAlignment="Center"
                           Data="{x:Static content:Icons.SukiLogo}" />
-                <TextBlock FontSize="16" TextWrapping="Wrap">
+                <TextBlock Name="TextBlockWithInline">
                     In this app you'll find a sample page
                     (<InlineUIContainer>
                         <Button Classes="Hyperlink"
@@ -28,11 +28,13 @@
                                 FontSize="16" />
                     </InlineUIContainer>
                     )
-                    with a variety of controls used together, as well as a control library for testing and demonstration purposes.<LineBreak />
-                    <LineBreak />
-                    You'll also find in the menu above toggles and other options to control the theme of the app.<LineBreak />
-                    <LineBreak />
-                    If you see a control on one of the demo pages and would like to see how to use it in your own app, simply press the small tag icon to the bottom right of the control.</TextBlock>
+                    with a variety of controls used together, as well as a control library for testing and demonstration purposes.</TextBlock>
+                <TextBlock>
+                    You'll also find in the menu above toggles and other options to control the theme of the app.
+                </TextBlock>
+                <TextBlock>
+                    If you see a control on one of the demo pages and would like to see how to use it in your own app, simply press the small tag icon to the bottom right of the control.
+                </TextBlock>
             </StackPanel>
         </controls:GroupBox>
     </controls:GlassCard>

--- a/SukiUI.Demo/Features/Splash/SplashView.axaml.cs
+++ b/SukiUI.Demo/Features/Splash/SplashView.axaml.cs
@@ -11,8 +11,7 @@ public partial class SplashView : UserControl
         {
             Dispatcher.UIThread.Post(() =>
             {
-                TextBlockWithInline.IsVisible = false;
-                TextBlockWithInline.IsVisible = true;
+                TextBlockWithInline.InvalidateVisual();
             });
         };
         InitializeComponent();

--- a/SukiUI.Demo/Features/Splash/SplashView.axaml.cs
+++ b/SukiUI.Demo/Features/Splash/SplashView.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Threading;
 
 namespace SukiUI.Demo.Features.Splash;
 
@@ -6,6 +7,14 @@ public partial class SplashView : UserControl
 {
     public SplashView()
     {
+        SukiTheme.GetInstance().OnBaseThemeChanged += _ =>
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                TextBlockWithInline.IsVisible = false;
+                TextBlockWithInline.IsVisible = true;
+            });
+        };
         InitializeComponent();
     }
 }

--- a/SukiUI.Demo/Styles/TextStyles.axaml
+++ b/SukiUI.Demo/Styles/TextStyles.axaml
@@ -1,0 +1,9 @@
+<Styles xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Style Selector="StackPanel.HeaderContent">
+        <Setter Property="Spacing" Value="5" />
+        <Style Selector="^ &gt; TextBlock">
+            <Setter Property="TextWrapping" Value="Wrap" />
+            <Setter Property="FontSize" Value="16" />
+        </Style>
+    </Style>
+</Styles>

--- a/SukiUI/Theme/MenuItemStyle.axaml
+++ b/SukiUI/Theme/MenuItemStyle.axaml
@@ -130,6 +130,7 @@
 
     <Style Selector="Menu &gt; MenuItem">
         <Setter Property="Padding" Value="10 0" />
+        <Setter Property="FontWeight" Value="DemiBold" />
         <Setter Property="Template">
             <ControlTemplate>
                 <Border Name="root"
@@ -150,8 +151,8 @@
                                             <Setter Property="Width" Value="0" />
                                         </KeyFrame>
                                         <KeyFrame Cue="100%">
-                                            <!-- TODO: This causes any long menu items to be cut off -->
-                                            <!-- This technically fixes it but prevents the animation from working, not sure... -->
+                                            <!--  TODO: This causes any long menu items to be cut off  -->
+                                            <!--  This technically fixes it but prevents the animation from working, not sure...  -->
                                             <!-- <Setter Property="Width" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ActualWidth}" /> -->
                                             <Setter Property="Width" Value="150" />
                                         </KeyFrame>

--- a/SukiUI/Theme/MenuItemStyle.axaml
+++ b/SukiUI/Theme/MenuItemStyle.axaml
@@ -150,7 +150,9 @@
                                             <Setter Property="Width" Value="0" />
                                         </KeyFrame>
                                         <KeyFrame Cue="100%">
-
+                                            <!-- TODO: This causes any long menu items to be cut off -->
+                                            <!-- This technically fixes it but prevents the animation from working, not sure... -->
+                                            <!-- <Setter Property="Width" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ActualWidth}" /> -->
                                             <Setter Property="Width" Value="150" />
                                         </KeyFrame>
                                     </Animation>

--- a/SukiUI/Theme/ProgressBarStyles.xaml
+++ b/SukiUI/Theme/ProgressBarStyles.xaml
@@ -12,18 +12,23 @@
         <Setter Property="CornerRadius" Value="{DynamicResource SmallCornerRadius}" />
         <Setter Property="Background" Value="{DynamicResource SukiBorderBrush}" />
         <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
-        
+
         <Setter Property="Template">
             <ControlTemplate>
                 <DockPanel>
-                 
-                        <TextBlock HorizontalAlignment="Center"
-                                   VerticalAlignment="Center"
-                                   IsVisible="{Binding ShowProgressText, RelativeSource={RelativeSource TemplatedParent}}" Margin="10,0,0,0" DockPanel.Dock="Right" FontWeight="DemiBold" Foreground="{DynamicResource SukiText}" Text="{Binding Value, RelativeSource={RelativeSource TemplatedParent}, StringFormat={}{0:0}%}" />
-                 
+
+                    <TextBlock Width="35"
+                               Margin="10,0,0,0"
+                               HorizontalAlignment="Center"
+                               VerticalAlignment="Center"
+                               DockPanel.Dock="Right"
+                               FontWeight="DemiBold"
+                               Foreground="{DynamicResource SukiText}"
+                               IsVisible="{Binding ShowProgressText, RelativeSource={RelativeSource TemplatedParent}}"
+                               Text="{Binding Value, RelativeSource={RelativeSource TemplatedParent}, StringFormat={}{0:0}%}" />
+
                     <Border Name="PART_RootBorder"
                             MinWidth="{TemplateBinding MinWidth}"
-                      
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
@@ -51,8 +56,8 @@
                                     IsVisible="{Binding IsIndeterminate, RelativeSource={RelativeSource TemplatedParent}}" />
                         </Panel>
                     </Border>
-                    
-                
+
+
                 </DockPanel>
             </ControlTemplate>
         </Setter>
@@ -67,25 +72,25 @@
     </Style>
     <Style Selector="ProgressBar:horizontal">
         <Setter Property="MinWidth" Value="200" />
-     
+
     </Style>
     <Style Selector="ProgressBar:vertical">
-        
+
         <Setter Property="MinHeight" Value="200" />
     </Style>
-    
+
     <Style Selector="ProgressBar:horizontal /template/ Border#PART_RootBorder">
-        <Setter Property="MinHeight" Value="8"></Setter>
-        <Setter Property="Height" Value="8"></Setter>
-        <Setter Property="MaxHeight" Value="8"></Setter>
+        <Setter Property="MinHeight" Value="8" />
+        <Setter Property="Height" Value="8" />
+        <Setter Property="MaxHeight" Value="8" />
     </Style>
-    
+
     <Style Selector="ProgressBar:vertical /template/ Border#PART_RootBorder">
-        <Setter Property="MinWidth" Value="8"></Setter>
-        <Setter Property="Width" Value="8"></Setter>
-        <Setter Property="MaxWidth" Value="8"></Setter>
+        <Setter Property="MinWidth" Value="8" />
+        <Setter Property="Width" Value="8" />
+        <Setter Property="MaxWidth" Value="8" />
     </Style>
-    
+
     <Style Selector="ProgressBar:vertical /template/ LayoutTransformControl#PART_LayoutTransformControl">
         <Setter Property="LayoutTransform">
             <Setter.Value>


### PR DESCRIPTION
***Fixes***
- Fix text not responding properly to base theme changes in the demo app.
  - Fix is relatively sane, except for the one place where I needed an in-line control which had to be done the dirty way.
- Make `Progress` text fixed size to prevent UI bumping.
- Inconsistent font weights in menu now fixed.

***Oustanding Issues***
- `MenuItem` style still has a fixed width which isn't ideal, this is due to the animation setter explicitly setting the width, I've put a `TODO` in the file, but animations aren't really my area of expertise.
- Enabling/Disabling text causes the `Progress` container to resize instead of resizing the progress bar itself, I would suggest placing the text on the top in the `Vertical` style and placing the progress bar and text into the same container, preventing changes to the UI surrounding the control would be nice.
- Horizontal progress bar values aren't rendered correctly when a page is first drawn, takes a few ticks to actually update, however the vertical bar is entirely fine.
- Toast stack doesn't animate down when an item is removed.