### PR TITLE
Fix some memory leaks with not disposing of observable subscriptions.

### DIFF
--- a/SukiUI/Controls/Stepper.axaml.cs
+++ b/SukiUI/Controls/Stepper.axaml.cs
@@ -11,7 +11,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
+using System.Reactive;
 using System.Reactive.Linq;
+using Avalonia.Interactivity;
 
 namespace SukiUI.Controls
 {
@@ -36,6 +38,7 @@ namespace SukiUI.Controls
         }
 
         private Grid? _grid;
+        private IDisposable? _subscriptionDisposables;
 
         private static readonly IBrush DisabledColor = new SolidColorBrush(Color.FromArgb(100, 150, 150, 150));
 
@@ -44,12 +47,13 @@ namespace SukiUI.Controls
             base.OnApplyTemplate(e);
             if (e.NameScope.Get<Grid>("PART_GridStepper") is not { } grid) return;
             _grid = grid;
-            this.GetObservable(IndexProperty)
+            var indexObs = this.GetObservable(IndexProperty)
+                .Select(_ => Unit.Default);
+            _subscriptionDisposables = this.GetObservable(StepsProperty)
+                .Select(_ => Unit.Default)
+                .Merge(indexObs)
                 .ObserveOn(new AvaloniaSynchronizationContext())
                 .Subscribe(_ => StepsChangedHandler(Steps));
-            this.GetObservable(StepsProperty)
-                .ObserveOn(new AvaloniaSynchronizationContext())
-                .Subscribe(StepsChangedHandler);
         }
 
         private void StepsChangedHandler(IEnumerable? newSteps)
@@ -90,7 +94,7 @@ namespace SukiUI.Controls
             };
 
             var icon = new PathIcon()
-            { Height = 10, Width = 10, Data = Icons.ChevronRight, Margin = new Thickness(0, 0, 20, 0) };
+                { Height = 10, Width = 10, Data = Icons.ChevronRight, Margin = new Thickness(0, 0, 20, 0) };
             if (index == stepCount - 1)
                 icon.IsVisible = false;
 
@@ -157,6 +161,12 @@ namespace SukiUI.Controls
             Grid.SetColumn(griditem, index);
 
             grid.Children.Add(griditem);
+        }
+
+        protected override void OnUnloaded(RoutedEventArgs e)
+        {
+            base.OnUnloaded(e);
+            _subscriptionDisposables?.Dispose();
         }
     }
 }

--- a/SukiUI/Controls/SukiTransitioningContentControl.axaml.cs
+++ b/SukiUI/Controls/SukiTransitioningContentControl.axaml.cs
@@ -116,8 +116,6 @@ namespace SukiUI.Controls
             FadeIn.Duration = FadeOut.Duration = TimeSpan.FromMilliseconds(250);
         }
 
-        private readonly Task[] _animTasks = new Task[2];
-
         private CancellationTokenSource _animCancellationToken = new();
 
         protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
@@ -145,8 +143,8 @@ namespace SukiUI.Controls
             else FirstBuffer = content;
             try
             {
-                _animTasks[0] = FadeOut.RunAsync(From, _animCancellationToken.Token);
-                _animTasks[1] = FadeIn.RunAsync(To, _animCancellationToken.Token);
+                FadeOut.RunAsync(From, _animCancellationToken.Token);
+                FadeIn.RunAsync(To, _animCancellationToken.Token);
             }
             catch
             {

--- a/SukiUI/Controls/SukiWindow.axaml.cs
+++ b/SukiUI/Controls/SukiWindow.axaml.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
 using System.Runtime.InteropServices;
+using Avalonia.Interactivity;
 
 namespace SukiUI.Controls;
 
@@ -102,6 +103,8 @@ public class SukiWindow : Window
         set => SetValue(BackgroundAnimationEnabledProperty, value);
     }
 
+    private IDisposable? _subscribtionDisposables;
+
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
     {
         base.OnApplyTemplate(e);
@@ -137,7 +140,7 @@ public class SukiWindow : Window
         if (e.NameScope.Find<SukiBackground>("PART_Background") is { } background)
         {
             background.SetAnimationEnabled(BackgroundAnimationEnabled);
-            this.GetObservable(BackgroundAnimationEnabledProperty)
+            _subscribtionDisposables = this.GetObservable(BackgroundAnimationEnabledProperty)
                 .Do(enabled => background.SetAnimationEnabled(enabled))
                 .ObserveOn(new AvaloniaSynchronizationContext())
                 .Subscribe();
@@ -155,5 +158,11 @@ public class SukiWindow : Window
         }
         else
             BeginMoveDrag(e);
+    }
+
+    protected override void OnUnloaded(RoutedEventArgs e)
+    {
+        base.OnUnloaded(e);
+        _subscribtionDisposables?.Dispose();
     }
 }


### PR DESCRIPTION
***Fixes***
- Cleans up disposables where I could find them, preventing memory leaks.
- Wrote the `SukiTransitioningContentControl` behaviour a bit more sanely now that I know it works.
  - Better performance overall.
  - Included task cancellation so now you can spam page changes as fast as you like and it won't fall over. 