### PR TITLE
Toggles Page and some tidying up.

### DIFF
--- a/SukiTest/DashboardPage.axaml
+++ b/SukiTest/DashboardPage.axaml
@@ -393,21 +393,17 @@
                                    VerticalAlignment="Center">
                             <RadioButton Width="210"
                                          Height="138"
-                                         Margin="8"
                                          Classes="GigaChips"
                                          IsChecked="True">
-                                <StackPanel Margin="7" HorizontalAlignment="Left">
-                                    <TextBlock Margin="5,8,5,4"
-                                               FontSize="12"
+                                <StackPanel HorizontalAlignment="Left">
+                                    <TextBlock FontSize="12"
                                                FontWeight="DemiBold"
                                                Foreground="{DynamicResource SukiLowText}"
                                                Text="HOBBY" />
-                                    <TextBlock Margin="5,8"
-                                               FontSize="23"
+                                    <TextBlock FontSize="23"
                                                FontWeight="DemiBold"
                                                Text="1 Gb" />
-                                    <TextBlock Margin="5,3"
-                                               FontSize="15"
+                                    <TextBlock FontSize="15"
                                                Foreground="{DynamicResource SukiLowText}"
                                                Text="Plan for a moderate use as hobby."
                                                TextWrapping="Wrap" />
@@ -415,20 +411,16 @@
                             </RadioButton>
                             <RadioButton Width="210"
                                          Height="138"
-                                         Margin="8"
                                          Classes="GigaChips">
-                                <StackPanel Margin="7" HorizontalAlignment="Left">
-                                    <TextBlock Margin="5,8,5,4"
-                                               FontSize="12"
+                                <StackPanel HorizontalAlignment="Left">
+                                    <TextBlock FontSize="12"
                                                FontWeight="DemiBold"
                                                Foreground="{DynamicResource SukiLowText}"
                                                Text="PROFESSIONAL" />
-                                    <TextBlock Margin="5,8"
-                                               FontSize="23"
+                                    <TextBlock FontSize="23"
                                                FontWeight="DemiBold"
                                                Text="5 Gb" />
-                                    <TextBlock Margin="5,3"
-                                               FontSize="15"
+                                    <TextBlock FontSize="15"
                                                Foreground="{DynamicResource SukiLowText}"
                                                Text="Plan for a professional use in an application."
                                                TextWrapping="Wrap" />
@@ -436,20 +428,16 @@
                             </RadioButton>
                             <RadioButton Width="210"
                                          Height="138"
-                                         Margin="8"
                                          Classes="GigaChips">
-                                <StackPanel Margin="7" HorizontalAlignment="Left">
-                                    <TextBlock Margin="5,8,5,4"
-                                               FontSize="12"
+                                <StackPanel HorizontalAlignment="Left">
+                                    <TextBlock FontSize="12"
                                                FontWeight="DemiBold"
                                                Foreground="{DynamicResource SukiLowText}"
                                                Text="COMPANY" />
-                                    <TextBlock Margin="5,8"
-                                               FontSize="23"
+                                    <TextBlock FontSize="23"
                                                FontWeight="DemiBold"
                                                Text="50 Gb" />
-                                    <TextBlock Margin="5,3"
-                                               FontSize="15"
+                                    <TextBlock FontSize="15"
                                                Foreground="{DynamicResource SukiLowText}"
                                                Text="Plan for a industrial use in a company."
                                                TextWrapping="Wrap" />

--- a/SukiTest/DashboardPage.axaml
+++ b/SukiTest/DashboardPage.axaml
@@ -14,7 +14,7 @@
         <Grid Margin="15">
             <WrapPanel Orientation="Horizontal">
                 <Grid Margin="15">
-                    <suki:GlassCard  Width="300" Margin="0,0,0,25">
+                    <suki:GlassCard Width="300" Margin="0,0,0,25">
                         <suki:BusyArea Name="BusySignIn" BusyText="Signing In...">
                             <StackPanel>
                                 <material:MaterialIcon Width="30"
@@ -72,17 +72,19 @@
                                            Foreground="{DynamicResource SukiLowText}"
                                            Text="Presentation.pdf" />
                             </StackPanel>
-                            <suki:CircleProgressBar Width="37" Name="CP"
+                            <suki:CircleProgressBar Name="CP"
+                                                    Width="37"
                                                     Height="37"
                                                     Margin="-55,-65,-10,-65"
                                                     HorizontalAlignment="Right"
                                                     VerticalAlignment="Center"
                                                     StrokeWidth="4"
                                                     Value="67">
-                                <TextBlock Margin="1,1,0,0"
+                                <TextBlock Name="TP"
+                                           Margin="1,1,0,0"
                                            HorizontalAlignment="Center"
                                            VerticalAlignment="Center"
-                                           FontSize="13" Name="TP"
+                                           FontSize="13"
                                            FontWeight="DemiBold"
                                            Text="67" />
                             </suki:CircleProgressBar>
@@ -112,7 +114,9 @@
                                                            Kind="ArrowUp" />
                                 </StackPanel>
                             </Grid>
-                            <ProgressBar Name="P1" Margin="0,1,0,0" Value="16" />
+                            <ProgressBar Name="P1"
+                                         Margin="0,1,0,0"
+                                         Value="16" />
                             <Grid Margin="0,13,0,0">
                                 <TextBlock HorizontalAlignment="Left"
                                            FontSize="12"
@@ -128,7 +132,9 @@
                                                            Kind="ArrowDown" />
                                 </StackPanel>
                             </Grid>
-                            <ProgressBar Name="P2" Margin="0,1,0,0" Value="62" />
+                            <ProgressBar Name="P2"
+                                         Margin="0,1,0,0"
+                                         Value="62" />
 
                             <Grid Margin="0,13,0,0">
                                 <TextBlock HorizontalAlignment="Left"
@@ -145,7 +151,9 @@
                                                            Kind="ArrowUp" />
                                 </StackPanel>
                             </Grid>
-                            <ProgressBar Name="P3" Margin="0,1,0,0" Value="34" />
+                            <ProgressBar Name="P3"
+                                         Margin="0,1,0,0"
+                                         Value="34" />
 
                         </StackPanel>
                     </suki:GlassCard>

--- a/SukiTest/MainWindow.axaml
+++ b/SukiTest/MainWindow.axaml
@@ -1,5 +1,4 @@
-<suki:SukiWindow Title="Suki UI Testing - New Project"
-                 x:Class="SukiTest.MainWindow"
+<suki:SukiWindow x:Class="SukiTest.MainWindow"
                  xmlns="https://github.com/avaloniaui"
                  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                  xmlns:circleProgressBarsTestMvvm="clr-namespace:SukiTest.CircleProgressBarsTestMVVM"
@@ -8,7 +7,7 @@
                  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                  xmlns:suki="clr-namespace:SukiUI.Controls;assembly=SukiUI"
                  xmlns:sukiTest="clr-namespace:SukiTest"
-                 
+                 Title="Suki UI Testing - New Project"
                  d:DesignHeight="1050"
                  d:DesignWidth="1050"
                  suki:SukiHost.ToastLimit="4"
@@ -22,7 +21,7 @@
                                Foreground="{DynamicResource SukiPrimaryColor}"
                                Kind="MicrosoftXaml" />
     </suki:SukiWindow.LogoContent>
-   <suki:SukiSideMenu Name="SideMenu" HeaderContentOverlapsToggleButton="True">
+    <suki:SukiSideMenu Name="SideMenu" HeaderContentOverlapsToggleButton="True">
         <suki:SukiSideMenu.HeaderContent>
             <StackPanel Margin="0,4,0,0">
                 <StackPanel HorizontalAlignment="Left" Orientation="Horizontal">
@@ -36,8 +35,9 @@
                             ToolTip.Tip="Change Color">
                         <material:MaterialIcon Kind="Palette" />
                     </Button>
-                    <Button Classes="Basic" IsVisible="False"
+                    <Button Classes="Basic"
                             Click="ChangeAnimationState"
+                            IsVisible="False"
                             ToolTip.Tip="Toggle Background Animation">
                         <material:MaterialIcon Kind="Animation" />
                     </Button>
@@ -113,7 +113,18 @@
                     <sukiTest:StackExemplePage />
                 </suki:SukiSideMenuItem.PageContent>
             </suki:SukiSideMenuItem>
+            <suki:SukiSideMenuItem Header="Testing">
+                <suki:SukiSideMenuItem.Icon>
+                    <material:MaterialIcon Width="24"
+                                           Height="24"
+                                           Foreground="{DynamicResource SukiText}"
+                                           Kind="TestTube" />
+                </suki:SukiSideMenuItem.Icon>
+                <suki:SukiSideMenuItem.PageContent>
+                    <TextBlock Text="A completely pointless testing page to make sure the tests are exhaustive." />
+                </suki:SukiSideMenuItem.PageContent>
+            </suki:SukiSideMenuItem>
         </suki:SukiSideMenu.Items>
-       
+
     </suki:SukiSideMenu>
 </suki:SukiWindow>

--- a/SukiUI.Demo/Features/ControlsLibrary/TogglesView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/TogglesView.axaml
@@ -24,9 +24,9 @@
                 </controls:GroupBox>
             </controls:GlassCard>
             <controls:GlassCard>
-                <controls:GroupBox Header="Radio Buttons">
-                    <showMeTheXaml:XamlDisplay UniqueId="GigaChips">
-                        <StackPanel Spacing="10">
+                <controls:GroupBox Header="Simple GigaChips">
+                    <showMeTheXaml:XamlDisplay UniqueId="SimpleGigaChips">
+                        <StackPanel>
                             <RadioButton Classes="GigaChips"
                                          Content="Option One"
                                          GroupName="R2" />
@@ -38,6 +38,53 @@
                                          GroupName="R2" />
                         </StackPanel>
                     </showMeTheXaml:XamlDisplay>
+                </controls:GroupBox>
+            </controls:GlassCard>
+            <controls:GlassCard>
+                <controls:GroupBox Header="Complex GigaChips">
+                    <showMeTheXaml:XamlDisplay UniqueId="ComplexGigaChips">
+                        <StackPanel Orientation="Horizontal">
+                            <RadioButton Classes="GigaChips" GroupName="R3">
+                                <StackPanel>
+                                    <TextBlock Classes="h4"
+                                               FontWeight="Bold"
+                                               Foreground="{DynamicResource SukiAccentColor}"
+                                               Text="One Header" />
+                                    <TextBlock Text="Some content." />
+                                </StackPanel>
+                            </RadioButton>
+                            <RadioButton Classes="GigaChips" GroupName="R3">
+                                <StackPanel>
+                                    <TextBlock Classes="h4"
+                                               FontWeight="Bold"
+                                               Foreground="{DynamicResource SukiAccentColor}"
+                                               Text="Another Header" />
+                                    <TextBlock Text="Some other content." />
+                                </StackPanel>
+                            </RadioButton>
+                            <RadioButton Classes="GigaChips" GroupName="R3">
+                                <StackPanel>
+                                    <TextBlock Classes="h4"
+                                               FontWeight="Bold"
+                                               Foreground="{DynamicResource SukiAccentColor}"
+                                               Text="Final Header" />
+                                    <TextBlock Text="Some final content." />
+                                </StackPanel>
+                            </RadioButton>
+                        </StackPanel>
+                    </showMeTheXaml:XamlDisplay>
+                </controls:GroupBox>
+            </controls:GlassCard>
+            <controls:GlassCard>
+                <controls:GroupBox Header="Simple Toggle Switch">
+                    <StackPanel>
+                        <showMeTheXaml:XamlDisplay UniqueId="ToggleSwitch">
+                            <ToggleSwitch />
+                        </showMeTheXaml:XamlDisplay>
+                        <showMeTheXaml:XamlDisplay UniqueId="CustomContentToggleSwitch">
+                            <ToggleSwitch OffContent="Switch Off." OnContent="Switch On." />
+                        </showMeTheXaml:XamlDisplay>
+                    </StackPanel>
                 </controls:GroupBox>
             </controls:GlassCard>
         </WrapPanel>

--- a/SukiUI.Demo/Features/ControlsLibrary/TogglesView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/TogglesView.axaml
@@ -76,13 +76,38 @@
                 </controls:GroupBox>
             </controls:GlassCard>
             <controls:GlassCard>
-                <controls:GroupBox Header="Simple Toggle Switch">
+                <controls:GroupBox Header="Toggle Switches">
                     <StackPanel>
                         <showMeTheXaml:XamlDisplay UniqueId="ToggleSwitch">
                             <ToggleSwitch />
                         </showMeTheXaml:XamlDisplay>
                         <showMeTheXaml:XamlDisplay UniqueId="CustomContentToggleSwitch">
                             <ToggleSwitch OffContent="Switch Off." OnContent="Switch On." />
+                        </showMeTheXaml:XamlDisplay>
+                    </StackPanel>
+                </controls:GroupBox>
+            </controls:GlassCard>
+            <controls:GlassCard>
+                <controls:GroupBox Header="Toggle Buttons">
+                    <StackPanel>
+                        <showMeTheXaml:XamlDisplay UniqueId="ToggleButton">
+                            <ToggleButton Content="Toggle Me" />
+                        </showMeTheXaml:XamlDisplay>
+                        <showMeTheXaml:XamlDisplay UniqueId="ToggleButtonSwitch">
+                            <ToggleButton Classes="Switch" Content="Toggle Me" />
+                        </showMeTheXaml:XamlDisplay>
+                    </StackPanel>
+                </controls:GroupBox>
+            </controls:GlassCard>
+            <controls:GlassCard>
+                <controls:GroupBox Header="CheckBoxes">
+                    <StackPanel>
+                        <showMeTheXaml:XamlDisplay UniqueId="CheckBox">
+                            <StackPanel Spacing="5">
+                                <CheckBox Content="Option One" />
+                                <CheckBox Content="Option Two" />
+                                <CheckBox Content="Option Three" />
+                            </StackPanel>
                         </showMeTheXaml:XamlDisplay>
                     </StackPanel>
                 </controls:GroupBox>

--- a/SukiUI.Demo/Features/ControlsLibrary/TogglesView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/TogglesView.axaml
@@ -1,12 +1,45 @@
 <UserControl x:Class="SukiUI.Demo.Features.ControlsLibrary.TogglesView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
              xmlns:controlsLibrary="clr-namespace:SukiUI.Demo.Features.ControlsLibrary"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:showMeTheXaml="clr-namespace:ShowMeTheXaml;assembly=ShowMeTheXaml.Avalonia"
              d:DesignHeight="450"
              d:DesignWidth="800"
              x:DataType="controlsLibrary:TogglesViewModel"
              mc:Ignorable="d">
-    Toggles view!
+    <ScrollViewer>
+        <WrapPanel Classes="PageContainer">
+            <controls:GlassCard>
+                <controls:GroupBox Header="Radio Buttons">
+                    <showMeTheXaml:XamlDisplay UniqueId="RadioButtons">
+                        <StackPanel VerticalAlignment="Center" Spacing="10">
+                            <RadioButton Content="Option One" GroupName="R1" />
+                            <RadioButton Content="Option Two" GroupName="R1" />
+                            <RadioButton Content="Option Three" GroupName="R1" />
+                        </StackPanel>
+                    </showMeTheXaml:XamlDisplay>
+                </controls:GroupBox>
+            </controls:GlassCard>
+            <controls:GlassCard>
+                <controls:GroupBox Header="Radio Buttons">
+                    <showMeTheXaml:XamlDisplay UniqueId="GigaChips">
+                        <StackPanel Spacing="10">
+                            <RadioButton Classes="GigaChips"
+                                         Content="Option One"
+                                         GroupName="R2" />
+                            <RadioButton Classes="GigaChips"
+                                         Content="Option Two"
+                                         GroupName="R2" />
+                            <RadioButton Classes="GigaChips"
+                                         Content="Option Three"
+                                         GroupName="R2" />
+                        </StackPanel>
+                    </showMeTheXaml:XamlDisplay>
+                </controls:GroupBox>
+            </controls:GlassCard>
+        </WrapPanel>
+    </ScrollViewer>
 </UserControl>

--- a/SukiUI.Demo/Features/Dashboard/DashboardView.axaml
+++ b/SukiUI.Demo/Features/Dashboard/DashboardView.axaml
@@ -377,21 +377,17 @@
                                    VerticalAlignment="Center">
                             <RadioButton Width="210"
                                          Height="138"
-                                         Margin="8"
                                          Classes="GigaChips"
                                          IsChecked="True">
-                                <StackPanel Margin="7" HorizontalAlignment="Left">
-                                    <TextBlock Margin="5,8,5,4"
-                                               FontSize="12"
+                                <StackPanel HorizontalAlignment="Left">
+                                    <TextBlock FontSize="12"
                                                FontWeight="DemiBold"
                                                Foreground="{DynamicResource SukiLowText}"
                                                Text="HOBBY" />
-                                    <TextBlock Margin="5,8"
-                                               FontSize="23"
+                                    <TextBlock FontSize="23"
                                                FontWeight="DemiBold"
                                                Text="1 Gb" />
-                                    <TextBlock Margin="5,3"
-                                               FontSize="15"
+                                    <TextBlock FontSize="15"
                                                Foreground="{DynamicResource SukiLowText}"
                                                Text="Plan for a moderate use as hobby."
                                                TextWrapping="Wrap" />
@@ -399,20 +395,16 @@
                             </RadioButton>
                             <RadioButton Width="210"
                                          Height="138"
-                                         Margin="8"
                                          Classes="GigaChips">
-                                <StackPanel Margin="7" HorizontalAlignment="Left">
-                                    <TextBlock Margin="5,8,5,4"
-                                               FontSize="12"
+                                <StackPanel HorizontalAlignment="Left">
+                                    <TextBlock FontSize="12"
                                                FontWeight="DemiBold"
                                                Foreground="{DynamicResource SukiLowText}"
                                                Text="PROFESSIONAL" />
-                                    <TextBlock Margin="5,8"
-                                               FontSize="23"
+                                    <TextBlock FontSize="23"
                                                FontWeight="DemiBold"
                                                Text="5 Gb" />
-                                    <TextBlock Margin="5,3"
-                                               FontSize="15"
+                                    <TextBlock FontSize="15"
                                                Foreground="{DynamicResource SukiLowText}"
                                                Text="Plan for a professional use in an application."
                                                TextWrapping="Wrap" />
@@ -420,20 +412,16 @@
                             </RadioButton>
                             <RadioButton Width="210"
                                          Height="138"
-                                         Margin="8"
                                          Classes="GigaChips">
-                                <StackPanel Margin="7" HorizontalAlignment="Left">
-                                    <TextBlock Margin="5,8,5,4"
-                                               FontSize="12"
+                                <StackPanel HorizontalAlignment="Left">
+                                    <TextBlock FontSize="12"
                                                FontWeight="DemiBold"
                                                Foreground="{DynamicResource SukiLowText}"
                                                Text="COMPANY" />
-                                    <TextBlock Margin="5,8"
-                                               FontSize="23"
+                                    <TextBlock FontSize="23"
                                                FontWeight="DemiBold"
                                                Text="50 Gb" />
-                                    <TextBlock Margin="5,3"
-                                               FontSize="15"
+                                    <TextBlock FontSize="15"
                                                Foreground="{DynamicResource SukiLowText}"
                                                Text="Plan for a industrial use in a company."
                                                TextWrapping="Wrap" />

--- a/SukiUI/Controls/SukiSideMenu.axaml.cs
+++ b/SukiUI/Controls/SukiSideMenu.axaml.cs
@@ -103,7 +103,7 @@ public class SukiSideMenu : SelectingItemsControl
                 {
                     contentControl.Content = obj switch
                     {
-                        SukiSideMenuItem { PageContent: Control sukiMenuPageContent } =>  Activator.CreateInstance(sukiMenuPageContent.GetType()),
+                        SukiSideMenuItem { PageContent: { } sukiMenuPageContent } => sukiMenuPageContent,
                         _ => obj
                     };
                 })

--- a/SukiUI/Controls/SukiTransitioningContentControl.axaml
+++ b/SukiUI/Controls/SukiTransitioningContentControl.axaml
@@ -5,12 +5,12 @@
         <Setter Property="Template">
             <ControlTemplate>
                 <Grid>
-                    <ContentControl Name="PART_FirstBufferControl"
-                                    Content="{TemplateBinding FirstBuffer}"
-                                    IsHitTestVisible="False" />
-                    <ContentControl Name="PART_SecondBufferControl"
-                                    Content="{TemplateBinding SecondBuffer}"
-                                    IsHitTestVisible="False" />
+                    <ContentPresenter Name="PART_FirstBufferControl"
+                                      Content="{TemplateBinding FirstBuffer}"
+                                      IsHitTestVisible="False" />
+                    <ContentPresenter Name="PART_SecondBufferControl"
+                                      Content="{TemplateBinding SecondBuffer}"
+                                      IsHitTestVisible="False" />
                 </Grid>
             </ControlTemplate>
         </Setter>

--- a/SukiUI/Controls/SukiTransitioningContentControl.axaml.cs
+++ b/SukiUI/Controls/SukiTransitioningContentControl.axaml.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Animation;
 using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -38,16 +39,16 @@ namespace SukiUI.Controls
 
         private bool _isFirstBufferActive;
 
-        private ContentControl _firstBuffer = null!;
-        private ContentControl _secondBuffer = null!;
+        private ContentPresenter _firstBuffer = null!;
+        private ContentPresenter _secondBuffer = null!;
 
         private IDisposable? _disposable;
 
         private static readonly Animation FadeIn;
         private static readonly Animation FadeOut;
         
-        private ContentControl To => _isFirstBufferActive ? _secondBuffer : _firstBuffer;
-        private ContentControl From => _isFirstBufferActive ? _firstBuffer : _secondBuffer;
+        private ContentPresenter To => _isFirstBufferActive ? _secondBuffer : _firstBuffer;
+        private ContentPresenter From => _isFirstBufferActive ? _firstBuffer : _secondBuffer;
 
         static SukiTransitioningContentControl()
         {
@@ -121,9 +122,9 @@ namespace SukiUI.Controls
         protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
         {
             base.OnApplyTemplate(e);
-            if (e.NameScope.Get<ContentControl>("PART_FirstBufferControl") is { } fBuff)
+            if (e.NameScope.Get<ContentPresenter>("PART_FirstBufferControl") is { } fBuff)
                 _firstBuffer = fBuff;
-            if (e.NameScope.Get<ContentControl>("PART_SecondBufferControl") is { } sBuff)
+            if (e.NameScope.Get<ContentPresenter>("PART_SecondBufferControl") is { } sBuff)
                 _secondBuffer = sBuff;
 
             _disposable = this.GetObservable(ContentProperty)

--- a/SukiUI/Controls/SukiTransitioningContentControl.axaml.cs
+++ b/SukiUI/Controls/SukiTransitioningContentControl.axaml.cs
@@ -17,7 +17,7 @@ namespace SukiUI.Controls
     // TODO: This needs fairly significant work to make a bit more bomb proof
     // There are probably some more gains that can be made in terms of performance.
     // Unfortunately we're still bound by the arrange of controls having to happen on the main thread.
-    public class SukiTransitioningContentControl : ContentControl
+    public class SukiTransitioningContentControl : TemplatedControl
     {
         internal static readonly StyledProperty<object?> FirstBufferProperty =
             AvaloniaProperty.Register<SukiTransitioningContentControl, object?>(nameof(FirstBuffer));

--- a/SukiUI/Theme/RadioButtonStyles.xaml
+++ b/SukiUI/Theme/RadioButtonStyles.xaml
@@ -77,7 +77,7 @@
                 <Grid>
                     <Border Name="BigBorder"
                             Margin="5"
-                            Padding="0"
+                            Padding="15,15,30,15"
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
@@ -86,7 +86,7 @@
                         <Border.Transitions>
                             <Transitions>
                                 <ThicknessTransition Property="BorderThickness" Duration="00:00:0.2" />
-                                <TransformOperationsTransition Property="RenderTransform" Duration="00:00:0.1"></TransformOperationsTransition>
+                                <TransformOperationsTransition Property="RenderTransform" Duration="00:00:0.1" />
                                 <BrushTransition Property="BorderBrush" Duration="00:00:0.2" />
                                 <ThicknessTransition Property="Margin" Duration="0:0:0.1" />
                             </Transitions>
@@ -123,7 +123,6 @@
         <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor2}" />
         <Setter Property="RenderTransform" Value="scale(1.03)" />
         <Setter Property="BorderThickness" Value="2" />
-
     </Style>
 
     <Style Selector="RadioButton.GigaChips PathIcon">

--- a/SukiUI/Theme/TextBlockStyles.xaml
+++ b/SukiUI/Theme/TextBlockStyles.xaml
@@ -1,7 +1,4 @@
-﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:controls="clr-namespace:SukiUI.Controls"
-                    xmlns:theme="clr-namespace:SukiUI.Theme">
+﻿<ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <ControlTheme x:Key="SukiTextBlockStyle" TargetType="TextBlock">
 
         <Setter Property="Foreground" Value="{DynamicResource SukiText}" />

--- a/SukiUI/Theme/TextBlockStyles.xaml
+++ b/SukiUI/Theme/TextBlockStyles.xaml
@@ -3,10 +3,10 @@
                     xmlns:controls="clr-namespace:SukiUI.Controls"
                     xmlns:theme="clr-namespace:SukiUI.Theme">
     <ControlTheme x:Key="SukiTextBlockStyle" TargetType="TextBlock">
-       
+
         <Setter Property="Foreground" Value="{DynamicResource SukiText}" />
         <Setter Property="FontSize" Value="14" />
-        
+
 
         <Style Selector="^.h4">
             <Setter Property="Margin" Value="0 7 0 10" />
@@ -42,4 +42,11 @@
     <ControlTheme x:Key="{x:Type TextBlock}"
                   BasedOn="{StaticResource SukiTextBlockStyle}"
                   TargetType="TextBlock" />
+
+    <ControlTheme x:Key="SukiAccessTextStyle" TargetType="AccessText">
+        <Setter Property="Foreground" Value="{DynamicResource SukiText}" />
+    </ControlTheme>
+    <ControlTheme x:Key="{x:Type AccessText}"
+                  BasedOn="{StaticResource SukiAccessTextStyle}"
+                  TargetType="AccessText" />
 </ResourceDictionary>


### PR DESCRIPTION
***Added***
- Completed the bulk of the toggles page in the demo app.
- Added a style for `AccessText` which is the default fallback type if you provide a simple string in a `Content` property on a control.

***Changed***
- Removed the vast majority of magic numbers in `GigaChips` and it's uses.

***Oustanding Issues***
- `ToggleButton` default not styled.
- `ToggleSwitches` exist and the `Switch` style should probably be applied to those instead,
- `GigaChips` is still a bit awkward to use even with all the magic numbers ripped out, it does still flicker the UI layout a bit whenever it's selected and accounting for the tick icon in the top right can be a little annoying.
- A few more pages left to do in the demo app for all controls.
- `Stepper` stops responding to `Index` property changes in some cases, but I can't figure out the precise cases...