### PR TITLE
New Collections and Colours pages for demo.

### DIFF
--- a/SukiUI.Demo/Features/ControlsLibrary/CollectionsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/CollectionsView.axaml
@@ -1,0 +1,67 @@
+<UserControl x:Class="SukiUI.Demo.Features.ControlsLibrary.CollectionsView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:controlsLibrary="clr-namespace:SukiUI.Demo.Features.ControlsLibrary"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:showMeTheXaml="clr-namespace:ShowMeTheXaml;assembly=ShowMeTheXaml.Avalonia"
+             d:DesignHeight="450"
+             d:DesignWidth="800"
+             x:DataType="controlsLibrary:CollectionsViewModel"
+             mc:Ignorable="d">
+    <Grid RowDefinitions="Auto,*">
+        <controls:GlassCard Classes="HeaderCard">
+            <controls:GroupBox Header="Collections">
+                <StackPanel Classes="HeaderContent">
+                    <TextBlock>
+                        All basic collection controls have been styled and animated.
+                    </TextBlock>
+                </StackPanel>
+            </controls:GroupBox>
+        </controls:GlassCard>
+        <ScrollViewer Grid.Row="1">
+            <WrapPanel Classes="PageContainer">
+                <controls:GlassCard>
+                    <controls:GroupBox Header="ListBox">
+                        <showMeTheXaml:XamlDisplay UniqueId="ListBox">
+                            <ListBox MaxHeight="200"
+                                     ItemsSource="{Binding SimpleContent}"
+                                     SelectedItem="{Binding SelectedSimpleContent}" />
+                        </showMeTheXaml:XamlDisplay>
+                    </controls:GroupBox>
+                </controls:GlassCard>
+                <controls:GlassCard>
+                    <controls:GroupBox Header="ComboBox">
+                        <showMeTheXaml:XamlDisplay UniqueId="ComboBox">
+                            <ComboBox ItemsSource="{Binding SimpleContent}" SelectedItem="{Binding SelectedSimpleContent}" />
+                        </showMeTheXaml:XamlDisplay>
+                    </controls:GroupBox>
+                </controls:GlassCard>
+                <controls:GlassCard>
+                    <controls:GroupBox Header="DataGrid">
+                        <showMeTheXaml:XamlDisplay UniqueId="DataGrid">
+                            <DataGrid MaxHeight="200"
+                                      AutoGenerateColumns="True"
+                                      IsReadOnly="False"
+                                      ItemsSource="{Binding DataGridContent}" />
+                        </showMeTheXaml:XamlDisplay>
+                    </controls:GroupBox>
+                </controls:GlassCard>
+                <controls:GlassCard>
+                    <controls:GroupBox Header="Tree View">
+                        <showMeTheXaml:XamlDisplay UniqueId="TreeView">
+                            <TreeView MaxHeight="200" ItemsSource="{Binding TreeViewContent}">
+                                <TreeView.ItemTemplate>
+                                    <TreeDataTemplate ItemsSource="{Binding SubNodes}">
+                                        <TextBlock Text="{Binding Value}" />
+                                    </TreeDataTemplate>
+                                </TreeView.ItemTemplate>
+                            </TreeView>
+                        </showMeTheXaml:XamlDisplay>
+                    </controls:GroupBox>
+                </controls:GlassCard>
+            </WrapPanel>
+        </ScrollViewer>
+    </Grid>
+</UserControl>

--- a/SukiUI.Demo/Features/ControlsLibrary/CollectionsView.axaml.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/CollectionsView.axaml.cs
@@ -1,0 +1,14 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace SukiUI.Demo.Features.ControlsLibrary
+{
+    public partial class CollectionsView : UserControl
+    {
+        public CollectionsView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/SukiUI.Demo/Features/ControlsLibrary/CollectionsViewModel.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/CollectionsViewModel.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Collections;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Material.Icons;
+
+namespace SukiUI.Demo.Features.ControlsLibrary
+{
+    public partial class CollectionsViewModel : DemoPageBase
+    {
+        public AvaloniaList<string> SimpleContent { get; } = new();
+        public AvaloniaList<DataGridContentViewModel> DataGridContent { get; } = new();
+        public AvaloniaList<Node> TreeViewContent { get; } = new();
+        [ObservableProperty] private string _selectedSimpleContent;
+
+        public CollectionsViewModel() : base("Collections", MaterialIconKind.ListBox)
+        {
+            SimpleContent.AddRange(Enumerable.Range(1, 50).Select(x => $"Option {x}"));
+            DataGridContent.AddRange(Enumerable.Range(1, 50).Select(x => new DataGridContentViewModel(x)));
+            SelectedSimpleContent = SimpleContent.First();
+            TreeViewContent.AddRange(
+                Enumerable.Range(1, 10).Select(x => new Node($"Outer {x}",
+                    Enumerable.Range(1, 5).Select(y => new Node($"Inner {y}",
+                        Enumerable.Range(1, 2).Select(z => new Node($"Innermost {z}")))))));
+        }
+    }
+
+    public partial class DataGridContentViewModel(int value) : ObservableObject
+    {
+        [ObservableProperty] private string _stringColumn = $"Content {value}";
+        [ObservableProperty] private int _intColumn = value;
+        [ObservableProperty] private bool _boolColumn = Random.Shared.Next(0, 2) == 0;
+    }
+
+    public partial class Node(string value, IEnumerable<Node>? subNodes = null) : ObservableObject
+    {
+        public AvaloniaList<Node> SubNodes { get; } = new(subNodes ?? Array.Empty<Node>());
+        [ObservableProperty] private string _value = value;
+    }
+}

--- a/SukiUI.Demo/Features/ControlsLibrary/ColorsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/ColorsView.axaml
@@ -1,0 +1,51 @@
+<UserControl x:Class="SukiUI.Demo.Features.ControlsLibrary.ColorsView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:controlsLibrary="clr-namespace:SukiUI.Demo.Features.ControlsLibrary"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             d:DesignHeight="450"
+             d:DesignWidth="800"
+             x:DataType="controlsLibrary:ColorsViewModel"
+             mc:Ignorable="d">
+    <Grid RowDefinitions="Auto,*">
+        <controls:GlassCard Classes="HeaderCard">
+            <controls:GroupBox Header="Colors">
+                <TextBlock>Below is a full list of all defined colors that are available either via XAML (DynamicResource) or via Application.Resources</TextBlock>
+            </controls:GroupBox>
+        </controls:GlassCard>
+        <ScrollViewer Grid.Row="1">
+            <ItemsControl ItemsSource="{Binding Colors}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <controls:GlassCard Margin="15">
+                            <controls:GroupBox Header="{Binding Name}">
+                                <Rectangle Width="50"
+                                           Height="50"
+                                           HorizontalAlignment="Center"
+                                           VerticalAlignment="Center"
+                                           Fill="{Binding Brush}"
+                                           RadiusX="5"
+                                           RadiusY="5"
+                                           Stroke="{DynamicResource SukiBorderBrush}"
+                                           StrokeThickness="2">
+                                    <Rectangle.Transitions>
+                                        <Transitions>
+                                            <BrushTransition Property="Fill" Duration="0:0:0.20" />
+                                        </Transitions>
+                                    </Rectangle.Transitions>
+                                </Rectangle>
+                            </controls:GroupBox>
+                        </controls:GlassCard>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <WrapPanel Classes="PageContainer" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+            </ItemsControl>
+        </ScrollViewer>
+    </Grid>
+</UserControl>

--- a/SukiUI.Demo/Features/ControlsLibrary/ColorsView.axaml.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/ColorsView.axaml.cs
@@ -1,0 +1,14 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace SukiUI.Demo.Features.ControlsLibrary
+{
+    public partial class ColorsView : UserControl
+    {
+        public ColorsView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/SukiUI.Demo/Features/ControlsLibrary/ColorsViewModel.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/ColorsViewModel.cs
@@ -18,8 +18,8 @@ namespace SukiUI.Demo.Features.ControlsLibrary
         private readonly string[] _keys =
         [
             "SukiText", "SukiLowText", "SukiCardBackground", "SukiLightBorderBrush", "SukiControlBorderBrush",
-            "GlassBorderBrush", "SukiDialogBackground", "SukiMediumBorderBrush", "SukiMediumBorderBrush",
-            "SukiControlTouchBackground", "SukiBorderBrush", "SukiBorderBrush", "SukiStrongBackground"
+            "GlassBorderBrush", "SukiDialogBackground", "SukiMediumBorderBrush", "SukiControlTouchBackground",
+            "SukiBorderBrush", "SukiStrongBackground"
         ];
 
         public AvaloniaList<ColorViewModel> Colors { get; } = new();
@@ -75,7 +75,7 @@ namespace SukiUI.Demo.Features.ControlsLibrary
             foreach (var key in _keys)
             {
                 if (Application.Current.TryGetResource(key, variant, out var obj) && obj is Color col)
-                    newRes.TryAdd(key, new SolidColorBrush(col));
+                    newRes.Add(key, new SolidColorBrush(col));
             }
 
             _baseThemeCache[variant] = newRes;

--- a/SukiUI.Demo/Features/ControlsLibrary/ColorsViewModel.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/ColorsViewModel.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia;
+using Avalonia.Collections;
+using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.Styling;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Material.Icons;
+using SukiUI.Enums;
+using SukiUI.Models;
+
+namespace SukiUI.Demo.Features.ControlsLibrary
+{
+    public partial class ColorsViewModel : DemoPageBase
+    {
+        private readonly string[] _keys =
+        [
+            "SukiText", "SukiLowText", "SukiCardBackground", "SukiLightBorderBrush", "SukiControlBorderBrush",
+            "GlassBorderBrush", "SukiDialogBackground", "SukiMediumBorderBrush", "SukiMediumBorderBrush",
+            "SukiControlTouchBackground", "SukiBorderBrush", "SukiBorderBrush", "SukiStrongBackground"
+        ];
+
+        public AvaloniaList<ColorViewModel> Colors { get; } = new();
+
+        private readonly Dictionary<ThemeVariant, Dictionary<string, IBrush>> _baseThemeCache = new();
+        private readonly Dictionary<SukiColorTheme, Dictionary<string, IBrush>> _colorThemeCache = new();
+
+        private readonly SukiTheme _theme;
+
+        public ColorsViewModel() : base("Colors", MaterialIconKind.Paintbrush)
+        {
+            _theme = SukiTheme.GetInstance();
+
+
+            Colors.AddRange(BuildOrGetColorTheme(_theme.ActiveColorTheme)
+                .Select(x => new ColorViewModel(x.Key, x.Value)));
+            Colors.AddRange(BuildOrGetBaseTheme(_theme.ActiveBaseTheme)
+                .OrderBy(x => x.Key)
+                .Select(x => new ColorViewModel(x.Key, x.Value)));
+
+            _theme.OnBaseThemeChanged += variant => ReApply(_theme.ActiveColorTheme, variant);
+            _theme.OnColorThemeChanged += theme => ReApply(theme, _theme.ActiveBaseTheme);
+        }
+
+        private void ReApply(SukiColorTheme theme, ThemeVariant variant)
+        {
+            var themeBrushes = BuildOrGetColorTheme(theme);
+            var baseBrushes = BuildOrGetBaseTheme(variant);
+            foreach (var vm in Colors)
+            {
+                if (themeBrushes.TryGetValue(vm.Name, out var themeBrush))
+                    vm.Brush = themeBrush;
+                else if (baseBrushes.TryGetValue(vm.Name, out var baseBrush))
+                    vm.Brush = baseBrush;
+            }
+        }
+
+        private Dictionary<string, IBrush> BuildOrGetColorTheme(SukiColorTheme theme)
+        {
+            if (_colorThemeCache.TryGetValue(theme, out var res))
+                return res;
+            var colors = Application.Current.Resources
+                .ToDictionary(x => (string)x.Key, y => (IBrush)new SolidColorBrush((Color)y.Value));
+            _colorThemeCache[theme] = colors;
+            return _colorThemeCache[theme];
+        }
+
+        private Dictionary<string, IBrush> BuildOrGetBaseTheme(ThemeVariant variant)
+        {
+            if (_baseThemeCache.TryGetValue(variant, out var res))
+                return res;
+            var newRes = new Dictionary<string, IBrush>();
+            foreach (var key in _keys)
+            {
+                if (Application.Current.TryGetResource(key, variant, out var obj) && obj is Color col)
+                    newRes.TryAdd(key, new SolidColorBrush(col));
+            }
+
+            _baseThemeCache[variant] = newRes;
+            return _baseThemeCache[variant];
+        }
+    }
+
+    public partial class ColorViewModel : ObservableObject
+    {
+        [ObservableProperty] private string _name;
+        [ObservableProperty] private IBrush _brush;
+
+        public ColorViewModel(string name, IBrush brush)
+        {
+            _brush = brush;
+            _name = name;
+        }
+    }
+}

--- a/SukiUI/Theme/DatePicker.axaml
+++ b/SukiUI/Theme/DatePicker.axaml
@@ -158,7 +158,7 @@
                                                     Padding="8,4"
                                                     CornerRadius="6">
 
-                                                <ContentPresenter Name="PART_ContentPresentern"
+                                                <ContentPresenter Name="PART_ContentPresenter"
                                                                   Margin="0,0,0,0"
                                                                   Padding="{TemplateBinding Padding}"
                                                                   VerticalAlignment="Center"

--- a/SukiUI/Theme/ExpanderStyles.xaml
+++ b/SukiUI/Theme/ExpanderStyles.xaml
@@ -99,7 +99,7 @@
                                       Content="{TemplateBinding Header}"
                                       IsChecked="{TemplateBinding IsExpanded,
                                                                   Mode=TwoWay}" />
-                        <ContentPresenter Name="PART_ContentPresentern"
+                        <ContentPresenter Name="PART_ContentPresenter"
                                           Grid.Row="0"
                                           Padding="{TemplateBinding Padding}"
                                           HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"

--- a/SukiUI/Theme/Index.axaml.cs
+++ b/SukiUI/Theme/Index.axaml.cs
@@ -192,18 +192,10 @@ public partial class SukiTheme : Styles
 
     private void SetColorTheme(SukiColorTheme colorTheme)
     {
-        
         SetColorWithOpacities("SukiPrimaryColor", colorTheme.Primary);
         SetColorWithOpacities("SukiAccentColor", colorTheme.Accent);
-
-        SetResource("SukiPrimaryColor7", colorTheme.Primary.WithAlpha(0.07));
-        SetResource("SukiPrimaryColor2", colorTheme.Primary.WithAlpha(0.02));
-        SetResource("SukiAccentColor1", colorTheme.Accent.WithAlpha(0.01));
-
         ActiveColorTheme = colorTheme;
         OnColorThemeChanged?.Invoke(ActiveColorTheme);
-        
-        
     }
 
     private void SetColorWithOpacities(string baseName, Color baseColor)
@@ -213,7 +205,10 @@ public partial class SukiTheme : Styles
         SetResource($"{baseName}50", baseColor.WithAlpha(0.5));
         SetResource($"{baseName}25", baseColor.WithAlpha(0.25));
         SetResource($"{baseName}10", baseColor.WithAlpha(0.1));
+        SetResource($"{baseName}7", baseColor.WithAlpha(0.07));
         SetResource($"{baseName}5", baseColor.WithAlpha(0.05));
+        SetResource($"{baseName}2", baseColor.WithAlpha(0.02));
+        SetResource($"{baseName}1", baseColor.WithAlpha(0.01));
     }
 
     private void SetResource(string name, Color color) =>

--- a/SukiUI/Theme/Index.axaml.cs
+++ b/SukiUI/Theme/Index.axaml.cs
@@ -197,7 +197,6 @@ public partial class SukiTheme : Styles
         SetColorWithOpacities("SukiAccentColor", colorTheme.Accent);
 
         SetResource("SukiPrimaryColor7", colorTheme.Primary.WithAlpha(0.07));
-        SetResource("SukiPrimaryColor5", colorTheme.Primary.WithAlpha(0.05));
         SetResource("SukiPrimaryColor2", colorTheme.Primary.WithAlpha(0.02));
         SetResource("SukiAccentColor1", colorTheme.Accent.WithAlpha(0.01));
 
@@ -214,6 +213,7 @@ public partial class SukiTheme : Styles
         SetResource($"{baseName}50", baseColor.WithAlpha(0.5));
         SetResource($"{baseName}25", baseColor.WithAlpha(0.25));
         SetResource($"{baseName}10", baseColor.WithAlpha(0.1));
+        SetResource($"{baseName}5", baseColor.WithAlpha(0.05));
     }
 
     private void SetResource(string name, Color color) =>

--- a/SukiUI/Theme/ListBoxItemStyle.axaml
+++ b/SukiUI/Theme/ListBoxItemStyle.axaml
@@ -13,7 +13,7 @@
         </Border>
     </Design.PreviewWith>
 
-    <Style Selector="ListBoxItem:selected /template/ ContentPresenter#PART_ContentPresentern">
+    <Style Selector="ListBoxItem:selected /template/ ContentPresenter#PART_ContentPresenter">
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="TextBlock.Foreground" Value="{DynamicResource SukiPrimaryColor}" />
     </Style>
@@ -40,7 +40,7 @@
                                   Data="{x:Static content:Icons.CircleCheck}"
                                   DockPanel.Dock="Right"
                                   Foreground="{DynamicResource SukiPrimaryColor}" />
-                        <ContentPresenter Name="PART_ContentPresentern"
+                        <ContentPresenter Name="PART_ContentPresenter"
                                           Margin="0,0,0,0"
                                           Padding="{TemplateBinding Padding}"
                                           HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
@@ -56,7 +56,6 @@
         </Setter>
     </Style>
 
-
     <Style Selector="ListBoxItem:selected /template/ PathIcon#CheckSelected">
         <Setter Property="IsVisible" Value="True" />
     </Style>
@@ -65,15 +64,15 @@
         <Setter Property="IsVisible" Value="False" />
     </Style>
 
-    <Style Selector="ListBoxItem:pointerover /template/ ContentPresenter#PART_ContentPresentern">
+    <Style Selector="ListBoxItem:pointerover /template/ ContentPresenter#PART_ContentPresenter">
         <Setter Property="Background" Value="Transparent" />
     </Style>
 
     <Style Selector="ListBoxItem:selected /template/ Border#BorderBasicStyle">
-        <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor5}" />
+        <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor10}" />
     </Style>
     <Style Selector="ListBoxItem:pointerover /template/ Border#BorderBasicStyle">
-        <Setter Property="Background" Value="{DynamicResource SukiLightBackground}" />
+        <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor5}" />
     </Style>
 
     <Style Selector="ListBoxItem.WithCheck">
@@ -87,7 +86,7 @@
                             <ScaleTransform ScaleX="1.2" ScaleY="1.2" />
                         </CheckBox.RenderTransform>
                     </CheckBox>
-                    <ContentPresenter Name="PART_ContentPresentern"
+                    <ContentPresenter Name="PART_ContentPresenter"
                                       Margin="-8,0,0,0"
                                       Padding="{TemplateBinding Padding}"
                                       VerticalAlignment="Center"
@@ -104,16 +103,16 @@
         </Setter>
     </Style>
 
-    <Style Selector="ListBoxItem.WithCheck:selected /template/ ContentPresenter#PART_ContentPresentern">
+    <Style Selector="ListBoxItem.WithCheck:selected /template/ ContentPresenter#PART_ContentPresenter">
         <Setter Property="Background" Value="Transparent" />
     </Style>
 
-    <Style Selector="ListBoxItem.WithCheck:pointerover /template/ ContentPresenter#PART_ContentPresentern">
+    <Style Selector="ListBoxItem.WithCheck:pointerover /template/ ContentPresenter#PART_ContentPresenter">
         <Setter Property="Background" Value="Transparent" />
     </Style>
 
 
-    <Style Selector="ListBoxItem.WithCheck:selected /template/ ContentPresenter#PART_ContentPresentern">
+    <Style Selector="ListBoxItem.WithCheck:selected /template/ ContentPresenter#PART_ContentPresenter">
         <Setter Property="Background" Value="Transparent" />
     </Style>
 

--- a/SukiUI/Theme/TabItemStyle.axaml
+++ b/SukiUI/Theme/TabItemStyle.axaml
@@ -38,7 +38,7 @@
                         CornerRadius="{TemplateBinding CornerRadius}">
                     <StackPanel>
 
-                        <ContentPresenter Name="PART_ContentPresentern"
+                        <ContentPresenter Name="PART_ContentPresenter"
                                           Padding="7,5"
                                           HorizontalAlignment="Center"
                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -226,7 +226,7 @@
                                     <BrushTransition Property="Background" Duration="00:00:00.2" />
                                 </Transitions>
                             </Border.Transitions>
-                            <ContentPresenter Name="PART_ContentPresentern"
+                            <ContentPresenter Name="PART_ContentPresenter"
                                               Padding="10,12"
                                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                               HorizontalContentAlignment="Center"


### PR DESCRIPTION
***Changes***
- Standardized 7%, 5%, 2% and 1% opacity for `Primary` and `Accent` as it's quite useful.
- Added a `Colours` page to the demo app to show off all the available colours (At least the ones that I could find).
- Added a `Collections` page to demo `ListBox`, `ComboBox`, `DataGrid` and `TreeView` controls.
- Minor change to `ListBoxItem` to improve interaction feel.

***Oustanding Issues***
- `TreeView` togglebuttons are incorrectly styled.
- `ListBoxItem` feels _very_ cramped inside the `ListBox` with a huge chunk of free space off to the sides.
- `ComboBox` items in the dropdown seem to be cut-off at the ends and feel very cramped too.
  - Probably could do with some `pointerover` styling to make the interaction feel a bit better. 
- `DataGrid` doesn't seem to support editing the checkboxes.
- Overall the collections do need a pass to tidy them up.