### PR TITLE
Added cards page.

### DIFF
--- a/SukiUI.Demo/Features/ControlsLibrary/ButtonsLibraryView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/ButtonsLibraryView.axaml
@@ -32,9 +32,7 @@
             </controls:GroupBox>
         </controls:GlassCard>
         <ScrollViewer Grid.Row="1">
-            <WrapPanel Classes="PageContainer" theme:WrapPanelExtensions.AnimatedScroll="True">
-                
-                
+            <WrapPanel Classes="PageContainer">
                 <controls:GlassCard>
                     <controls:GroupBox Header="Standard Button">
                         <showMeTheXaml:XamlDisplay UniqueId="Button1">
@@ -120,7 +118,7 @@
                         </showMeTheXaml:XamlDisplay>
                     </controls:GroupBox>
                 </controls:GlassCard>
-       
+
             </WrapPanel>
         </ScrollViewer>
     </Grid>

--- a/SukiUI.Demo/Features/ControlsLibrary/CardsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/CardsView.axaml
@@ -1,0 +1,86 @@
+<UserControl x:Class="SukiUI.Demo.Features.ControlsLibrary.CardsView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:controlsLibrary="clr-namespace:SukiUI.Demo.Features.ControlsLibrary"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:system="clr-namespace:System;assembly=System.Runtime"
+             d:DesignHeight="450"
+             d:DesignWidth="800"
+             x:DataType="controlsLibrary:CardsViewModel"
+             mc:Ignorable="d">
+    <UserControl.Styles>
+        <Style Selector="WrapPanel &gt; controls|GlassCard">
+            <Setter Property="IsOpaque" Value="{Binding IsOpaque}" />
+            <Setter Property="IsInteractive" Value="{Binding IsInteractive}" />
+        </Style>
+    </UserControl.Styles>
+    <Grid RowDefinitions="Auto,*">
+        <controls:GlassCard Classes="HeaderCard">
+            <controls:GroupBox Header="Cards">
+                <StackPanel Classes="HeaderContent">
+                    <TextBlock>
+                        SukiUI provides a simple GlassCard control which has some basic customisation built in.
+                    </TextBlock>
+                    <TextBlock>
+                        The GlassCard can be opaque and interactive, those properties can be toggled for all cards below.
+                    </TextBlock>
+                    <TextBlock>
+                        It's also possible to override the Color/Opacity via correctly named keyed values, this can be done at any level of the visual tree.
+                    </TextBlock>
+                    <TextBlock>
+                        If you'd like to override these values app-wide then simply override the keys in App.axaml
+                    </TextBlock>
+                    <DockPanel>
+                        <ToggleSwitch DockPanel.Dock="Left" IsChecked="{Binding IsOpaque}" />
+                        <TextBlock VerticalAlignment="Center" Text="Is Opaque" />
+                    </DockPanel>
+                    <DockPanel>
+                        <ToggleSwitch DockPanel.Dock="Left" IsChecked="{Binding IsInteractive}" />
+                        <TextBlock VerticalAlignment="Center" Text="Is Interactive" />
+                    </DockPanel>
+                </StackPanel>
+            </controls:GroupBox>
+        </controls:GlassCard>
+        <ScrollViewer Grid.Row="1">
+            <WrapPanel Classes="PageContainer">
+                <controls:GlassCard>
+                    <controls:GroupBox Header="Standard">
+                        <TextBlock Classes="h3">A standard GlassCard</TextBlock>
+                    </controls:GroupBox>
+                </controls:GlassCard>
+                <controls:GlassCard Classes="Primary">
+                    <controls:GroupBox Header="Primary">
+                        <TextBlock Classes="h3">A primary colored GlassCard</TextBlock>
+                    </controls:GroupBox>
+                </controls:GlassCard>
+                <controls:GlassCard Classes="Accent">
+                    <controls:GroupBox Header="Accent">
+                        <TextBlock Classes="h3">An accent colored GlassCard</TextBlock>
+                    </controls:GroupBox>
+                </controls:GlassCard>
+                <controls:GlassCard>
+                    <controls:GlassCard.Resources>
+                        <system:Double x:Key="GlassOpacity">0.2</system:Double>
+                    </controls:GlassCard.Resources>
+                    <controls:GroupBox Header="Overriden Opacity">
+                        <TextBlock Classes="h3">This card's resources sets the double resource of "GlassOpacity" to 0.2</TextBlock>
+                    </controls:GroupBox>
+                </controls:GlassCard>
+                <controls:GlassCard>
+                    <controls:GlassCard.Resources>
+                        <Color x:Key="SukiGlassCardBackground">DarkRed</Color>
+                        <Color x:Key="SukiGlassCardOpaqueBackground">DarkRed</Color>
+                    </controls:GlassCard.Resources>
+                    <controls:GroupBox Header="Overriden Color">
+                        <StackPanel>
+                            <TextBlock Classes="h3">This card's resources sets the color resource of</TextBlock>
+                            <TextBlock Classes="h3">"SukiGlassCardBackground" and "SukiGlassCardOpaqueBackground to Red.</TextBlock>
+                        </StackPanel>
+                    </controls:GroupBox>
+                </controls:GlassCard>
+            </WrapPanel>
+        </ScrollViewer>
+    </Grid>
+</UserControl>

--- a/SukiUI.Demo/Features/ControlsLibrary/CardsView.axaml.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/CardsView.axaml.cs
@@ -1,0 +1,14 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace SukiUI.Demo.Features.ControlsLibrary
+{
+    public partial class CardsView : UserControl
+    {
+        public CardsView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/SukiUI.Demo/Features/ControlsLibrary/CardsViewModel.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/CardsViewModel.cs
@@ -1,0 +1,11 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using Material.Icons;
+
+namespace SukiUI.Demo.Features.ControlsLibrary
+{
+    public partial class CardsViewModel() : DemoPageBase("Cards", MaterialIconKind.Cards)
+    {
+        [ObservableProperty] private bool _isOpaque;
+        [ObservableProperty] private bool _isInteractive;
+    }
+}

--- a/SukiUI.Demo/Features/ControlsLibrary/CollectionsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/CollectionsView.axaml
@@ -22,7 +22,7 @@
             </controls:GroupBox>
         </controls:GlassCard>
         <ScrollViewer Grid.Row="1">
-            <WrapPanel theme:WrapPanelExtensions.AnimatedScroll="True" Classes="PageContainer">
+            <WrapPanel Classes="PageContainer">
                 <controls:GlassCard>
                     <controls:GroupBox Header="ListBox">
                         <showMeTheXaml:XamlDisplay UniqueId="ListBox">

--- a/SukiUI.Demo/Features/ControlsLibrary/DialogsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/DialogsView.axaml
@@ -30,20 +30,26 @@
             </controls:GroupBox>
         </controls:GlassCard>
         <ScrollViewer Grid.Row="1">
-            <WrapPanel theme:WrapPanelExtensions.AnimatedScroll="True" Classes="PageContainer">
+            <WrapPanel Classes="PageContainer">
                 <controls:GlassCard>
                     <controls:GroupBox Header="Standard Dialog">
-                        <Button Margin="15,10,15,0" Command="{Binding OpenStandardDialogCommand}" Content="Open" />
+                        <Button Margin="15,10,15,0"
+                                Command="{Binding OpenStandardDialogCommand}"
+                                Content="Open" />
                     </controls:GroupBox>
                 </controls:GlassCard>
                 <controls:GlassCard>
                     <controls:GroupBox Header="Background Closable Dialog">
-                        <Button Margin="15,10,15,0" Command="{Binding OpenBackgroundCloseDialogCommand}" Content="Open" />
+                        <Button Margin="15,10,15,0"
+                                Command="{Binding OpenBackgroundCloseDialogCommand}"
+                                Content="Open" />
                     </controls:GroupBox>
                 </controls:GlassCard>
                 <controls:GlassCard>
                     <controls:GroupBox Header="ViewModel Dialog">
-                        <Button Margin="15,10,15,0" Command="{Binding OpenViewModelDialogCommand}" Content="Open" />
+                        <Button Margin="15,10,15,0"
+                                Command="{Binding OpenViewModelDialogCommand}"
+                                Content="Open" />
                     </controls:GroupBox>
                 </controls:GlassCard>
             </WrapPanel>

--- a/SukiUI.Demo/Features/ControlsLibrary/ProgressView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/ProgressView.axaml
@@ -59,7 +59,7 @@
             </controls:GroupBox>
         </controls:GlassCard>
         <ScrollViewer Grid.Row="1" HorizontalScrollBarVisibility="Disabled">
-            <WrapPanel theme:WrapPanelExtensions.AnimatedScroll="True" Classes="PageContainer">
+            <WrapPanel Classes="PageContainer">
                 <controls:GlassCard Margin="20">
                     <controls:GroupBox Header="Wave Progress">
                         <Grid>

--- a/SukiUI.Demo/Features/ControlsLibrary/ToastsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/ToastsView.axaml
@@ -36,20 +36,26 @@
             </controls:GroupBox>
         </controls:GlassCard>
         <ScrollViewer Grid.Row="1">
-            <WrapPanel theme:WrapPanelExtensions.AnimatedScroll="True" Classes="PageContainer">
+            <WrapPanel Classes="PageContainer">
                 <controls:GlassCard>
                     <controls:GroupBox Header="Single Standard Toast">
-                        <Button Margin="15,10,15,0"  Command="{Binding ShowSingleStandardToastCommand}" Content="Show Toast" />
+                        <Button Margin="15,10,15,0"
+                                Command="{Binding ShowSingleStandardToastCommand}"
+                                Content="Show Toast" />
                     </controls:GroupBox>
                 </controls:GlassCard>
                 <controls:GlassCard>
                     <controls:GroupBox Header="3 Standard Toasts">
-                        <Button Margin="15,10,15,0" Command="{Binding ShowThreeStandardToastsCommand}" Content="Show Toasts" />
+                        <Button Margin="15,10,15,0"
+                                Command="{Binding ShowThreeStandardToastsCommand}"
+                                Content="Show Toasts" />
                     </controls:GroupBox>
                 </controls:GlassCard>
                 <controls:GlassCard>
                     <controls:GroupBox Header="Callback Toast">
-                        <Button Margin="15,10,15,0" Command="{Binding ShowToastWithCallbackCommand}" Content="Show Toast" />
+                        <Button Margin="15,10,15,0"
+                                Command="{Binding ShowToastWithCallbackCommand}"
+                                Content="Show Toast" />
                     </controls:GroupBox>
                 </controls:GlassCard>
             </WrapPanel>

--- a/SukiUI.Demo/Features/ControlsLibrary/TogglesView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/TogglesView.axaml
@@ -12,12 +12,14 @@
              x:DataType="controlsLibrary:TogglesViewModel"
              mc:Ignorable="d">
     <ScrollViewer>
-        <WrapPanel theme:WrapPanelExtensions.AnimatedScroll="True" Classes="PageContainer">
+        <WrapPanel Classes="PageContainer">
             <controls:GlassCard>
                 <controls:GroupBox Header="Radio Buttons">
                     <showMeTheXaml:XamlDisplay UniqueId="RadioButtons">
                         <StackPanel VerticalAlignment="Center" Spacing="10">
-                            <RadioButton IsChecked="True" Content="Option One" GroupName="R1" />
+                            <RadioButton Content="Option One"
+                                         GroupName="R1"
+                                         IsChecked="True" />
                             <RadioButton Content="Option Two" GroupName="R1" />
                             <RadioButton Content="Option Three" GroupName="R1" />
                         </StackPanel>
@@ -28,9 +30,10 @@
                 <controls:GroupBox Header="Simple GigaChips">
                     <showMeTheXaml:XamlDisplay UniqueId="SimpleGigaChips">
                         <StackPanel>
-                            <RadioButton Classes="GigaChips" IsChecked="True"
+                            <RadioButton Classes="GigaChips"
                                          Content="Option One"
-                                         GroupName="R2" />
+                                         GroupName="R2"
+                                         IsChecked="True" />
                             <RadioButton Classes="GigaChips"
                                          Content="Option Two"
                                          GroupName="R2" />
@@ -45,12 +48,16 @@
                 <controls:GroupBox Header="Complex GigaChips">
                     <showMeTheXaml:XamlDisplay UniqueId="ComplexGigaChips">
                         <StackPanel Orientation="Horizontal">
-                            <RadioButton IsChecked="True" Classes="GigaChips" GroupName="R3">
+                            <RadioButton Classes="GigaChips"
+                                         GroupName="R3"
+                                         IsChecked="True">
                                 <StackPanel>
                                     <TextBlock FontSize="18"
                                                FontWeight="DemiBold"
                                                Text="One Header" />
-                                    <TextBlock Margin="0,8,0,0" Foreground="{DynamicResource SukiLowText}" Text="Some content." />
+                                    <TextBlock Margin="0,8,0,0"
+                                               Foreground="{DynamicResource SukiLowText}"
+                                               Text="Some content." />
                                 </StackPanel>
                             </RadioButton>
                             <RadioButton Classes="GigaChips" GroupName="R3">
@@ -58,7 +65,9 @@
                                     <TextBlock FontSize="18"
                                                FontWeight="DemiBold"
                                                Text="Another Header" />
-                                    <TextBlock Margin="0,8,0,0" Foreground="{DynamicResource SukiLowText}" Text="Some content." />
+                                    <TextBlock Margin="0,8,0,0"
+                                               Foreground="{DynamicResource SukiLowText}"
+                                               Text="Some content." />
                                 </StackPanel>
                             </RadioButton>
                             <RadioButton Classes="GigaChips" GroupName="R3">
@@ -66,7 +75,9 @@
                                     <TextBlock FontSize="18"
                                                FontWeight="DemiBold"
                                                Text="Final Header" />
-                                    <TextBlock Margin="0,8,0,0" Foreground="{DynamicResource SukiLowText}" Text="Some content." />
+                                    <TextBlock Margin="0,8,0,0"
+                                               Foreground="{DynamicResource SukiLowText}"
+                                               Text="Some content." />
                                 </StackPanel>
                             </RadioButton>
                         </StackPanel>
@@ -80,7 +91,7 @@
                             <ToggleSwitch IsChecked="True" />
                         </showMeTheXaml:XamlDisplay>
                         <showMeTheXaml:XamlDisplay UniqueId="CustomContentToggleSwitch">
-                            <ToggleSwitch OffContent="Switch Off."  OnContent="Switch On." />
+                            <ToggleSwitch OffContent="Switch Off." OnContent="Switch On." />
                         </showMeTheXaml:XamlDisplay>
                     </StackPanel>
                 </controls:GroupBox>
@@ -105,7 +116,7 @@
                     <StackPanel>
                         <showMeTheXaml:XamlDisplay UniqueId="CheckBox">
                             <StackPanel Spacing="5">
-                                <CheckBox IsChecked="True" Content="Option One" />
+                                <CheckBox Content="Option One" IsChecked="True" />
                                 <CheckBox Content="Option Two" />
                                 <CheckBox Content="Option Three" />
                             </StackPanel>

--- a/SukiUI.Demo/Styles/WrapPanelStyles.axaml
+++ b/SukiUI.Demo/Styles/WrapPanelStyles.axaml
@@ -1,9 +1,11 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI">
+        xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+        xmlns:theme="clr-namespace:SukiUI.Theme;assembly=SukiUI">
     <Style Selector="WrapPanel.PageContainer">
         <Setter Property="Margin" Value="15,15,0,0" />
         <Setter Property="Orientation" Value="Horizontal" />
+        <Setter Property="theme:WrapPanelExtensions.AnimatedScroll" Value="True" />
         <Style Selector="^ &gt; controls|GlassCard">
             <Setter Property="Margin" Value="15,15,15,15" />
         </Style>

--- a/SukiUI/Controls/GlassMorphism/GlassCard.axaml
+++ b/SukiUI/Controls/GlassMorphism/GlassCard.axaml
@@ -18,31 +18,18 @@
                         <Border.Transitions>
                             <Transitions>
                                 <BoxShadowsTransition Property="BoxShadow" Duration="0:0:0.15" />
+                                <BrushTransition Property="Background" Duration="0:0:0.15" />
+                                <DoubleTransition Property="Opacity" Duration="0:0:0.15" />
                             </Transitions>
                         </Border.Transitions>
                     </Border>
-                    
-                   
-                    
-                   
-                    <Border 
-                            Background="Transparent"
+                    <Border Background="Transparent"
                             BorderBrush="Transparent"
                             BorderThickness="0"
-                           
                             ClipToBounds="{TemplateBinding ClipToBounds}"
-                            CornerRadius="{TemplateBinding CornerRadius}"
-                            >
-                        
-                           <Grid>
-                               
-                               <suki:SukiBackground IsVisible="{TemplateBinding IsOpaque}"></suki:SukiBackground>          
-                  
-                    
-                               <suki:GlassCard IsVisible="{TemplateBinding IsOpaque}"></suki:GlassCard>
-                               <ContentPresenter  Margin="{TemplateBinding Padding}" Content="{TemplateBinding Content}" />
-                        </Grid>
-                        </Border>
+                            CornerRadius="{TemplateBinding CornerRadius}">
+                        <ContentPresenter Margin="{TemplateBinding Padding}" Content="{TemplateBinding Content}" />
+                    </Border>
                 </Grid>
             </ControlTemplate>
         </Setter>
@@ -52,6 +39,12 @@
         </Style>
         <Style Selector="^[IsInteractive=True]:pointerover /template/ Border#PART_BorderCard">
             <Setter Property="BoxShadow" Value="{DynamicResource SukiGlassCardHighlightedShadow}" />
+        </Style>
+        <Style Selector="^.Accent /template/ Border#PART_BorderCard">
+            <Setter Property="Background" Value="{DynamicResource SukiAccentColor}" />
+        </Style>
+        <Style Selector="^.Primary /template/ Border#PART_BorderCard">
+            <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor}" />
         </Style>
     </ControlTheme>
     <ControlTheme x:Key="{x:Type suki:GlassCard}"


### PR DESCRIPTION
***Changes***
- Added Cards page to the demo app.
- Reverted `GlassCard` with `ClipToBounds` fix included this time.
- Added `Accent` and `Primary` versions of `GlassCard.
- Added transitions for `GlassCards`

***Oustanding Issues***
- `IsInteractive` state of the `GlassCard` could maybe do with some work, the boxshadow doesn't look that good. Perhaps just make the border brush primary on `pointerover` and a less extreme inside boxshadow for `pointerdown`? Would be nice in general to make the `GlassCard` feel fully interactive for people who need it.
- Overwriting the light/dark versions of a brush is a bit more involved than just overwriting the single key, but that's just a limitation of Avalonia more than anything else.