### PR TITLE
Minor fixes and adjustments

### DIFF
--- a/SukiTest/DashboardPage.axaml.cs
+++ b/SukiTest/DashboardPage.axaml.cs
@@ -100,7 +100,6 @@ public partial class DashboardPage : UserControl
     private void Button_OnClickProgressBar(object? sender, RoutedEventArgs e)
     {
         this.FindRequiredControl<ProgressBar>("myProgressBarLine").Value = 60;
-        this.FindRequiredControl<PercentProgressBar>("myPercentProgress").Value = 100;
     }
 
     private void Button_OnClick(object? sender, RoutedEventArgs e)
@@ -122,11 +121,6 @@ public partial class DashboardPage : UserControl
     private void BusyMe(object? sender, RoutedEventArgs e)
     {
         this.FindRequiredControl<BusyArea>("myBusyArea").IsBusy = true;
-    }
-
-    private void GoTo50(object? sender, RoutedEventArgs e)
-    {
-        this.FindRequiredControl<PercentProgressBar>("myPercentProgress").Value = 50;
     }
 
     // Write a function that returns the sum of two numbers.

--- a/SukiUI.Demo/Features/ControlsLibrary/CollectionsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/CollectionsView.axaml
@@ -47,9 +47,18 @@
                         <StackPanel>
                             <showMeTheXaml:XamlDisplay UniqueId="DataGrid">
                                 <DataGrid MaxHeight="200"
-                                          AutoGenerateColumns="True"
                                           CanUserResizeColumns="{Binding IsDataGridColumnsResizable}"
-                                          ItemsSource="{Binding DataGridContent}" />
+                                          ItemsSource="{Binding DataGridContent}">
+                                    <DataGrid.Columns>
+                                        <DataGridTextColumn Binding="{Binding StringColumn}" Header="String" />
+                                        <DataGridTextColumn Binding="{Binding IntColumn}"
+                                                            CellStyleClasses="RightAlign"
+                                                            Header="Int" />
+                                        <DataGridCheckBoxColumn Binding="{Binding BoolColumn}"
+                                                                CellStyleClasses="CenterAlign"
+                                                                Header="Bool" />
+                                    </DataGrid.Columns>
+                                </DataGrid>
                             </showMeTheXaml:XamlDisplay>
                             <DockPanel>
                                 <ToggleSwitch DockPanel.Dock="Left" IsChecked="{Binding IsDataGridColumnsResizable}" />

--- a/SukiUI.Demo/Features/ControlsLibrary/CollectionsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/CollectionsView.axaml
@@ -18,6 +18,9 @@
                     <TextBlock>
                         All basic collection controls have been styled and animated.
                     </TextBlock>
+                    <TextBlock>
+                        The DataGrid aligns it's content to the left by default, but you can apply CenterAlign and LeftAlign classes to the CellStyleClasses property of a column definition.
+                    </TextBlock>
                 </StackPanel>
             </controls:GroupBox>
         </controls:GlassCard>
@@ -41,12 +44,20 @@
                 </controls:GlassCard>
                 <controls:GlassCard>
                     <controls:GroupBox Header="DataGrid">
-                        <showMeTheXaml:XamlDisplay UniqueId="DataGrid">
-                            <DataGrid MaxHeight="200"
-                                      AutoGenerateColumns="True"
-                                      IsReadOnly="False"
-                                      ItemsSource="{Binding DataGridContent}" />
-                        </showMeTheXaml:XamlDisplay>
+                        <StackPanel>
+                            <showMeTheXaml:XamlDisplay UniqueId="DataGrid">
+                                <DataGrid MaxHeight="200"
+                                          AutoGenerateColumns="True"
+                                          CanUserResizeColumns="{Binding IsDataGridColumnsResizable}"
+                                          ItemsSource="{Binding DataGridContent}" />
+                            </showMeTheXaml:XamlDisplay>
+                            <DockPanel>
+                                <ToggleSwitch DockPanel.Dock="Left" IsChecked="{Binding IsDataGridColumnsResizable}" />
+                                <TextBlock Margin="5,0"
+                                           VerticalAlignment="Center"
+                                           Text="Resizable Columns" />
+                            </DockPanel>
+                        </StackPanel>
                     </controls:GroupBox>
                 </controls:GlassCard>
                 <controls:GlassCard>

--- a/SukiUI.Demo/Features/ControlsLibrary/CollectionsViewModel.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/CollectionsViewModel.cs
@@ -13,6 +13,7 @@ namespace SukiUI.Demo.Features.ControlsLibrary
         public AvaloniaList<DataGridContentViewModel> DataGridContent { get; } = new();
         public AvaloniaList<Node> TreeViewContent { get; } = new();
         [ObservableProperty] private string _selectedSimpleContent;
+        [ObservableProperty] private bool _isDataGridColumnsResizable = true;
 
         public CollectionsViewModel() : base("Collections", MaterialIconKind.ListBox)
         {

--- a/SukiUI.Demo/Features/ControlsLibrary/ContextMenusView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/ContextMenusView.axaml
@@ -1,0 +1,40 @@
+<UserControl x:Class="SukiUI.Demo.Features.ControlsLibrary.ContextMenusView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:content="clr-namespace:SukiUI.Content;assembly=SukiUI"
+             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:controlsLibrary="clr-namespace:SukiUI.Demo.Features.ControlsLibrary"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             d:DesignHeight="450"
+             d:DesignWidth="800"
+             x:DataType="controlsLibrary:ContextMenusViewModel"
+             mc:Ignorable="d">
+    <controls:GlassCard HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        IsInteractive="True">
+        <controls:GlassCard.ContextMenu>
+            <ContextMenu>
+                <!--  Ignore your IDE, x:False is a valid intrinsic  -->
+                <MenuItem Command="{Binding TestClickedCommand}"
+                          CommandParameter="{x:False}"
+                          Header="Option" />
+                <!--  Ignore your IDE, x:True is a valid intrinsic  -->
+                <MenuItem Command="{Binding TestClickedCommand}"
+                          CommandParameter="{x:True}"
+                          Header="Option With Icon">
+                    <MenuItem.Icon>
+                        <PathIcon Data="{x:Static content:Icons.Star}" />
+                    </MenuItem.Icon>
+                </MenuItem>
+            </ContextMenu>
+        </controls:GlassCard.ContextMenu>
+        <controls:GroupBox Header="Context Menu Demo">
+            <TextBlock HorizontalAlignment="Center"
+                       VerticalAlignment="Center"
+                       Classes="h3">
+                Right click anywhere in this card to open a context menu.
+            </TextBlock>
+        </controls:GroupBox>
+    </controls:GlassCard>
+</UserControl>

--- a/SukiUI.Demo/Features/ControlsLibrary/ContextMenusView.axaml.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/ContextMenusView.axaml.cs
@@ -1,0 +1,14 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace SukiUI.Demo.Features.ControlsLibrary
+{
+    public partial class ContextMenusView : UserControl
+    {
+        public ContextMenusView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/SukiUI.Demo/Features/ControlsLibrary/ContextMenusViewModel.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/ContextMenusViewModel.cs
@@ -1,0 +1,15 @@
+using CommunityToolkit.Mvvm.Input;
+using Material.Icons;
+using SukiUI.Controls;
+
+namespace SukiUI.Demo.Features.ControlsLibrary
+{
+    public partial class ContextMenusViewModel() : DemoPageBase("Context Menus", MaterialIconKind.Menu)
+    {
+        [RelayCommand]
+        public void TestClicked(bool withIcon)
+        {
+            SukiHost.ShowToast("Clicked Context Menu", withIcon ? "You clicked the option with the icon." : "You clicked the option without the icon.");
+        }
+    }
+}

--- a/SukiUI.Demo/Features/ControlsLibrary/IconsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/IconsView.axaml
@@ -40,7 +40,7 @@
                 </StackPanel>
             </controls:GroupBox>
         </controls:GlassCard>
-        <ScrollViewer Grid.Row="1" HorizontalScrollBarVisibility="Disabled">
+        <ScrollViewer Grid.Row="1">
             <ItemsControl theme:ItemsControlExtensions.AnimatedScroll="True" ItemsSource="{Binding AllIcons}">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate x:CompileBindings="False">
@@ -63,6 +63,5 @@
                 </ItemsControl.ItemsPanel>
             </ItemsControl>
         </ScrollViewer>
-
     </Grid>
 </UserControl>

--- a/SukiUI.Demo/SukiUIDemoView.axaml
+++ b/SukiUI.Demo/SukiUIDemoView.axaml
@@ -24,7 +24,11 @@
     </suki:SukiWindow.LogoContent>
     <suki:SukiWindow.MenuItems>
         <MenuItem Header="Toggles">
-            <MenuItem Command="{Binding ToggleBaseThemeCommand}" Header="{Binding BaseTheme}" />
+            <MenuItem Command="{Binding ToggleBaseThemeCommand}" Header="{Binding BaseTheme}">
+                <MenuItem.Icon>
+                    <avalonia:MaterialIcon Kind="Lightbulb" />
+                </MenuItem.Icon>
+            </MenuItem>
             <MenuItem Command="{Binding ToggleAnimationsCommand}" Header="Animations" />
         </MenuItem>
         <MenuItem Click="MenuItem_OnClick"

--- a/SukiUI/Controls/GlassMorphism/GlassCard.axaml.cs
+++ b/SukiUI/Controls/GlassMorphism/GlassCard.axaml.cs
@@ -1,7 +1,9 @@
-﻿using System.Windows.Input;
+﻿using System.ComponentModel;
+using System.Windows.Input;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
 
 namespace SukiUI.Controls;
@@ -57,6 +59,18 @@ public class GlassCard : ContentControl
     {
         get => GetValue(CommandParameterProperty);
         set => SetValue(CommandParameterProperty, value);
+    }
+
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        if (ContextMenu is null) return;
+        ContextMenu.Opening += ContextMenuOnOpening;
+    }
+
+    private void ContextMenuOnOpening(object sender, CancelEventArgs e)
+    {
+        PseudoClasses.Set(":pointerdown", false);
     }
 
     protected override void OnPointerPressed(PointerPressedEventArgs e)

--- a/SukiUI/Controls/SukiSideMenu.axaml.cs
+++ b/SukiUI/Controls/SukiSideMenu.axaml.cs
@@ -102,11 +102,11 @@ public class SukiSideMenu : SelectingItemsControl
                 .ObserveOn(new AvaloniaSynchronizationContext())
                 .Do(obj =>
                 {
-                    contentControl.PushContent(obj switch
+                    contentControl.Content = obj switch
                     {
                         SukiSideMenuItem { PageContent: { } sukiMenuPageContent } => sukiMenuPageContent,
                         _ => obj
-                    });
+                    };
                 })
                 .Subscribe();
         }

--- a/SukiUI/Controls/SukiTransitioningContentControl.axaml.cs
+++ b/SukiUI/Controls/SukiTransitioningContentControl.axaml.cs
@@ -37,6 +37,14 @@ namespace SukiUI.Controls
             set => SetValue(SecondBufferProperty, value);
         }
 
+        public static readonly StyledProperty<object?> ContentProperty = AvaloniaProperty.Register<SukiTransitioningContentControl, object?>(nameof(Content));
+
+        public object? Content
+        {
+            get => GetValue(ContentProperty);
+            set => SetValue(ContentProperty, value);
+        }
+
         private bool _isFirstBufferActive;
 
         private ContentPresenter _firstBuffer = null!;
@@ -121,6 +129,16 @@ namespace SukiUI.Controls
 
         private CancellationTokenSource _animCancellationToken = new();
 
+        private IDisposable? _contentDisposable;
+
+        protected override void OnLoaded(RoutedEventArgs e)
+        {
+            base.OnLoaded(e);
+            _contentDisposable = this.GetObservable(ContentProperty)
+                .ObserveOn(new AvaloniaSynchronizationContext())
+                .Subscribe(PushContent);
+        }
+
         protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
         {
             base.OnApplyTemplate(e);
@@ -159,6 +177,7 @@ namespace SukiUI.Controls
         {
             base.OnUnloaded(e);
             _disposable?.Dispose();
+            _contentDisposable?.Dispose();
             _animCancellationToken.Dispose();
         }
     }

--- a/SukiUI/Theme/ContextMenuStyle.axaml
+++ b/SukiUI/Theme/ContextMenuStyle.axaml
@@ -12,12 +12,11 @@
         <Setter Property="CornerRadius" Value="{DynamicResource SmallCornerRadius}" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Border Margin="10"
-                        Padding="{TemplateBinding Padding}"
-                        Background="{TemplateBinding Background}"
+                <Border Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
                         BoxShadow="{DynamicResource SukiSwitchShadow}"
+                        ClipToBounds="True"
                         CornerRadius="{TemplateBinding CornerRadius}">
                     <ItemsPresenter Name="PART_ItemsPresenter"
                                     HorizontalAlignment="Left"

--- a/SukiUI/Theme/ContextMenuStyle.axaml
+++ b/SukiUI/Theme/ContextMenuStyle.axaml
@@ -6,11 +6,10 @@
     </Design.PreviewWith>
 
     <Style Selector="ContextMenu">
-        <Setter Property="Background" Value="{DynamicResource SukiBackground}" />
+        <Setter Property="Background" Value="{DynamicResource SukiStrongBackground}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="BorderBrush" Value="{DynamicResource SukiControlBorderBrush}" />
         <Setter Property="CornerRadius" Value="{DynamicResource SmallCornerRadius}" />
-
         <Setter Property="Template">
             <ControlTemplate>
                 <Border Margin="10"
@@ -20,14 +19,11 @@
                         BorderThickness="{TemplateBinding BorderThickness}"
                         BoxShadow="{DynamicResource SukiSwitchShadow}"
                         CornerRadius="{TemplateBinding CornerRadius}">
-                    <ScrollViewer Theme="{StaticResource SimpleMenuScrollViewer}">
-                        <ItemsPresenter Name="PART_ItemsPresenter"
-                                        Margin="-20,0,0,0"
-                                        HorizontalAlignment="Left"
-                                        VerticalAlignment="Center"
-                                        ItemsPanel="{TemplateBinding ItemsPanel}"
-                                        KeyboardNavigation.TabNavigation="Continue" />
-                    </ScrollViewer>
+                    <ItemsPresenter Name="PART_ItemsPresenter"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center"
+                                    ItemsPanel="{TemplateBinding ItemsPanel}"
+                                    KeyboardNavigation.TabNavigation="Continue" />
                 </Border>
             </ControlTemplate>
         </Setter>

--- a/SukiUI/Theme/DataGridStyle.axaml
+++ b/SukiUI/Theme/DataGridStyle.axaml
@@ -56,6 +56,7 @@
         <Style Selector="^.RightAlign">
             <Setter Property="HorizontalContentAlignment" Value="Right" />
             <Setter Property="HorizontalAlignment" Value="Right" />
+            <Setter Property="Margin" Value="0 0 15 0" />
         </Style>
     </Style>
 

--- a/SukiUI/Theme/DataGridStyle.axaml
+++ b/SukiUI/Theme/DataGridStyle.axaml
@@ -20,7 +20,8 @@
     </Design.PreviewWith>
     <Style Selector="DataGridCell">
         <Setter Property="Background" Value="Transparent" />
-        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="HorizontalContentAlignment" Value="Left" />
+        <Setter Property="HorizontalAlignment" Value="Left" />
         <Setter Property="VerticalContentAlignment" Value="Stretch" />
         <Setter Property="FontSize" Value="25" />
         <Setter Property="Template">
@@ -44,6 +45,18 @@
                 </Grid>
             </ControlTemplate>
         </Setter>
+        <Style Selector="^ TextBlock">
+            <Setter Property="TextTrimming" Value="CharacterEllipsis" />
+            <Setter Property="Margin" Value="5 0 0 0" />
+        </Style>
+        <Style Selector="^.CenterAlign">
+            <Setter Property="HorizontalContentAlignment" Value="Center" />
+            <Setter Property="HorizontalAlignment" Value="Center" />
+        </Style>
+        <Style Selector="^.RightAlign">
+            <Setter Property="HorizontalContentAlignment" Value="Right" />
+            <Setter Property="HorizontalAlignment" Value="Right" />
+        </Style>
     </Style>
 
     <Style Selector="DataGridColumnHeader">
@@ -59,12 +72,12 @@
 
         <Setter Property="Template">
             <ControlTemplate>
-                <Border Background="Transparent"
+                <Border Name="PART_Border"
+                        Background="Transparent"
                         BorderBrush="{DynamicResource SukiControlBorderBrush}"
                         BorderThickness="0,0,0,1.5"
                         CornerRadius="0">
                     <Grid ColumnDefinitions="*,Auto">
-
                         <Grid Margin="{TemplateBinding Padding}"
                               HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -72,7 +85,6 @@
                             <ContentPresenter Background="Transparent"
                                               Content="{TemplateBinding Content}"
                                               ContentTemplate="{TemplateBinding ContentTemplate}" />
-
                             <Path Name="SortIcon"
                                   Grid.Column="1"
                                   Width="8"
@@ -89,6 +101,13 @@
                 </Border>
             </ControlTemplate>
         </Setter>
+        <Style Selector="^ TextBlock">
+            <Setter Property="TextTrimming" Value="CharacterEllipsis" />
+        </Style>
+    </Style>
+
+    <Style Selector="DataGrid[CanUserResizeColumns=True] DataGridColumnHeader:not(#PART_TopRightCornerHeader) /template/ Border#PART_Border">
+        <Setter Property="BorderThickness" Value="0,0,1.5,1.5" />
     </Style>
 
     <Style Selector="DataGridColumnHeader:dragIndicator">

--- a/SukiUI/Theme/MenuItemStyle.axaml
+++ b/SukiUI/Theme/MenuItemStyle.axaml
@@ -197,7 +197,7 @@
                                     BorderThickness="1"
                                     BoxShadow="{DynamicResource SukiSwitchShadow}"
                                     ClipToBounds="True"
-                                    CornerRadius="{DynamicResource SmallCornerRadius}">
+                                    CornerRadius="0 0 10 10">
                                 <ScrollViewer Classes="menuscroller">
                                     <ItemsPresenter Name="PART_ItemsPresenter"
                                                     Grid.IsSharedSizeScope="True"
@@ -215,8 +215,7 @@
         <Setter Property="Background" Value="{DynamicResource SukiLightBorderBrush}" />
     </Style>
 
-    <Style Selector="MenuItem /template/ ItemsPresenter#PART_ItemsPresenter">
-    </Style>
+    <Style Selector="MenuItem /template/ ItemsPresenter#PART_ItemsPresenter" />
 
     <Style Selector="MenuItem:selected /template/ Border#root">
         <Setter Property="Background" Value="{DynamicResource SukiLightBorderBrush}" />

--- a/SukiUI/Theme/MenuItemStyle.axaml
+++ b/SukiUI/Theme/MenuItemStyle.axaml
@@ -30,7 +30,7 @@
         <Setter Property="Template">
             <ControlTemplate>
                 <Border Name="root"
-                        Padding="5,5,5,10"
+                        Padding="5,5,20,5"
                         Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
                         ClipToBounds="True">
@@ -216,12 +216,10 @@
     </Style>
 
     <Style Selector="MenuItem /template/ ItemsPresenter#PART_ItemsPresenter">
-        <!-- <Setter Property="Margin" Value="2" /> -->
     </Style>
 
     <Style Selector="MenuItem:selected /template/ Border#root">
         <Setter Property="Background" Value="{DynamicResource SukiLightBorderBrush}" />
-        <!-- <Setter Property="CornerRadius" Value="6" /> -->
         <Setter Property="BorderBrush" Value="{DynamicResource SukiLightBorderBrush}" />
     </Style>
 

--- a/SukiUI/Theme/MenuItemStyle.axaml
+++ b/SukiUI/Theme/MenuItemStyle.axaml
@@ -24,16 +24,16 @@
         <Setter Property="Background" Value="{DynamicResource SukiBackground}" />
         <Setter Property="BorderThickness" Value="1.5" />
         <Setter Property="FontSize" Value="14" />
-        <Setter Property="Margin" Value="5,0" />
+        <Setter Property="Margin" Value="0" />
         <Setter Property="Foreground" Value="{DynamicResource SukiText}" />
 
         <Setter Property="Template">
             <ControlTemplate>
                 <Border Name="root"
+                        Padding="5,5,5,10"
                         Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="{TemplateBinding BorderThickness}"
-                        CornerRadius="{TemplateBinding CornerRadius}">
+                        ClipToBounds="True">
                     <Grid>
                         <StackPanel Orientation="Horizontal">
                             <StackPanel.Styles>
@@ -55,15 +55,14 @@
                             </StackPanel.Styles>
 
                             <ContentPresenter Name="icon"
+                                              Width="25"
+                                              Height="25"
                                               HorizontalAlignment="Center"
                                               VerticalAlignment="Center"
                                               Content="{TemplateBinding Icon}" />
-                            <Path Name="check"
-                                  Margin="3"
-                                  VerticalAlignment="Center"
-                                  Data="F1M10,1.2L4.7,9.1 4.5,9.1 0,5.2 1.3,3.5 4.3,6.1 8.3,0 10,1.2z"
-                                  Fill="{DynamicResource SukiText}"
-                                  IsVisible="False" />
+                            <Rectangle Width="2"
+                                       Margin="5,-1"
+                                       Fill="{DynamicResource SukiLightBorderBrush}" />
                             <ContentPresenter Name="PART_HeaderPresenter"
                                               Margin="4,7,0,7"
                                               HorizontalAlignment="Left"
@@ -93,6 +92,7 @@
                                         BorderBrush="{DynamicResource SukiBorderBrush}"
                                         BorderThickness="1"
                                         BoxShadow="{DynamicResource SukiSwitchShadow}"
+                                        ClipToBounds="True"
                                         CornerRadius="{DynamicResource SmallCornerRadius}">
                                     <ScrollViewer Classes="menuscroller">
                                         <ItemsPresenter Name="PART_ItemsPresenter"
@@ -129,22 +129,19 @@
     </Style>
 
     <Style Selector="Menu &gt; MenuItem">
-        <Setter Property="Padding" Value="10 0" />
         <Setter Property="FontWeight" Value="DemiBold" />
+        <Setter Property="Padding" Value="10 0" />
         <Setter Property="Template">
             <ControlTemplate>
                 <Border Name="root"
-                        Margin="0,6"
                         Background="{TemplateBinding Background}"
                         BorderBrush="{DynamicResource SukiLightBorderBrush}"
                         BorderThickness="0,0,0,0"
                         CornerRadius="{TemplateBinding CornerRadius}">
-
                     <Panel>
                         <Panel.Styles>
-                           
                             <Style Selector="Popup#PART_Popup[IsOpen=true]">
-                               
+
                                 <Style.Animations>
                                     <Animation Easing="CircularEaseOut"
                                                FillMode="Forward"
@@ -153,24 +150,22 @@
                                             <Setter Property="HorizontalOffset" Value="-20" />
                                         </KeyFrame>
                                         <KeyFrame Cue="100%">
-                                           
+
                                             <Setter Property="HorizontalOffset" Value="0" />
                                         </KeyFrame>
                                     </Animation>
                                 </Style.Animations>
                             </Style>
-                            
+
                             <Style Selector="Popup#PART_Popup[IsOpen=true] Border">
-                               
+
                                 <Style.Animations>
-                                    <Animation 
-                                               FillMode="Forward"
-                                               Duration="0:0:0.45">
+                                    <Animation FillMode="Forward" Duration="0:0:0.45">
                                         <KeyFrame Cue="0%">
                                             <Setter Property="Opacity" Value="0" />
                                         </KeyFrame>
                                         <KeyFrame Cue="100%">
-                                            
+
                                             <Setter Property="Opacity" Value="1" />
                                         </KeyFrame>
                                     </Animation>
@@ -188,20 +183,20 @@
                                 </DataTemplate>
                             </ContentPresenter.DataTemplates>
                         </ContentPresenter>
-                        <Popup Name="PART_Popup" Opacity="0"
+                        <Popup Name="PART_Popup"
                                IsLightDismissEnabled="True"
                                IsOpen="{TemplateBinding IsSubMenuOpen,
                                                         Mode=TwoWay}"
+                               Opacity="0"
                                OverlayInputPassThroughElement="{Binding $parent[Menu]}"
                                Placement="BottomEdgeAlignedLeft">
-                            <Popup.Transitions>
-                               
-                            </Popup.Transitions>
-                            <Border Margin="10" Name="PART_Border"
+                            <Popup.Transitions />
+                            <Border Name="PART_Border"
                                     Background="{DynamicResource SukiCardBackground}"
                                     BorderBrush="{DynamicResource SukiBorderBrush}"
                                     BorderThickness="1"
                                     BoxShadow="{DynamicResource SukiSwitchShadow}"
+                                    ClipToBounds="True"
                                     CornerRadius="{DynamicResource SmallCornerRadius}">
                                 <ScrollViewer Classes="menuscroller">
                                     <ItemsPresenter Name="PART_ItemsPresenter"
@@ -221,12 +216,12 @@
     </Style>
 
     <Style Selector="MenuItem /template/ ItemsPresenter#PART_ItemsPresenter">
-        <Setter Property="Margin" Value="2" />
+        <!-- <Setter Property="Margin" Value="2" /> -->
     </Style>
 
     <Style Selector="MenuItem:selected /template/ Border#root">
         <Setter Property="Background" Value="{DynamicResource SukiLightBorderBrush}" />
-        <Setter Property="CornerRadius" Value="6" />
+        <!-- <Setter Property="CornerRadius" Value="6" /> -->
         <Setter Property="BorderBrush" Value="{DynamicResource SukiLightBorderBrush}" />
     </Style>
 

--- a/SukiUI/Theme/TextBoxStyles.xaml
+++ b/SukiUI/Theme/TextBoxStyles.xaml
@@ -343,7 +343,7 @@
         <Setter Property="BorderBrush" Value="{DynamicResource SukiControlBorderBrush}" />
         <Setter Property="CornerRadius" Value="{DynamicResource SmallCornerRadius}" />
         <Setter Property="Background" Value="{DynamicResource SukiBackground}" />
-      
+
 
         <Setter Property="Foreground" Value="{DynamicResource SukiText}" />
         <Setter Property="SelectionBrush" Value="{DynamicResource SukiBorderBrush}" />
@@ -442,6 +442,7 @@
                                         </ScrollViewer>
                                         <theme:TextEraserButton Grid.Column="2"
                                                                 Margin="5,0,0,0"
+                                                                Cursor="Hand"
                                                                 IsVisible="{TemplateBinding theme:TextBoxExtensions.AddDeleteButton}"
                                                                 Opacity="{TemplateBinding Text,
                                                                                           Converter={StaticResource StringToDoubleC}}"


### PR DESCRIPTION
***Changes***
- Made a visible drag handler for `DataGrid` when `CanUserResizeColumns` is set to `True`.
- Left align content by default for `DataGrid`.
  - Add `CenterAlign` and `RightAlign` classes for those who need them.
- Re-added `Content` property to `SukiTransitioningContentControl` so it can be used in MVVM. 
  - I'm currently using the control directly myself in a personal project, was relying on an attached property.
- Re-styled `ContextMenu` and `MenuItems` - Fixes #100 
  - Items now fill up the menu, giving it a much more consistent and clean look.
  - Icon now reserves a fixed amount of space to give Menus a consistent layout as you would expect.
  - `Menu > MenuItem` uses a custom square-topped border to create a feeling of the control being connected to the menu.

***Fixes***
- Very rough fix for `ContextMenu` causing `IsInteractive` GlassCard to be stuck in `pointerdown`.
- Fix the clear button in `TextBox` having a caret instead of a hand pointer.

***Outstanding Issues***
- `ContextMenu` could maybe do with a bit of love when it comes to styling and animation.
- `MenuItem` Icon reservation space could do with being tweaked, and perhaps the look of the separator.
- `TreeView` still a little buggy on first expanding items.
- `SukiTest` should probably be fully deleted at this point (when you have .NET 8 anyway).