### PR TITLE
Enable customization for PropertyGrid 

### DIFF
--- a/SukiUI/Controls/PropertyGrid/CategoryViewModel.cs
+++ b/SukiUI/Controls/PropertyGrid/CategoryViewModel.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace SukiUI.Controls
 {
-    public sealed class CategoryViewModel : SukiObservableObject
+    public class CategoryViewModel : SukiObservableObject
     {
         public string DisplayName { get; }
 

--- a/SukiUI/Controls/PropertyGrid/InstanceViewModel.cs
+++ b/SukiUI/Controls/PropertyGrid/InstanceViewModel.cs
@@ -7,7 +7,7 @@ using System.Reflection;
 
 namespace SukiUI.Controls
 {
-    public sealed class InstanceViewModel : SukiObservableObject, IDisposable
+    public class InstanceViewModel : SukiObservableObject, IDisposable
     {
         public INotifyPropertyChanged ViewModel { get; }
 
@@ -17,6 +17,38 @@ namespace SukiUI.Controls
         {
             ViewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
 
+            Categories = GenerateCategories(viewModel);
+        }
+
+        private static string? GetCategory(PropertyInfo property)
+        {
+            var attributes = property.GetCustomAttributes<CategoryAttribute>(false);
+            if (attributes.Any())
+            {
+                return attributes.First().Category;
+            }
+
+            return null;
+        }
+
+        private static string? GetDisplayName(PropertyInfo property)
+        {
+            var attributes = property.GetCustomAttributes<DisplayNameAttribute>(false);
+            if (attributes.Any())
+            {
+                return attributes.First().DisplayName;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Factory creating all the categories for a given instance of a ViewModel implementing <see cref="INotifyPropertyChanged"/>.
+        /// </summary>
+        /// <param name="viewModel">the ViewModel instance, to generate/show controls/categories for</param>
+        /// <returns>CategoryViewModels holding representations for each public non static property</returns>
+        public virtual IAvaloniaReadOnlyList<CategoryViewModel> GenerateCategories(INotifyPropertyChanged viewModel)
+        {
             var properties = viewModel
                 .GetType()
                 .GetProperties(BindingFlags.Public | BindingFlags.Instance)
@@ -97,29 +129,7 @@ namespace SukiUI.Controls
                 categoryViewModels.Add(categoryViewModel);
             }
 
-            Categories = categoryViewModels;
-        }
-
-        private static string? GetCategory(PropertyInfo property)
-        {
-            var attributes = property.GetCustomAttributes<CategoryAttribute>(false);
-            if (attributes.Any())
-            {
-                return attributes.First().Category;
-            }
-
-            return null;
-        }
-
-        private static string? GetDisplayName(PropertyInfo property)
-        {
-            var attributes = property.GetCustomAttributes<DisplayNameAttribute>(false);
-            if (attributes.Any())
-            {
-                return attributes.First().DisplayName;
-            }
-
-            return null;
+            return categoryViewModels;
         }
 
         public void Dispose()


### PR DESCRIPTION
**_Changes:_**

- makes subclassing of the required types for the PropertyGrid possible
- solves #112 

**_Customization Workflow for PropertyGrid_**

- subclass or wrap ``PropertyGridTemplateSelector`` in your own type
  - has to be a ``ResourceDictionary``
  - has to implement ``IDataTemplate``
  - should contain DataTemplates for each custom type you want to show in the PropertyGrid e.g.:
 ```xml
<DataTemplate x:Key="SomeNewTypeViewModel" DataType="yourNameSpace:SomeNewTypeViewModel" />
```
  - assign your new ``PropertyGridTemplateSelector`` like [here](https://github.com/Insire/SukiUI/blob/main/SukiUI.Demo/Features/ControlsLibrary/PropertyGridView.axaml#L27)
  - subclass ``InstanceViewModel`` and override ``GenerateCategories`` to provide your own logic for generating ``CategoryViewModel``s
