### PR TITLE
Fix a couple simple issues.

### DIFF
--- a/SukiUI.Demo/Converters/BoolToIconConverter.cs
+++ b/SukiUI.Demo/Converters/BoolToIconConverter.cs
@@ -5,14 +5,19 @@ using Material.Icons;
 
 namespace SukiUI.Demo.Converters
 {
-    public class AnimationBoolToIconKindConverter : IValueConverter
+    public static class BoolToIconConverters
     {
-        public static AnimationBoolToIconKindConverter Instance { get; } = new();
-        
+        public static readonly BoolToIconConverter Animation = new(MaterialIconKind.Pause, MaterialIconKind.Play);
+        public static readonly BoolToIconConverter WindowLock = new(MaterialIconKind.Unlocked, MaterialIconKind.Lock);
+    }
+
+    public class BoolToIconConverter(MaterialIconKind trueIcon, MaterialIconKind falseIcon) : IValueConverter
+    {
+
         public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
             if (value is not bool b) return null;
-            return b ? MaterialIconKind.Pause : MaterialIconKind.Play;
+            return b ? trueIcon : falseIcon;
         }
 
         public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)

--- a/SukiUI.Demo/SukiUIDemoView.axaml
+++ b/SukiUI.Demo/SukiUIDemoView.axaml
@@ -25,6 +25,7 @@
                                Foreground="{DynamicResource SukiPrimaryColor}"
                                Kind="Dog" />
     </suki:SukiWindow.LogoContent>
+
     <suki:SukiWindow.MenuItems>
         <MenuItem Header="Toggles">
             <MenuItem Command="{Binding ToggleBaseThemeCommand}" Header="{Binding BaseTheme}">

--- a/SukiUI.Demo/SukiUIDemoView.axaml
+++ b/SukiUI.Demo/SukiUIDemoView.axaml
@@ -13,6 +13,9 @@
                  d:DesignWidth="800"
                  x:DataType="demo:SukiUIDemoViewModel"
                  BackgroundAnimationEnabled="{Binding AnimationsEnabled}"
+                 CanMinimize="{Binding !WindowLocked}"
+                 CanMove="{Binding !WindowLocked}"
+                 CanResize="{Binding !WindowLocked}"
                  IsMenuVisible="True"
                  mc:Ignorable="d">
     <suki:SukiWindow.LogoContent>
@@ -31,7 +34,14 @@
             </MenuItem>
             <MenuItem Command="{Binding ToggleAnimationsCommand}" Header="Animations">
                 <MenuItem.Icon>
-                    <avalonia:MaterialIcon Kind="{Binding AnimationsEnabled, Converter={x:Static converters:AnimationBoolToIconKindConverter.Instance}}" />
+                    <avalonia:MaterialIcon Kind="{Binding AnimationsEnabled, Converter={x:Static converters:BoolToIconConverters.Animation}}" />
+                </MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Command="{Binding ToggleWindowLockCommand}"
+                      Header="Window Lock"
+                      ToolTip.Tip="Toggles minimizing and resizing.">
+                <MenuItem.Icon>
+                    <avalonia:MaterialIcon Kind="{Binding WindowLocked, Converter={x:Static converters:BoolToIconConverters.WindowLock}}" />
                 </MenuItem.Icon>
             </MenuItem>
         </MenuItem>

--- a/SukiUI.Demo/SukiUIDemoView.axaml.cs
+++ b/SukiUI.Demo/SukiUIDemoView.axaml.cs
@@ -34,7 +34,5 @@ public partial class SukiUIDemoView : SukiWindow
     private void InputElement_OnPointerPressed(object? sender, PointerPressedEventArgs e)
     {
         IsMenuVisible = !IsMenuVisible;
-        var win = new SukiWindow();
-        win.Show();
     }
 }

--- a/SukiUI.Demo/SukiUIDemoView.axaml.cs
+++ b/SukiUI.Demo/SukiUIDemoView.axaml.cs
@@ -34,5 +34,6 @@ public partial class SukiUIDemoView : SukiWindow
     private void InputElement_OnPointerPressed(object? sender, PointerPressedEventArgs e)
     {
         IsMenuVisible = !IsMenuVisible;
+        new SukiWindow().Show();
     }
 }

--- a/SukiUI.Demo/SukiUIDemoView.axaml.cs
+++ b/SukiUI.Demo/SukiUIDemoView.axaml.cs
@@ -34,6 +34,7 @@ public partial class SukiUIDemoView : SukiWindow
     private void InputElement_OnPointerPressed(object? sender, PointerPressedEventArgs e)
     {
         IsMenuVisible = !IsMenuVisible;
-        new SukiWindow().Show();
+        var win = new SukiWindow();
+        win.Show();
     }
 }

--- a/SukiUI.Demo/SukiUIDemoViewModel.cs
+++ b/SukiUI.Demo/SukiUIDemoViewModel.cs
@@ -23,6 +23,7 @@ public partial class SukiUIDemoViewModel : ObservableObject
     [ObservableProperty] private ThemeVariant _baseTheme;
     [ObservableProperty] private bool _animationsEnabled;
     [ObservableProperty] private DemoPageBase? _activePage;
+    [ObservableProperty] private bool _windowLocked = false;
 
     private readonly SukiTheme _theme;
 
@@ -68,11 +69,18 @@ public partial class SukiUIDemoViewModel : ObservableObject
         _theme.ChangeColorTheme(theme);
 
     [RelayCommand]
-    private void CreateCustomTheme()
-    {
+    private void CreateCustomTheme() => 
         SukiHost.ShowDialog(new CustomThemeDialogViewModel(_theme), allowBackgroundClose: true);
-    }
 
+    [RelayCommand]
+    private void ToggleWindowLock()
+    {
+        WindowLocked = !WindowLocked;
+        SukiHost.ShowToast(
+            $"Window {(WindowLocked ? "Locked" : "Unlocked")}", 
+            $"Window has been {(WindowLocked ? "locked" : "unlocked")}.");
+    }
+    
     [RelayCommand]
     private void OpenURL(string url) => UrlUtilities.OpenURL(url);
 }

--- a/SukiUI/Controls/SukiHost.axaml
+++ b/SukiUI/Controls/SukiHost.axaml
@@ -1,58 +1,56 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:suki="clr-namespace:SukiUI.Controls">
-    <ControlTheme
-        TargetType="suki:SukiHost"
-        x:Key="SukiHostTheme">
+    <ControlTheme x:Key="SukiHostTheme" TargetType="suki:SukiHost">
         <Setter Property="Template">
             <ControlTemplate>
                 <Grid>
                     <Grid Name="PART_ContentContainer">
-                        <ContentControl Content="{TemplateBinding Content}" />
+                        <ContentPresenter Content="{TemplateBinding Content}" />
                     </Grid>
-                    
+
                     <ItemsControl Name="PART_ToastPresenter"
+                                  Margin="5,5"
+                                  HorizontalAlignment="Stretch"
                                   VerticalAlignment="Bottom"
-                                  HorizontalAlignment="Stretch" 
-                                  Margin="5,5" 
                                   ItemsSource="{TemplateBinding ToastsCollection}">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
-                                <DockPanel LastChildFill="True"   VerticalAlignment="Bottom" />
+                                <DockPanel VerticalAlignment="Bottom" LastChildFill="True" />
                             </ItemsPanelTemplate>
                         </ItemsControl.ItemsPanel>
                     </ItemsControl>
-                    
-                    <Border
-                        Name="PART_DialogBackground"
-                        IsHitTestVisible="False" Opacity="0"
-                        HorizontalAlignment="Stretch"
-                        VerticalAlignment="Stretch"
-                        Background="{DynamicResource SukiDialogBackground}" >
+
+                    <Border Name="PART_DialogBackground"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Stretch"
+                            Background="{DynamicResource SukiDialogBackground}"
+                            IsHitTestVisible="False"
+                            Opacity="0">
                         <Border.Transitions>
                             <Transitions>
-                                <DoubleTransition Property="Opacity" Duration="0:0:0.4"></DoubleTransition>
+                                <DoubleTransition Property="Opacity" Duration="0:0:0.4" />
                             </Transitions>
                         </Border.Transitions>
                     </Border>
 
-                    <Border Background="{DynamicResource SukiBackground}"
+                    <Border Name="borderDialog"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Background="{DynamicResource SukiBackground}"
                             Classes.opened="False"
                             CornerRadius="15"
-                            HorizontalAlignment="Center"
                             IsHitTestVisible="False"
-                            Name="borderDialog"
-                            Opacity="0"
-                            VerticalAlignment="Center">
+                            Opacity="0">
                         <Border.Transitions>
                             <Transitions>
-                                <ThicknessTransition Duration="0:0:0.25" Property="Margin">
+                                <ThicknessTransition Property="Margin" Duration="0:0:0.25">
                                     <ThicknessTransition.Easing>
                                         <CircularEaseOut />
                                     </ThicknessTransition.Easing>
                                 </ThicknessTransition>
-                                <DoubleTransition Duration="0:0:0.15" Property="Opacity" />
-                                <TransformOperationsTransition Duration="0:0:0.25" Property="RenderTransform">
+                                <DoubleTransition Property="Opacity" Duration="0:0:0.15" />
+                                <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.25">
                                     <TransformOperationsTransition.Easing>
                                         <CircularEaseOut />
                                     </TransformOperationsTransition.Easing>
@@ -61,9 +59,10 @@
                         </Border.Transitions>
 
                         <Grid>
-                            <Border Name="BorderDialog1" Classes="Card"
-                                    Background="{DynamicResource SukiCardBackground}" />
-                            <ContentControl Content="{TemplateBinding DialogContent}" Margin="20" />
+                            <Border Name="BorderDialog1"
+                                    Background="{DynamicResource SukiCardBackground}"
+                                    Classes="Card" />
+                            <ContentPresenter Margin="20" Content="{TemplateBinding DialogContent}" />
                         </Grid>
                     </Border>
 
@@ -71,13 +70,13 @@
                         <Style Selector="suki|SukiHost[IsDialogOpen=True]">
 
                             <Style Selector="^ Border#PART_DialogBackground">
-                                <Setter Property="Opacity" Value="0.4"></Setter>
+                                <Setter Property="Opacity" Value="0.4" />
                                 <Setter Property="IsHitTestVisible" Value="True" />
                             </Style>
 
                             <Style Selector="^ Grid#PART_ContentContainer">
                                 <Setter Property="IsHitTestVisible" Value="False" />
-                                <!-- Please do not remove this empty blur -->
+                                <!--  Please do not remove this empty blur  -->
                                 <Style.Animations>
                                     <Animation FillMode="Forward" Duration="0:0:0.5">
                                         <KeyFrame Cue="0%">
@@ -88,7 +87,7 @@
                                         </KeyFrame>
                                     </Animation>
                                 </Style.Animations>
-                             
+
                             </Style>
 
                             <Style Selector="^ Border#borderDialog">
@@ -103,13 +102,13 @@
                         <Style Selector="suki|SukiHost[IsDialogOpen=False]">
 
                             <Style Selector="^ Border#PART_DialogBackground">
-                                <Setter Property="Opacity" Value="0"></Setter>
+                                <Setter Property="Opacity" Value="0" />
                                 <Setter Property="IsHitTestVisible" Value="False" />
                             </Style>
 
                             <Style Selector="^ Grid#PART_ContentContainer">
                                 <Setter Property="IsHitTestVisible" Value="True" />
-                                <!-- Please do not remove this empty blur -->
+                                <!--  Please do not remove this empty blur  -->
                                 <Style.Animations>
                                     <Animation FillMode="Forward" Duration="0:0:0.5">
                                         <KeyFrame Cue="0%">
@@ -130,13 +129,12 @@
                             </Style>
                         </Style>
                     </Grid.Styles>
-                    
+
                 </Grid>
             </ControlTemplate>
         </Setter>
     </ControlTheme>
-    <ControlTheme
-        TargetType="suki:SukiHost"
-        x:Key="{x:Type suki:SukiHost}"
-        BasedOn="{StaticResource SukiHostTheme}" />
+    <ControlTheme x:Key="{x:Type suki:SukiHost}"
+                  BasedOn="{StaticResource SukiHostTheme}"
+                  TargetType="suki:SukiHost" />
 </ResourceDictionary>

--- a/SukiUI/Controls/SukiHost.axaml.cs
+++ b/SukiUI/Controls/SukiHost.axaml.cs
@@ -66,11 +66,10 @@ public class SukiHost : ContentControl
     public static void SetToastLimit(Control element, int value) =>
         element.SetValue(ToastLimitProperty, value);
 
-    public static readonly StyledProperty<AvaloniaList<SukiToast>> ToastsCollectionProperty =
-        AvaloniaProperty.Register<SukiHost, AvaloniaList<SukiToast>>(nameof(ToastsCollection),
-            defaultValue: new AvaloniaList<SukiToast>());
+    public static readonly StyledProperty<AvaloniaList<SukiToast>?> ToastsCollectionProperty =
+        AvaloniaProperty.Register<SukiHost, AvaloniaList<SukiToast>?>(nameof(ToastsCollection));
 
-    public AvaloniaList<SukiToast> ToastsCollection
+    public AvaloniaList<SukiToast>? ToastsCollection
     {
         get => GetValue(ToastsCollectionProperty);
         set => SetValue(ToastsCollectionProperty, value);
@@ -92,6 +91,7 @@ public class SukiHost : ContentControl
         base.OnApplyTemplate(e);
         if (VisualRoot is not Window window)
             throw new InvalidOperationException("SukiHost must be hosted inside a Window or SukiWindow");
+        ToastsCollection ??= new AvaloniaList<SukiToast>();
         _maxToasts = GetToastLimit(window);
         var toastLoc = GetToastLocation(window);
 

--- a/SukiUI/Controls/SukiHost.axaml.cs
+++ b/SukiUI/Controls/SukiHost.axaml.cs
@@ -31,7 +31,7 @@ public class SukiHost : ContentControl
     }
 
     public static readonly StyledProperty<Control> DialogContentProperty =
-        AvaloniaProperty.Register<SukiHost, Control>(nameof(DialogContent), defaultValue: new Grid());
+        AvaloniaProperty.Register<SukiHost, Control>(nameof(DialogContent));
 
     public Control DialogContent
     {
@@ -101,27 +101,6 @@ public class SukiHost : ContentControl
             toastLoc == ToastLocation.BottomLeft
                 ? HorizontalAlignment.Left
                 : HorizontalAlignment.Right;
-
-        /*  CompositionVisual compositionVisual =
-              ElementComposition.GetElementVisual(e.NameScope.Get<ItemsControl>("PART_ToastPresenter"));
-          Compositor compositor = compositionVisual.Compositor;
-
-          var animationGroup = compositor.CreateAnimationGroup();
-          Vector3KeyFrameAnimation offsetAnimation = compositor.CreateVector3KeyFrameAnimation();
-          offsetAnimation.Target = "Offset";
-
-          offsetAnimation.InsertExpressionKeyFrame(1.0f, "this.FinalValue");
-          offsetAnimation.Duration = TimeSpan.FromMilliseconds(300);
-
-          ImplicitAnimationCollection implicitAnimationCollection = compositor.CreateImplicitAnimationCollection();
-          animationGroup.Add(offsetAnimation);
-          implicitAnimationCollection["Offset"] = animationGroup;
-          compositionVisual.ImplicitAnimations = implicitAnimationCollection; */
-
-        // Using implicit animation for the itemscontrol make the first appearance not visible - avalonia problem ?
-        // Showing a quick toast at startup to prevent problem even if it is dirty right now, hope it can be removed
-
-        // ShowInvisibleToast();
     }
 
     // TODO: Dialog API desperately needs to support a result or on-close callback.
@@ -233,32 +212,5 @@ public class SukiHost : ContentControl
         if (_instance is null)
             throw new InvalidOperationException("SukiHost must be active somewhere in the VisualTree");
         return _instance;
-    }
-
-    // Horrible dirty workaround for annoying implicit animation issue
-    internal static void ShowInvisibleToast()
-    {
-        var toast = new SukiToast();
-        toast.InitializeInvisible();
-        Dispatcher.UIThread.Invoke(() =>
-        {
-            toast.Animate(MarginProperty, new Thickness(), new Thickness(0, 50, 0, -50),
-                TimeSpan.FromMilliseconds(1));
-            Instance.ToastsCollection.Add(toast);
-        });
-    }
-
-    // Clearing up the horrible dirty workaround for annoying implicit animation issue
-    internal static async Task ClearInvisibleToast(SukiToast toast)
-    {
-        Dispatcher.UIThread.Invoke(() =>
-        {
-            toast.Animate(MarginProperty, new Thickness(), new Thickness(0, 50, 0, -50),
-                TimeSpan.FromMilliseconds(1));
-        });
-
-        await Task.Delay(1);
-
-        Dispatcher.UIThread.Invoke(() => Instance.ToastsCollection.Remove(toast));
     }
 }

--- a/SukiUI/Controls/SukiHost.axaml.cs
+++ b/SukiUI/Controls/SukiHost.axaml.cs
@@ -83,7 +83,7 @@ public class SukiHost : ContentControl
     protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
     {
         base.OnAttachedToVisualTree(e);
-        _instance = this;
+        _instance ??= this;
     }
 
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)

--- a/SukiUI/Controls/SukiSideMenu.axaml
+++ b/SukiUI/Controls/SukiSideMenu.axaml
@@ -64,7 +64,7 @@
                                     <Grid MinHeight="{TemplateBinding HeaderMinHeight}"
                                           DockPanel.Dock="Top"
                                           IsVisible="{TemplateBinding IsMenuExpanded}">
-                                        <ContentControl Content="{TemplateBinding HeaderContent}" />
+                                        <ContentPresenter Content="{TemplateBinding HeaderContent}" />
                                     </Grid>
 
                                     <!--  Used to move menu icons down when sidebar is closed  -->
@@ -86,8 +86,9 @@
                                                   IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"
                                                   VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
                                                   VerticalSnapPointsType="{TemplateBinding (ScrollViewer.VerticalSnapPointsType)}">
-                                        <ItemsPresenter theme:ItemsPresenterExtensions.AnimatedScroll="True" Name="PART_ItemsPresenter"
+                                        <ItemsPresenter Name="PART_ItemsPresenter"
                                                         Margin="{TemplateBinding Padding}"
+                                                        theme:ItemsPresenterExtensions.AnimatedScroll="True"
                                                         ItemsPanel="{TemplateBinding ItemsPanel}" />
                                     </ScrollViewer>
                                 </DockPanel>

--- a/SukiUI/Controls/SukiToast.axaml.cs
+++ b/SukiUI/Controls/SukiToast.axaml.cs
@@ -59,15 +59,4 @@ public class SukiToast : ContentControl
         _timer.Start();
         DockPanel.SetDock(this, Dock.Bottom);
     }
-
-    internal void InitializeInvisible()
-    {
-        Title = "Invisible";
-        Content = "Invisible Content";
-        Opacity = 0;
-        _timer.Interval = 5;
-        _timer.Elapsed -= TimerOnElapsed;
-        _timer.Elapsed += async (_, _) => await SukiHost.ClearInvisibleToast(this);
-        _timer.Start();
-    }
 }

--- a/SukiUI/Controls/SukiWindow.axaml
+++ b/SukiUI/Controls/SukiWindow.axaml
@@ -11,15 +11,11 @@
             <ControlTemplate>
                 <Grid>
                     <Grid IsHitTestVisible="True">
-                        <VisualLayerManager IsHitTestVisible="True">
+                        <VisualLayerManager Name="PART_VisualLayerManager" IsHitTestVisible="True">
                             <suki:SukiHost>
                                 <Grid x:Name="PART_Root">
-
                                     <suki:SukiBackground Name="PART_Background" IsHitTestVisible="False" />
-
-
                                     <DockPanel LastChildFill="True">
-
                                         <Grid DockPanel.Dock="Top">
                                             <Grid.Styles>
                                                 <Style Selector="suki|SukiWindow[ShowBottomBorder=True] /template/ Border#PART_BottomBorder">
@@ -34,7 +30,6 @@
                                                             CornerRadius="0" />
                                             <StackPanel>
                                                 <Grid>
-
                                                     <DockPanel Margin="12,9" LastChildFill="True">
                                                         <StackPanel VerticalAlignment="Center"
                                                                     DockPanel.Dock="Right"
@@ -64,14 +59,13 @@
                                                                           Data="{x:Static icons:Icons.WindowMinimize}" />
                                                             </Button>
                                                         </StackPanel>
-
                                                         <StackPanel VerticalAlignment="Center"
                                                                     IsHitTestVisible="False"
                                                                     Orientation="Horizontal"
                                                                     Spacing="10">
-                                                            <ContentControl HorizontalAlignment="Left"
-                                                                            Content="{TemplateBinding LogoContent}"
-                                                                            IsHitTestVisible="False" />
+                                                            <ContentPresenter HorizontalAlignment="Left"
+                                                                              Content="{TemplateBinding LogoContent}"
+                                                                              IsHitTestVisible="False" />
                                                             <TextBlock VerticalAlignment="Center"
                                                                        FontSize="{TemplateBinding TitleFontSize}"
                                                                        FontWeight="{TemplateBinding TitleFontWeight}"
@@ -79,13 +73,11 @@
                                                                        Text="{TemplateBinding Title}" />
                                                         </StackPanel>
                                                     </DockPanel>
-
                                                 </Grid>
                                                 <Menu IsEnabled="{TemplateBinding IsMenuVisible}" ItemsSource="{TemplateBinding MenuItems}" />
                                                 <Border Name="PART_BottomBorder" BorderBrush="{DynamicResource SukiBorderBrush}" />
                                             </StackPanel>
                                         </Grid>
-
                                         <ContentPresenter x:Name="PART_ContentPresenter"
                                                           HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                           VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -104,7 +96,10 @@
         <Style Selector="^[WindowState=Maximized] /template/ PathIcon#MaximizeIcon">
             <Setter Property="Data" Value="{x:Static icons:Icons.WindowRestore}" />
         </Style>
-
+        <!--  Necessary to offset Windows' behaviour with windows that have no system borders.  -->
+        <Style Selector="^[WindowState=Maximized] /template/ VisualLayerManager#PART_VisualLayerManager">
+            <Setter Property="Padding" Value="{OnPlatform '0', Windows='8', x:TypeArguments=Thickness}" />
+        </Style>
         <Style Selector="^[WindowState=Normal] /template/ PathIcon#MaximizeIcon">
             <Setter Property="Data" Value="{x:Static icons:Icons.WindowMaximize}" />
         </Style>

--- a/SukiUI/Controls/SukiWindow.axaml
+++ b/SukiUI/Controls/SukiWindow.axaml
@@ -52,13 +52,13 @@
                                                             </Button>
                                                             <Button Name="PART_MaximizeButton"
                                                                     Classes="Basic Rounded WindowControlsButton"
-                                                                    IsVisible="{TemplateBinding IsMaximizeButtonEnabled}">
+                                                                    IsVisible="{TemplateBinding CanResize}">
                                                                 <PathIcon x:Name="MaximizeIcon" Data="{x:Static icons:Icons.WindowMaximize}" />
                                                             </Button>
                                                             <Button Name="PART_MinimizeButton"
                                                                     VerticalContentAlignment="Bottom"
                                                                     Classes="Basic Rounded WindowControlsButton"
-                                                                    IsVisible="{TemplateBinding IsMinimizeButtonEnabled}">
+                                                                    IsVisible="{TemplateBinding CanMinimize}">
                                                                 <PathIcon Margin="0,0,0,4"
                                                                           VerticalAlignment="Bottom"
                                                                           Data="{x:Static icons:Icons.WindowMinimize}" />

--- a/SukiUI/Controls/SukiWindow.axaml.cs
+++ b/SukiUI/Controls/SukiWindow.axaml.cs
@@ -3,14 +3,10 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Media;
-using Avalonia.Styling;
 using Avalonia.Threading;
 using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
-using System.Runtime.InteropServices;
-using Avalonia.Data;
-using Avalonia.Data.Converters;
 using Avalonia.Interactivity;
 
 namespace SukiUI.Controls;
@@ -109,18 +105,6 @@ public class SukiWindow : Window
     {
         base.OnApplyTemplate(e);
 
-        // Apply a style only on windows to offset oversizing.
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            var maxStyle = new Style(
-                x => x.OfType<SukiWindow>()
-                    .PropertyEquals(WindowStateProperty, WindowState.Maximized)
-                    .Template()
-                    .OfType<VisualLayerManager>());
-            maxStyle.Setters.Add(new Setter(PaddingProperty, new Thickness(8)));
-            Application.Current!.Styles.Add(maxStyle);
-        }
-
         // Create handlers for buttons
         if (e.NameScope.Find<Button>("PART_MaximizeButton") is { } maximize)
         {
@@ -132,8 +116,7 @@ public class SukiWindow : Window
                     : WindowState.Maximized;
             };
         }
-
-
+        
         if (e.NameScope.Find<Button>("PART_MinimizeButton") is { } minimize)
             minimize.Click += (_, _) => WindowState = WindowState.Minimized;
 

--- a/SukiUI/Theme/DatePicker.axaml
+++ b/SukiUI/Theme/DatePicker.axaml
@@ -246,10 +246,10 @@
                                     <PathIcon Width="13"
                                               Height="13"
                                               Data="{x:Static icons:Icons.Check}"
-                                              Foreground="White" />
+                                              Foreground="{DynamicResource SukiText}" />
                                     <TextBlock Margin="8,0,0,0"
                                                FontWeight="DemiBold"
-                                               Foreground="White"
+                                               Foreground="{DynamicResource SukiText}"
                                                Text="Apply" />
                                 </StackPanel>
                             </Button>


### PR DESCRIPTION
***Fixes***
- DatePicker apply button colors now correctly set - Fixes #111 
- Simplify window controls to use `CanResize`, `CanMove` and `CanMinimize` properties. - Fixes #114 
- Clean up some awkward code that caused windows to share controls, can now open any number of `SukiWindow`, it doesn't behave perfectly but it works. - Fixes #115  
- Apply the windows-only window padding fix via a XAML `OnPlatform` style instead of the horrible mess I wrote in C#

***Outstanding Issues***
- Window can still be minimized via the OS, for example clicking on the app in the Taskbar on Win10 will of course minimise it, don't think there's much we can do about that one across all platforms.
- Toasts and Dialogs are not localised to any specific window and simply attach to the first window the app opens, this would need a pretty major API change to account for separate windows.
- The background is shared between windows as is it's animation state, this may or may not be desirable but this would also need another major API change.