### PR TITLE
Side menu scroller improvements.

### DIFF
--- a/SukiUI/Controls/SukiSideMenu.axaml
+++ b/SukiUI/Controls/SukiSideMenu.axaml
@@ -65,7 +65,6 @@
                                                             Margin="{TemplateBinding Padding}"
                                                             theme:ItemsPresenterExtensions.AnimatedScroll="True"
                                                             ItemsPanel="{TemplateBinding ItemsPanel}" />
-                                            <!-- <Border Height="70" /> -->
                                         </StackPanel>
                                     </ScrollViewer>
                                 </DockPanel>

--- a/SukiUI/Controls/SukiSideMenu.axaml
+++ b/SukiUI/Controls/SukiSideMenu.axaml
@@ -81,8 +81,8 @@
                 </SplitView>
             </ControlTemplate>
         </Setter>
-        <Style Selector="^[IsMenuExpanded=True] /template/ PathIcon#PART_ExpandIcon">
-            <Setter Property="RenderTransform" Value="rotate(180deg)" />
+        <Style Selector="^[IsMenuExpanded=False] /template/ PathIcon#PART_ExpandIcon">
+            <Setter Property="RenderTransform" Value="rotate(-180deg)" />
         </Style>
     </ControlTheme>
     <ControlTheme x:Key="{x:Type suki:SukiSideMenu}"

--- a/SukiUI/Controls/SukiSideMenu.axaml
+++ b/SukiUI/Controls/SukiSideMenu.axaml
@@ -65,7 +65,7 @@
                                                             Margin="{TemplateBinding Padding}"
                                                             theme:ItemsPresenterExtensions.AnimatedScroll="True"
                                                             ItemsPanel="{TemplateBinding ItemsPanel}" />
-                                            <Border Height="70" />
+                                            <!-- <Border Height="70" /> -->
                                         </StackPanel>
                                     </ScrollViewer>
                                 </DockPanel>

--- a/SukiUI/Controls/SukiSideMenu.axaml
+++ b/SukiUI/Controls/SukiSideMenu.axaml
@@ -5,7 +5,7 @@
                     xmlns:sukiUi="clr-namespace:SukiUI"
                     xmlns:theme="clr-namespace:SukiUI.Theme">
     <ControlTheme x:Key="SukiSideMenuStyle" TargetType="suki:SukiSideMenu">
-        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"></Setter>
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
         <Setter Property="Template">
             <ControlTemplate>
                 <SplitView DisplayMode="CompactInline"
@@ -17,66 +17,55 @@
                                 <suki:GlassCard Name="Glass"
                                                 BorderThickness="0"
                                                 CornerRadius="0" />
-
-                             
-
                                 <DockPanel>
-                                    <!--  This sidebar toggle button can't be overlapped by header content  -->
                                     <Button Name="PART_SidebarToggleButton"
                                             Margin="7"
                                             HorizontalAlignment="Right"
                                             VerticalAlignment="Top"
                                             Classes="Basic"
-                                            DockPanel.Dock="Top"
-                                         >
+                                            DockPanel.Dock="Top">
                                         <Grid>
-                                            <PathIcon Width="12"
+                                            <PathIcon Name="PART_ExpandIcon"
+                                                      Width="12"
                                                       Height="12"
                                                       Data="{x:Static content:Icons.ChevronLeft}"
-                                                      Foreground="{DynamicResource SukiText}"
-                                                      IsVisible="{TemplateBinding IsMenuExpanded}" />
-                                            <PathIcon Width="12"
-                                                      Height="12"
-                                                      Data="{x:Static content:Icons.ChevronRight}"
-                                                      Foreground="{DynamicResource SukiText}"
-                                                      IsVisible="{Binding !IsMenuExpanded, RelativeSource={RelativeSource TemplatedParent}}" />
+                                                      Foreground="{DynamicResource SukiText}">
+                                                <PathIcon.Transitions>
+                                                    <Transitions>
+                                                        <TransformOperationsTransition Property="RenderTransform" Duration="{StaticResource MediumAnimationDuration}" />
+                                                    </Transitions>
+                                                </PathIcon.Transitions>
+                                            </PathIcon>
                                         </Grid>
                                     </Button>
-
                                     <Grid MinHeight="{TemplateBinding HeaderMinHeight}"
                                           DockPanel.Dock="Top"
                                           IsVisible="{TemplateBinding IsMenuExpanded}">
                                         <ContentPresenter Content="{TemplateBinding HeaderContent}" />
                                     </Grid>
-
-                                    <!--  Used to move menu icons down when sidebar is closed  -->
-                                
-
                                     <ContentControl Margin="0,0,0,12"
                                                     Content="{TemplateBinding FooterContent}"
                                                     DockPanel.Dock="Bottom"
                                                     IsVisible="{TemplateBinding IsMenuExpanded}" />
-                                    
-                                    <Grid Name="PART_Spacer" 
+                                    <Grid Name="PART_Spacer"
                                           Height="15"
                                           DockPanel.Dock="Top" />
-                                  
-
-                                    <ScrollViewer Name="PART_ScrollViewer" Classes="Stack"
+                                    <ScrollViewer Name="PART_ScrollViewer"
                                                   AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}"
                                                   Background="{TemplateBinding Background}"
                                                   BringIntoViewOnFocusChange="{TemplateBinding (ScrollViewer.BringIntoViewOnFocusChange)}"
+                                                  Classes="Stack"
                                                   HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
                                                   HorizontalSnapPointsType="{TemplateBinding (ScrollViewer.HorizontalSnapPointsType)}"
                                                   IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"
                                                   VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
                                                   VerticalSnapPointsType="{TemplateBinding (ScrollViewer.VerticalSnapPointsType)}">
                                         <StackPanel theme:StackPanelExtensions.AnimatedScroll="True">
-                                        <ItemsPresenter Name="PART_ItemsPresenter"
-                                                        Margin="{TemplateBinding Padding}"
-                                                        theme:ItemsPresenterExtensions.AnimatedScroll="True"
-                                                        ItemsPanel="{TemplateBinding ItemsPanel}" />
-                                        <Border Height="70"></Border>
+                                            <ItemsPresenter Name="PART_ItemsPresenter"
+                                                            Margin="{TemplateBinding Padding}"
+                                                            theme:ItemsPresenterExtensions.AnimatedScroll="True"
+                                                            ItemsPanel="{TemplateBinding ItemsPanel}" />
+                                            <Border Height="70" />
                                         </StackPanel>
                                     </ScrollViewer>
                                 </DockPanel>
@@ -93,6 +82,9 @@
                 </SplitView>
             </ControlTemplate>
         </Setter>
+        <Style Selector="^[IsMenuExpanded=True] /template/ PathIcon#PART_ExpandIcon">
+            <Setter Property="RenderTransform" Value="rotate(180deg)" />
+        </Style>
     </ControlTheme>
     <ControlTheme x:Key="{x:Type suki:SukiSideMenu}"
                   BasedOn="{StaticResource SukiSideMenuStyle}"

--- a/SukiUI/Controls/SukiWindow.axaml.cs
+++ b/SukiUI/Controls/SukiWindow.axaml.cs
@@ -5,12 +5,10 @@ using Avalonia.Input;
 using Avalonia.Media;
 using Avalonia.Threading;
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Reactive;
 using System.Reactive.Linq;
 using Avalonia.Collections;
-using Avalonia.Data;
+using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Interactivity;
 
 namespace SukiUI.Controls;
@@ -38,10 +36,10 @@ public class SukiWindow : Window
         set => SetValue(TitleFontWeightProperty, value);
     }
 
-    public static readonly StyledProperty<Control> LogoContentProperty =
-        AvaloniaProperty.Register<SukiWindow, Control>(nameof(LogoContent));
+    public static readonly StyledProperty<Control?> LogoContentProperty =
+        AvaloniaProperty.Register<SukiWindow, Control?>(nameof(LogoContent));
 
-    public Control LogoContent
+    public Control? LogoContent
     {
         get => GetValue(LogoContentProperty);
         set => SetValue(LogoContentProperty, value);
@@ -107,6 +105,19 @@ public class SukiWindow : Window
     }
     
     private IDisposable? _subscriptionDisposables;
+
+    protected override void OnLoaded(RoutedEventArgs e)
+    {
+        base.OnLoaded(e);
+        if (Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop) 
+            return;
+        if (desktop.MainWindow is SukiWindow s && s != this)
+        {
+            if (Icon == null) Icon = s.Icon;
+            // This would be nice to do, but obviously LogoContent is a control and you can't attach it twice.
+            // if (LogoContent is null) LogoContent = s.LogoContent;
+        }
+    }
 
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
     {

--- a/SukiUI/Converters/ScrollerToBool.cs
+++ b/SukiUI/Converters/ScrollerToBool.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Avalonia;
+using Avalonia.Controls.Primitives;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+
+namespace SukiUI.Converters
+{
+    public class ScrollerToBool : IMultiValueConverter
+    {
+        public static ScrollerToBool Up { get; } = new((x,y) => x > y);
+
+        public static ScrollerToBool Down { get; } = new((x, y) => x < y);
+
+        private readonly Func<double, double, bool> _converter;
+        
+        public ScrollerToBool(Func<double, double, bool> converter)
+        {
+            _converter = converter;
+        }
+        
+        public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (values[0] is not double firstVal) return null;
+            if (values[1] is not double secondVal) return null;
+            return _converter(firstVal,secondVal);
+        }
+    }
+    
+    // <!-- <LinearGradientBrush StartPoint="50%,0%" EndPoint="50%,95%"> -->
+    // <!--     <GradientStop Offset="0.9" Color="Black" /> -->
+    // <!--     <GradientStop Offset="1" Color="Transparent" /> -->
+    // <!-- </LinearGradientBrush> -->
+
+    public class ScrollerToOpacityMask : IMultiValueConverter
+    {
+        private readonly Func<double, double, IBrush?> _func;
+        
+        public static ScrollerToOpacityMask Top { get; } = new((x,y) => x > y ? TopBrush : Brushes.White);
+        public static ScrollerToOpacityMask Bottom { get; } = new((x,y) => x < y ? BottomBrush : Brushes.White);
+
+        private static readonly LinearGradientBrush BottomBrush = new()
+        {
+            StartPoint = new RelativePoint(0.5, 0, RelativeUnit.Relative),
+            EndPoint = new RelativePoint(0.5, 0.95, RelativeUnit.Relative),
+            GradientStops = new GradientStops()
+            {
+                new(Colors.Black, 0.9),
+                new(Colors.Transparent,1 )
+            }
+        };
+        
+        private static readonly LinearGradientBrush TopBrush = new()
+        {
+            StartPoint = new RelativePoint(0.5, 1, RelativeUnit.Relative),
+            EndPoint = new RelativePoint(0.5, 0.05, RelativeUnit.Relative),
+            GradientStops = new GradientStops()
+            {
+                new(Colors.Black, 0.9),
+                new(Colors.Transparent,1 )
+            }
+        };
+        
+        
+        public ScrollerToOpacityMask(Func<double, double, IBrush?> func)
+        {
+            _func = func;
+        }
+        
+        public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (values.Count != 2) return null;
+            if (values[0] is not double valOne) return null;
+            if (values[1] is not double valTwo) return null;
+            return _func(valOne, valTwo);
+        }
+    }
+}

--- a/SukiUI/Converters/SideMenuScrollerToOpacityMask.cs
+++ b/SukiUI/Converters/SideMenuScrollerToOpacityMask.cs
@@ -2,44 +2,17 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using Avalonia;
-using Avalonia.Controls.Primitives;
 using Avalonia.Data.Converters;
 using Avalonia.Media;
 
 namespace SukiUI.Converters
 {
-    public class ScrollerToBool : IMultiValueConverter
-    {
-        public static ScrollerToBool Up { get; } = new((x,y) => x > y);
-
-        public static ScrollerToBool Down { get; } = new((x, y) => x < y);
-
-        private readonly Func<double, double, bool> _converter;
-        
-        public ScrollerToBool(Func<double, double, bool> converter)
-        {
-            _converter = converter;
-        }
-        
-        public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
-        {
-            if (values[0] is not double firstVal) return null;
-            if (values[1] is not double secondVal) return null;
-            return _converter(firstVal,secondVal);
-        }
-    }
-    
-    // <!-- <LinearGradientBrush StartPoint="50%,0%" EndPoint="50%,95%"> -->
-    // <!--     <GradientStop Offset="0.9" Color="Black" /> -->
-    // <!--     <GradientStop Offset="1" Color="Transparent" /> -->
-    // <!-- </LinearGradientBrush> -->
-
-    public class ScrollerToOpacityMask : IMultiValueConverter
+    public class SideMenuScrollerToOpacityMask : IMultiValueConverter
     {
         private readonly Func<double, double, IBrush?> _func;
         
-        public static ScrollerToOpacityMask Top { get; } = new((x,y) => x > y ? TopBrush : Brushes.White);
-        public static ScrollerToOpacityMask Bottom { get; } = new((x,y) => x < y ? BottomBrush : Brushes.White);
+        public static SideMenuScrollerToOpacityMask Top { get; } = new((x,y) => x > y ? TopBrush : Brushes.White);
+        public static SideMenuScrollerToOpacityMask Bottom { get; } = new((x,y) => x < y ? BottomBrush : Brushes.White);
 
         private static readonly LinearGradientBrush BottomBrush = new()
         {
@@ -63,8 +36,7 @@ namespace SukiUI.Converters
             }
         };
         
-        
-        public ScrollerToOpacityMask(Func<double, double, IBrush?> func)
+        public SideMenuScrollerToOpacityMask(Func<double, double, IBrush?> func)
         {
             _func = func;
         }

--- a/SukiUI/Converters/SideMenuScrollerToVisibilityBool.cs
+++ b/SukiUI/Converters/SideMenuScrollerToVisibilityBool.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace SukiUI.Converters
+{
+    public class SideMenuScrollerToVisibilityBool : IMultiValueConverter
+    {
+        public static SideMenuScrollerToVisibilityBool Up { get; } = new((x,y) => x > y);
+
+        public static SideMenuScrollerToVisibilityBool Down { get; } = new((x, y) => x < y);
+
+        private readonly Func<double, double, bool> _converter;
+        
+        public SideMenuScrollerToVisibilityBool(Func<double, double, bool> converter)
+        {
+            _converter = converter;
+        }
+        
+        public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (values[0] is not double firstVal) return null;
+            if (values[1] is not double secondVal) return null;
+            return _converter(firstVal,secondVal);
+        }
+    }
+}

--- a/SukiUI/Theme/ScrollBarStyle.axaml
+++ b/SukiUI/Theme/ScrollBarStyle.axaml
@@ -1,40 +1,44 @@
-﻿<Styles xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:content="clr-namespace:SukiUI.Content">
+﻿<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:content="clr-namespace:SukiUI.Content"
+        xmlns:converters="clr-namespace:SukiUI.Converters">
     <Design.PreviewWith>
         <StackPanel Width="200">
             <Border Padding="20">
-                <ScrollViewer Classes="Stack" Width="200" Height="100">
+                <ScrollViewer Width="200"
+                              Height="100"
+                              Classes="Stack">
                     <StackPanel>
-                    <ListBoxItem>isse</ListBoxItem>
-                    <ListBoxItem>isse</ListBoxItem>
-                    <ListBoxItem>isse</ListBoxItem>
-                    <ListBoxItem>isse</ListBoxItem>
-                    <ListBoxItem>isse</ListBoxItem>
-                    <ListBoxItem>isse</ListBoxItem>
-                    <ListBoxItem>isse</ListBoxItem>
-                    <ListBoxItem>isse</ListBoxItem>
-                    <ListBoxItem>isse</ListBoxItem>
-                    <ListBoxItem>isse</ListBoxItem>
-                    <ListBoxItem>isse</ListBoxItem>
-                    <ListBoxItem>isse</ListBoxItem>
-                    <ListBoxItem>isse</ListBoxItem>
-                    <ListBoxItem>isse</ListBoxItem>
-                    <ListBoxItem>isse</ListBoxItem>
-                    <ListBoxItem>isse</ListBoxItem>
-                    <ListBoxItem>isse</ListBoxItem>
-                    <ListBoxItem>isse</ListBoxItem>
-                    <ListBoxItem>isse</ListBoxItem>
-                    <ListBoxItem>isse</ListBoxItem>
-                    <ListBoxItem>isse</ListBoxItem>
-                    <ListBoxItem>isse</ListBoxItem>
-                    <ListBoxItem>isse</ListBoxItem>
-                    <ListBoxItem>isse</ListBoxItem>
-                    <ListBoxItem>isse</ListBoxItem>
-                    <ListBoxItem>isse</ListBoxItem>
-                    <ListBoxItem>isse</ListBoxItem>
-                    <ListBoxItem>isse</ListBoxItem>
-                    <ListBoxItem>isse</ListBoxItem>
-                    <ListBoxItem>isse</ListBoxItem>
+                        <ListBoxItem>isse</ListBoxItem>
+                        <ListBoxItem>isse</ListBoxItem>
+                        <ListBoxItem>isse</ListBoxItem>
+                        <ListBoxItem>isse</ListBoxItem>
+                        <ListBoxItem>isse</ListBoxItem>
+                        <ListBoxItem>isse</ListBoxItem>
+                        <ListBoxItem>isse</ListBoxItem>
+                        <ListBoxItem>isse</ListBoxItem>
+                        <ListBoxItem>isse</ListBoxItem>
+                        <ListBoxItem>isse</ListBoxItem>
+                        <ListBoxItem>isse</ListBoxItem>
+                        <ListBoxItem>isse</ListBoxItem>
+                        <ListBoxItem>isse</ListBoxItem>
+                        <ListBoxItem>isse</ListBoxItem>
+                        <ListBoxItem>isse</ListBoxItem>
+                        <ListBoxItem>isse</ListBoxItem>
+                        <ListBoxItem>isse</ListBoxItem>
+                        <ListBoxItem>isse</ListBoxItem>
+                        <ListBoxItem>isse</ListBoxItem>
+                        <ListBoxItem>isse</ListBoxItem>
+                        <ListBoxItem>isse</ListBoxItem>
+                        <ListBoxItem>isse</ListBoxItem>
+                        <ListBoxItem>isse</ListBoxItem>
+                        <ListBoxItem>isse</ListBoxItem>
+                        <ListBoxItem>isse</ListBoxItem>
+                        <ListBoxItem>isse</ListBoxItem>
+                        <ListBoxItem>isse</ListBoxItem>
+                        <ListBoxItem>isse</ListBoxItem>
+                        <ListBoxItem>isse</ListBoxItem>
+                        <ListBoxItem>isse</ListBoxItem>
                     </StackPanel>
                 </ScrollViewer>
             </Border>
@@ -112,31 +116,62 @@
             </ControlTemplate>
         </Setter>
     </Style>
-    
-     <Style Selector="ScrollBar.Stack:vertical">
 
+    <Style Selector="ScrollBar.Stack:vertical">
         <Setter Property="Template">
             <ControlTemplate>
-                
-                                <RepeatButton BorderThickness="0" Width="60" Height="60" HorizontalAlignment="Stretch"  Name="PART_PageDownButton"
-                                              Background="Transparent"
-                                           
-                                              Focusable="False" >
-                                   
-                                    <PathIcon Width="10"   Height="25" Foreground="{DynamicResource SukiText}"
-                                              Data="{x:Static content:Icons.ChevronDown}" >
-                                        <PathIcon.RenderTransform>
-                                            <ScaleTransform ScaleX="1"></ScaleTransform>
-                                        </PathIcon.RenderTransform>
-                                    </PathIcon>
-                                    
-                                </RepeatButton>
-                          
+                <Grid RowDefinitions="Auto,*,Auto">
+                    <RepeatButton Name="PART_PageUpButton"
+                                  Width="60"
+                                  Height="60"
+                                  HorizontalAlignment="Stretch"
+                                  Background="Transparent"
+                                  BorderThickness="0"
+                                  Focusable="False">
+                        <RepeatButton.IsVisible>
+                            <MultiBinding Converter="{x:Static converters:ScrollerToBool.Up}">
+                                <Binding Path="Value" RelativeSource="{RelativeSource TemplatedParent}" />
+                                <Binding Path="Minimum" RelativeSource="{RelativeSource TemplatedParent}" />
+                            </MultiBinding>
+                        </RepeatButton.IsVisible>
+                        <PathIcon Width="10"
+                                  Height="25"
+                                  Data="{x:Static content:Icons.ChevronUp}"
+                                  Foreground="{DynamicResource SukiText}">
+                            <PathIcon.RenderTransform>
+                                <ScaleTransform ScaleX="1" />
+                            </PathIcon.RenderTransform>
+                        </PathIcon>
+                    </RepeatButton>
+                    <RepeatButton Name="PART_PageDownButton"
+                                  Grid.Row="2"
+                                  Width="60"
+                                  Height="60"
+                                  HorizontalAlignment="Stretch"
+                                  Background="Transparent"
+                                  BorderThickness="0"
+                                  Focusable="False">
+                        <RepeatButton.IsVisible>
+                            <MultiBinding Converter="{x:Static converters:ScrollerToBool.Down}">
+                                <Binding Path="Value" RelativeSource="{RelativeSource TemplatedParent}" />
+                                <Binding Path="Maximum" RelativeSource="{RelativeSource TemplatedParent}" />
+                            </MultiBinding>
+                        </RepeatButton.IsVisible>
+                        <PathIcon Width="10"
+                                  Height="25"
+                                  Data="{x:Static content:Icons.ChevronDown}"
+                                  Foreground="{DynamicResource SukiText}">
+                            <PathIcon.RenderTransform>
+                                <ScaleTransform ScaleX="1" />
+                            </PathIcon.RenderTransform>
+                        </PathIcon>
+                    </RepeatButton>
+                </Grid>
             </ControlTemplate>
         </Setter>
     </Style>
-    
-    
+
+
 
     <Style Selector="ScrollBar:horizontal">
         <Setter Property="Template">

--- a/SukiUI/Theme/ScrollBarStyle.axaml
+++ b/SukiUI/Theme/ScrollBarStyle.axaml
@@ -118,11 +118,12 @@
     </Style>
 
     <Style Selector="ScrollBar.Stack:vertical">
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
+        <Setter Property="Width" Value="NaN" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Grid RowDefinitions="Auto,*,Auto">
+                <Grid HorizontalAlignment="Stretch" RowDefinitions="Auto,*,Auto">
                     <RepeatButton Name="PART_PageUpButton"
-                                  Width="60"
                                   Height="60"
                                   HorizontalAlignment="Stretch"
                                   Background="Transparent"
@@ -145,7 +146,6 @@
                     </RepeatButton>
                     <RepeatButton Name="PART_PageDownButton"
                                   Grid.Row="2"
-                                  Width="60"
                                   Height="60"
                                   HorizontalAlignment="Stretch"
                                   Background="Transparent"

--- a/SukiUI/Theme/ScrollBarStyle.axaml
+++ b/SukiUI/Theme/ScrollBarStyle.axaml
@@ -130,7 +130,7 @@
                                   BorderThickness="0"
                                   Focusable="False">
                         <RepeatButton.IsVisible>
-                            <MultiBinding Converter="{x:Static converters:ScrollerToBool.Up}">
+                            <MultiBinding Converter="{x:Static converters:SideMenuScrollerToVisibilityBool.Up}">
                                 <Binding Path="Value" RelativeSource="{RelativeSource TemplatedParent}" />
                                 <Binding Path="Minimum" RelativeSource="{RelativeSource TemplatedParent}" />
                             </MultiBinding>
@@ -152,7 +152,7 @@
                                   BorderThickness="0"
                                   Focusable="False">
                         <RepeatButton.IsVisible>
-                            <MultiBinding Converter="{x:Static converters:ScrollerToBool.Down}">
+                            <MultiBinding Converter="{x:Static converters:SideMenuScrollerToVisibilityBool.Down}">
                                 <Binding Path="Value" RelativeSource="{RelativeSource TemplatedParent}" />
                                 <Binding Path="Maximum" RelativeSource="{RelativeSource TemplatedParent}" />
                             </MultiBinding>
@@ -170,8 +170,6 @@
             </ControlTemplate>
         </Setter>
     </Style>
-
-
 
     <Style Selector="ScrollBar:horizontal">
         <Setter Property="Template">

--- a/SukiUI/Theme/ScrollViewerStyles.axaml
+++ b/SukiUI/Theme/ScrollViewerStyles.axaml
@@ -1,12 +1,6 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:converters="clr-namespace:SukiUI.Converters">
-    <Design.PreviewWith>
-        <Border Padding="20">
-            <!--  Add Controls for Previewer Here  -->
-        </Border>
-    </Design.PreviewWith>
-
     <Style Selector="ScrollViewer.Stack">
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="Template">
@@ -14,7 +8,7 @@
                 <Grid>
                     <Panel>
                         <Panel.OpacityMask>
-                            <MultiBinding Converter="{x:Static converters:ScrollerToOpacityMask.Top}">
+                            <MultiBinding Converter="{x:Static converters:SideMenuScrollerToOpacityMask.Top}">
                                 <Binding ElementName="PART_VerticalScrollBar" Path="Value" />
                                 <Binding ElementName="PART_VerticalScrollBar" Path="Minimum" />
                             </MultiBinding>
@@ -33,7 +27,7 @@
                                                 VerticalSnapPointsAlignment="{TemplateBinding VerticalSnapPointsAlignment}"
                                                 VerticalSnapPointsType="{TemplateBinding VerticalSnapPointsType}">
                             <ScrollContentPresenter.OpacityMask>
-                                <MultiBinding Converter="{x:Static converters:ScrollerToOpacityMask.Bottom}">
+                                <MultiBinding Converter="{x:Static converters:SideMenuScrollerToOpacityMask.Bottom}">
                                     <Binding ElementName="PART_VerticalScrollBar" Path="Value" />
                                     <Binding ElementName="PART_VerticalScrollBar" Path="Maximum" />
                                 </MultiBinding>

--- a/SukiUI/Theme/ScrollViewerStyles.axaml
+++ b/SukiUI/Theme/ScrollViewerStyles.axaml
@@ -1,8 +1,9 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:converters="clr-namespace:SukiUI.Converters">
     <Design.PreviewWith>
         <Border Padding="20">
-            <!-- Add Controls for Previewer Here -->
+            <!--  Add Controls for Previewer Here  -->
         </Border>
     </Design.PreviewWith>
 
@@ -10,41 +11,53 @@
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Grid >
-                    <ScrollContentPresenter Name="PART_ContentPresenter"
-                                            Padding="{TemplateBinding Padding}"
-                                            HorizontalSnapPointsType="{TemplateBinding HorizontalSnapPointsType}"
-                                            VerticalSnapPointsType="{TemplateBinding VerticalSnapPointsType}"
-                                            HorizontalSnapPointsAlignment="{TemplateBinding HorizontalSnapPointsAlignment}"
-                                            VerticalSnapPointsAlignment="{TemplateBinding VerticalSnapPointsAlignment}"
-                                            Background="{TemplateBinding Background}"
-                                            ScrollViewer.IsScrollInertiaEnabled="{TemplateBinding IsScrollInertiaEnabled}">
-                        <ScrollContentPresenter.OpacityMask>
-                            <LinearGradientBrush  StartPoint="50%,0%" EndPoint="50%,95%" >
-
-                             
-
-                                <GradientStop  Color="Black" Offset="0.9"/>
-
-                                <GradientStop Color="Transparent" Offset="1"/>
-
-                            </LinearGradientBrush>
-                            
-                        </ScrollContentPresenter.OpacityMask>
-                        <ScrollContentPresenter.GestureRecognizers>
-                            <ScrollGestureRecognizer CanHorizontallyScroll="{Binding CanHorizontallyScroll, ElementName=PART_ContentPresenter}"
-                                                     CanVerticallyScroll="{Binding CanVerticallyScroll, ElementName=PART_ContentPresenter}"
-                                                     IsScrollInertiaEnabled="{Binding (ScrollViewer.IsScrollInertiaEnabled), ElementName=PART_ContentPresenter}"/>
-                        </ScrollContentPresenter.GestureRecognizers>
-                    </ScrollContentPresenter>
-                  
-                           
-                    <ScrollBar Classes="Stack" Name="PART_VerticalScrollBar"
-                               VerticalAlignment="Bottom" HorizontalAlignment="Stretch"
-                               Orientation="Vertical"/>
-                 
+                <Grid>
+                    <Panel>
+                        <Panel.OpacityMask>
+                            <MultiBinding Converter="{x:Static converters:ScrollerToOpacityMask.Top}">
+                                <Binding ElementName="PART_VerticalScrollBar" Path="Value" />
+                                <Binding ElementName="PART_VerticalScrollBar" Path="Minimum" />
+                            </MultiBinding>
+                        </Panel.OpacityMask>
+                        <Panel.Transitions>
+                            <Transitions>
+                                <BrushTransition Property="OpacityMask" Duration="{StaticResource ShortAnimationDuration}" />
+                            </Transitions>
+                        </Panel.Transitions>
+                        <ScrollContentPresenter Name="PART_ContentPresenter"
+                                                Padding="{TemplateBinding Padding}"
+                                                Background="{TemplateBinding Background}"
+                                                HorizontalSnapPointsAlignment="{TemplateBinding HorizontalSnapPointsAlignment}"
+                                                HorizontalSnapPointsType="{TemplateBinding HorizontalSnapPointsType}"
+                                                ScrollViewer.IsScrollInertiaEnabled="{TemplateBinding IsScrollInertiaEnabled}"
+                                                VerticalSnapPointsAlignment="{TemplateBinding VerticalSnapPointsAlignment}"
+                                                VerticalSnapPointsType="{TemplateBinding VerticalSnapPointsType}">
+                            <ScrollContentPresenter.OpacityMask>
+                                <MultiBinding Converter="{x:Static converters:ScrollerToOpacityMask.Bottom}">
+                                    <Binding ElementName="PART_VerticalScrollBar" Path="Value" />
+                                    <Binding ElementName="PART_VerticalScrollBar" Path="Maximum" />
+                                </MultiBinding>
+                            </ScrollContentPresenter.OpacityMask>
+                            <ScrollContentPresenter.Transitions>
+                                <Transitions>
+                                    <BrushTransition Property="OpacityMask" Duration="{StaticResource ShortAnimationDuration}" />
+                                </Transitions>
+                            </ScrollContentPresenter.Transitions>
+                            <ScrollContentPresenter.GestureRecognizers>
+                                <ScrollGestureRecognizer CanHorizontallyScroll="{Binding CanHorizontallyScroll, ElementName=PART_ContentPresenter}"
+                                                         CanVerticallyScroll="{Binding CanVerticallyScroll, ElementName=PART_ContentPresenter}"
+                                                         IsScrollInertiaEnabled="{Binding (ScrollViewer.IsScrollInertiaEnabled), ElementName=PART_ContentPresenter}" />
+                            </ScrollContentPresenter.GestureRecognizers>
+                        </ScrollContentPresenter>
+                    </Panel>
+                    <ScrollBar Name="PART_VerticalScrollBar"
+                               HorizontalAlignment="Stretch"
+                               VerticalAlignment="Stretch"
+                               Classes="Stack"
+                               Orientation="Vertical" />
                 </Grid>
             </ControlTemplate>
         </Setter>
+        <Style Selector="^ /template/ ScrollContentPresenter" />
     </Style>
 </Styles>


### PR DESCRIPTION
***Changes***
- Side menu scrolling now has an up and down button.
  - Button takes up the full width of the side-menu so that you can't click "through" the button and click an item that should essentially be hidden. 
- Side menu content now takes up the full height because the transparent overlay and button at the top/bottom appears/disappears at the end of travel.
- Side menu expand/collapse button is now animated.
  - Would be nice if there was a morph animation or something, but that's probably a lot of work for something so minor.
- New `SukiWindow` instances outside of the `MainWindow` will use the `Icon` set in the `MainWindow` as a fallback if one isn't provided.

***Outstanding Issues***
- `TimePicker` remains essentially the only control that I can think of that has no style in `SukiUI`, and even as-standard it's functional, it might be reasonable to just overwrite the relevant brush keys and call it a day because it does look reasonably decent out of the box.