### PR TITLE
Calendar control work.

### DIFF
--- a/SukiUI.Demo/Features/ControlsLibrary/MiscView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/MiscView.axaml
@@ -37,17 +37,17 @@
                 </controls:GlassCard>
                 <controls:GlassCard>
                     <controls:GroupBox Header="Date Picker">
-                        <DatePicker />
+                        <DatePicker SelectedDate="{Binding SelectedDateTimeOffset}" />
+                    </controls:GroupBox>
+                </controls:GlassCard>
+                <controls:GlassCard>
+                    <controls:GroupBox Header="Calendar">
+                        <Calendar SelectedDate="{Binding SelectedDateTime}" />
                     </controls:GroupBox>
                 </controls:GlassCard>
                 <controls:GlassCard>
                     <controls:GroupBox Header="Time Picker">
                         <TimePicker />
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Calendar">
-                        <Calendar />
                     </controls:GroupBox>
                 </controls:GlassCard>
                 <controls:GlassCard>

--- a/SukiUI.Demo/Features/ControlsLibrary/MiscView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/MiscView.axaml
@@ -5,6 +5,7 @@
              xmlns:controlsLibrary="clr-namespace:SukiUI.Demo.Features.ControlsLibrary"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:showMeTheXaml="clr-namespace:ShowMeTheXaml;assembly=ShowMeTheXaml.Avalonia"
              xmlns:theme="clr-namespace:SukiUI.Theme;assembly=SukiUI"
              d:DesignHeight="450"
              d:DesignWidth="800"
@@ -12,7 +13,7 @@
              mc:Ignorable="d">
     <Grid RowDefinitions="Auto,*">
         <controls:GlassCard Classes="HeaderCard">
-            <controls:GroupBox Header="Buttons">
+            <controls:GroupBox Header="Miscellaneous">
                 <StackPanel Classes="HeaderContent">
                     <TextBlock>
                         An assortment of controls that don't otherwise fit neatly into another category.
@@ -23,7 +24,7 @@
         <ScrollViewer Grid.Row="1">
             <WrapPanel Classes="PageContainer">
                 <controls:GlassCard MaxWidth="300">
-                    <controls:BusyArea IsBusy="{Binding IsBusy}">
+                    <controls:BusyArea BusyText="Busy..." IsBusy="{Binding IsBusy}">
                         <controls:GroupBox Header="Busy Area">
                             <StackPanel Spacing="10">
                                 <TextBlock Classes="h3" TextWrapping="Wrap">Click this button to set the card area busy for 3 seconds.</TextBlock>
@@ -45,12 +46,25 @@
                     </controls:GroupBox>
                 </controls:GlassCard>
                 <controls:GlassCard>
+                    <controls:GroupBox Header="Calendar">
+                        <Calendar />
+                    </controls:GroupBox>
+                </controls:GlassCard>
+                <controls:GlassCard>
                     <controls:GroupBox Header="Numeric Up/Down">
                         <StackPanel Spacing="10">
-                        <NumericUpDown Value="10" ShowButtonSpinner="False" theme:NumericUpDownExtensions.Unit="inch" />
-                        <NumericUpDown Value="10" theme:NumericUpDownExtensions.Unit="inch" />
-                        <NumericUpDown Value="10" />
-                        
+                            <showMeTheXaml:XamlDisplay UniqueId="Numeric1">
+                                <NumericUpDown Value="10" />
+                            </showMeTheXaml:XamlDisplay>
+                            <showMeTheXaml:XamlDisplay UniqueId="Numeric2">
+                                <NumericUpDown theme:NumericUpDownExtensions.Unit="inch" Value="10" />
+                            </showMeTheXaml:XamlDisplay>
+                            <showMeTheXaml:XamlDisplay UniqueId="Numeric3">
+                                <NumericUpDown theme:NumericUpDownExtensions.Unit="inch"
+                                               ShowButtonSpinner="False"
+                                               Value="10" />
+                            </showMeTheXaml:XamlDisplay>
+
                         </StackPanel>
                     </controls:GroupBox>
                 </controls:GlassCard>
@@ -59,7 +73,9 @@
                         <DropDownButton Content="Click To Open">
                             <DropDownButton.Flyout>
                                 <Flyout>
-                                    <Border Padding="10" CornerRadius="8" Classes="Card">
+                                    <Border Padding="10"
+                                            Classes="Card"
+                                            CornerRadius="8">
                                         <TextBlock Foreground="{DynamicResource SukiText}">
                                             Dropdown button content.
                                         </TextBlock>

--- a/SukiUI.Demo/Features/ControlsLibrary/MiscViewModel.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/MiscViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -8,6 +9,8 @@ namespace SukiUI.Demo.Features.ControlsLibrary
     public partial class MiscViewModel() : DemoPageBase("Miscellaneous", MaterialIconKind.DotsHorizontalCircle)
     {
         [ObservableProperty] private bool _isBusy;
+        [ObservableProperty] private DateTime _selectedDateTime = DateTime.Today;
+        [ObservableProperty] private DateTimeOffset _selectedDateTimeOffset = DateTimeOffset.Now;
 
         [RelayCommand]
         private async Task ToggleBusy()
@@ -16,5 +19,11 @@ namespace SukiUI.Demo.Features.ControlsLibrary
             await Task.Delay(3000);
             IsBusy = false;
         }
+
+        partial void OnSelectedDateTimeChanged(DateTime value) => 
+            SelectedDateTimeOffset = value;
+
+        partial void OnSelectedDateTimeOffsetChanged(DateTimeOffset value) => 
+            SelectedDateTime = value.DateTime;
     }
 }

--- a/SukiUI.Demo/Features/ControlsLibrary/ToastsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/ToastsView.axaml
@@ -5,14 +5,13 @@
              xmlns:controlsLibrary="clr-namespace:SukiUI.Demo.Features.ControlsLibrary"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:theme="clr-namespace:SukiUI.Theme;assembly=SukiUI"
              d:DesignHeight="450"
              d:DesignWidth="800"
              x:DataType="controlsLibrary:ToastsViewModel"
              mc:Ignorable="d">
     <Grid RowDefinitions="Auto,*">
         <controls:GlassCard Classes="HeaderCard">
-            <controls:GroupBox>
+            <controls:GroupBox Header="Toasts">
                 <StackPanel Classes="HeaderContent">
                     <TextBlock>
                         SukiUI contains an API for creating and dismissing toasts, with the ability to set limits on the number of toasts.

--- a/SukiUI/Controls/GlassMorphism/GlassCard.axaml
+++ b/SukiUI/Controls/GlassMorphism/GlassCard.axaml
@@ -6,7 +6,7 @@
         <Setter Property="Padding" Value="20" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Grid>
+                <Panel>
                     <Border Name="PART_BorderCard"
                             Background="{DynamicResource SukiGlassCardBackground}"
                             BorderBrush="{TemplateBinding BorderBrush}"
@@ -35,7 +35,7 @@
                         </Border.Transitions>
                         <ContentPresenter Margin="{TemplateBinding Padding}" Content="{TemplateBinding Content}" />
                     </Border>
-                </Grid>
+                </Panel>
             </ControlTemplate>
         </Setter>
         <Style Selector="^.Primary /template/ Border#PART_ClipBorder">

--- a/SukiUI/Theme/Calendar/Calendar.axaml
+++ b/SukiUI/Theme/Calendar/Calendar.axaml
@@ -1,0 +1,21 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <ControlTheme x:Key="SukiCalendarStyle" TargetType="Calendar">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="HeaderBackground" Value="Transparent" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Panel Name="PART_Root" ClipToBounds="True">
+                    <CalendarItem Name="PART_CalendarItem"
+                                  Background="{TemplateBinding Background}"
+                                  BorderBrush="{TemplateBinding BorderBrush}"
+                                  BorderThickness="{TemplateBinding BorderThickness}"
+                                  HeaderBackground="{TemplateBinding HeaderBackground}" />
+                </Panel>
+            </ControlTemplate>
+        </Setter>
+    </ControlTheme>
+    <ControlTheme x:Key="{x:Type Calendar}"
+                  BasedOn="{StaticResource SukiCalendarStyle}"
+                  TargetType="Calendar" />
+</ResourceDictionary>

--- a/SukiUI/Theme/Calendar/CalendarButton.axaml
+++ b/SukiUI/Theme/Calendar/CalendarButton.axaml
@@ -1,0 +1,60 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <ControlTheme x:Key="SukiCalendarButtonStyle" TargetType="CalendarButton">
+        <Setter Property="ClickMode" Value="Release" />
+        <Setter Property="MinWidth" Value="55" />
+        <Setter Property="MinHeight" Value="50" />
+        <Setter Property="Foreground" Value="{DynamicResource SukiText}" />
+        <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor0}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource SukiBorderBrush}" />
+        <Setter Property="CornerRadius" Value="{DynamicResource SmallCornerRadius}" />
+        <Setter Property="ClipToBounds" Value="False" />
+        <!-- <Setter Property="HorizontalAlignment" Value="Center" /> -->
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Panel>
+                    <Border Name="Root"
+                            Margin="5"
+                            Padding="5"
+                            Background="{TemplateBinding Background}"
+                            ClipToBounds="True"
+                            CornerRadius="{TemplateBinding CornerRadius}">
+                        <Border.Transitions>
+                            <Transitions>
+                                <BrushTransition Property="Background" Duration="{DynamicResource ShortAnimationDuration}" />
+                            </Transitions>
+                        </Border.Transitions>
+                        <ContentControl Name="Content"
+                                        Margin="{TemplateBinding Padding}"
+                                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                        Content="{TemplateBinding Content}"
+                                        ContentTemplate="{TemplateBinding ContentTemplate}"
+                                        FontSize="{TemplateBinding FontSize}" />
+                    </Border>
+                </Panel>
+            </ControlTemplate>
+        </Setter>
+        <Style Selector="^:pointerover">
+            <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor25}" />
+        </Style>
+        <Style Selector="^:pressed">
+            <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor75}" />
+        </Style>
+        <Style Selector="^:selected">
+            <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor50}" />
+            <Setter Property="TextElement.FontWeight" Value="Bold" />
+        </Style>
+        <Style Selector="^:inactive /template/ Border#Root">
+            <Setter Property="Opacity" Value="0.32" />
+        </Style>
+        <Style Selector="^:disabled /template/ ContentControl#Content">
+            <Setter Property="Opacity" Value="0.32" />
+        </Style>
+    </ControlTheme>
+    <ControlTheme x:Key="{x:Type CalendarButton}"
+                  BasedOn="{StaticResource SukiCalendarButtonStyle}"
+                  TargetType="CalendarButton" />
+</ResourceDictionary>

--- a/SukiUI/Theme/Calendar/CalendarDayButton.axaml
+++ b/SukiUI/Theme/Calendar/CalendarDayButton.axaml
@@ -30,6 +30,7 @@
                             <Border.Transitions>
                                 <Transitions>
                                     <BrushTransition Property="Background" Duration="{DynamicResource ShortAnimationDuration}" />
+                                    <BrushTransition Property="BorderBrush" Duration="{DynamicResource ShortAnimationDuration}" />
                                 </Transitions>
                             </Border.Transitions>
                         </Border>

--- a/SukiUI/Theme/Calendar/CalendarDayButton.axaml
+++ b/SukiUI/Theme/Calendar/CalendarDayButton.axaml
@@ -1,0 +1,80 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <ControlTheme x:Key="SukiCalendarDayButtonStyle" TargetType="CalendarDayButton">
+        <Setter Property="ClickMode" Value="Release" />
+        <Setter Property="MinWidth" Value="32" />
+        <Setter Property="MinHeight" Value="32" />
+        <Setter Property="Foreground" Value="{DynamicResource SukiText}" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="IsVisible" Value="True" />
+        <Setter Property="Padding" Value="2" />
+        <Setter Property="ClipToBounds" Value="False" />
+        <Setter Property="CornerRadius" Value="{DynamicResource SmallCornerRadius}" />
+        <Setter Property="HorizontalAlignment" Value="Center" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Border Name="PART_RootBorder"
+                        Padding="{TemplateBinding Padding}"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        CornerRadius="{TemplateBinding CornerRadius}">
+                    <Panel Name="PART_RootPanel">
+                        <Border Name="PART_EffectBorder"
+                                Background="{DynamicResource SukiPrimaryColor0}"
+                                CornerRadius="{TemplateBinding CornerRadius}">
+                            <Border.Transitions>
+                                <Transitions>
+                                    <BrushTransition Property="Background" Duration="{DynamicResource ShortAnimationDuration}" />
+                                </Transitions>
+                            </Border.Transitions>
+                        </Border>
+
+                        <ContentPresenter Name="PART_ContentPresenter"
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}" />
+                    </Panel>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^:pointerover /template/ Border#PART_EffectBorder">
+            <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor25}" />
+        </Style>
+
+        <Style Selector="^:selected /template/ Border#PART_EffectBorder">
+            <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor50}" />
+        </Style>
+
+        <Style Selector="^:selected /template/ Border#PART_RootBorder">
+            <Setter Property="TextElement.FontWeight" Value="Bold" />
+        </Style>
+
+        <Style Selector="^:today /template/ Border#PART_EffectBorder">
+            <Setter Property="BorderBrush" Value="{DynamicResource SukiAccentColor}" />
+            <Setter Property="BorderThickness" Value="1" />
+        </Style>
+
+        <Style Selector="^:inactive /template/ Border#PART_RootBorder">
+            <Setter Property="Opacity" Value="0.24" />
+        </Style>
+
+        <Style Selector="^:disabled /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Opacity" Value="0.32" />
+        </Style>
+
+        <Style Selector="^:blackout">
+            <Setter Property="IsVisible" Value="False" />
+        </Style>
+    </ControlTheme>
+
+    <ControlTheme x:Key="{x:Type CalendarDayButton}"
+                  BasedOn="{StaticResource SukiCalendarDayButtonStyle}"
+                  TargetType="CalendarDayButton" />
+</ResourceDictionary>

--- a/SukiUI/Theme/Calendar/CalendarItem.axaml
+++ b/SukiUI/Theme/Calendar/CalendarItem.axaml
@@ -1,0 +1,92 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:content="clr-namespace:SukiUI.Content">
+    <ControlTheme x:Key="SukiCalendarItemStyle" TargetType="CalendarItem">
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
+        <Setter Property="VerticalAlignment" Value="Stretch" />
+        <Setter Property="DayTitleTemplate">
+            <Template>
+                <TextBlock HorizontalAlignment="Stretch"
+                           VerticalAlignment="Stretch"
+                           FontSize="12"
+                           Text="{Binding}"
+                           TextAlignment="Center" />
+            </Template>
+        </Setter>
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Border Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        CornerRadius="{DynamicResource ControlCornerRadius}">
+                    <Grid MinWidth="225"
+                          HorizontalAlignment="Stretch"
+                          VerticalAlignment="Stretch"
+                          RowDefinitions="Auto, *">
+                        <Grid Name="CalendarHeader"
+                              Margin="0,5"
+                              ColumnDefinitions="Auto, *, Auto, Auto">
+                            <Button Name="PART_HeaderButton"
+                                    Grid.Column="0"
+                                    Classes="Basic"
+                                    IsEnabled="False" />
+
+                            <Button Name="PART_PreviousButton"
+                                    Grid.Column="2"
+                                    Classes="NavButton Basic">
+                                <PathIcon Data="{x:Static content:Icons.ChevronLeft}" />
+                            </Button>
+
+                            <Button Name="PART_NextButton"
+                                    Grid.Column="3"
+                                    Classes="NavButton Basic">
+                                <PathIcon Data="{x:Static content:Icons.ChevronRight}" />
+                            </Button>
+                        </Grid>
+
+                        <Grid Name="PART_MonthView"
+                              Grid.Row="1"
+                              Classes="CalendarView"
+                              ColumnDefinitions="32,32,32,32,32,32,32"
+                              RowDefinitions="32,32,32,32,32,32,32" />
+
+                        <Grid Name="PART_YearView"
+                              Grid.Row="1"
+                              Classes="CalendarView"
+                              ColumnDefinitions="*,*,*,*"
+                              RowDefinitions="*,*,*" />
+                    </Grid>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^ /template/ Button.NavButton">
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="Margin" Value="0,0,10,0" />
+            <Style Selector="^ &gt; PathIcon">
+                <Setter Property="Width" Value="15" />
+                <Setter Property="Height" Value="15" />
+                <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
+            </Style>
+        </Style>
+
+        <Style Selector="^ /template/ Button.HeaderButton">
+            <Setter Property="Height" Value="24" />
+            <Setter Property="Padding" Value="8, 0" />
+            <Setter Property="HorizontalContentAlignment" Value="Left" />
+        </Style>
+
+        <Style Selector="^ /template/ Grid.CalendarView">
+            <Setter Property="IsVisible" Value="False" />
+            <Setter Property="MinWidth" Value="240" />
+            <Setter Property="HorizontalAlignment" Value="Center" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+            <Setter Property="MinHeight" Value="225" />
+            <Setter Property="Row" Value="1" />
+        </Style>
+    </ControlTheme>
+
+    <ControlTheme x:Key="{x:Type CalendarItem}"
+                  BasedOn="{StaticResource SukiCalendarItemStyle}"
+                  TargetType="CalendarItem" />
+</ResourceDictionary>

--- a/SukiUI/Theme/Calendar/CalendarItem.axaml
+++ b/SukiUI/Theme/Calendar/CalendarItem.axaml
@@ -34,13 +34,13 @@
                             <Button Name="PART_PreviousButton"
                                     Grid.Column="2"
                                     Classes="NavButton Basic">
-                                <PathIcon Data="{x:Static content:Icons.ChevronLeft}" />
+                                <PathIcon Classes="Primary" Data="{x:Static content:Icons.ChevronLeft}" />
                             </Button>
 
                             <Button Name="PART_NextButton"
                                     Grid.Column="3"
                                     Classes="NavButton Basic">
-                                <PathIcon Data="{x:Static content:Icons.ChevronRight}" />
+                                <PathIcon Classes="Primary" Data="{x:Static content:Icons.ChevronRight}" />
                             </Button>
                         </Grid>
 
@@ -66,7 +66,6 @@
             <Style Selector="^ &gt; PathIcon">
                 <Setter Property="Width" Value="15" />
                 <Setter Property="Height" Value="15" />
-                <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
             </Style>
         </Style>
 

--- a/SukiUI/Theme/ContextMenu.axaml
+++ b/SukiUI/Theme/ContextMenu.axaml
@@ -8,27 +8,29 @@
             <ControlTemplate>
                 <!--  Tiny margin helps prevent mouse-over immediately  -->
                 <LayoutTransformControl Name="PART_LayoutTransform" Margin="1,0,0,0">
-               <Grid >
-                   <Border   CornerRadius="{TemplateBinding CornerRadius}"  BoxShadow="{DynamicResource SukiPopupShadow}" Margin="16" />
-                   <Border Margin="15" Background="{TemplateBinding Background}"
-                           BorderBrush="{TemplateBinding BorderBrush}"
-                           BorderThickness="{TemplateBinding BorderThickness}"
-                        
-                           ClipToBounds="True"
-                           CornerRadius="{TemplateBinding CornerRadius}">
-                       <ItemsPresenter Name="PART_ItemsPresenter"
-                                       HorizontalAlignment="Left"
-                                       VerticalAlignment="Center"
-                                       ItemsPanel="{TemplateBinding ItemsPanel}"
-                                       KeyboardNavigation.TabNavigation="Continue" />
-                   </Border>
-               </Grid>
-                    </LayoutTransformControl>
+                    <Grid>
+                        <Border Margin="16"
+                                BoxShadow="{DynamicResource SukiPopupShadow}"
+                                CornerRadius="{TemplateBinding CornerRadius}" />
+                        <Border Margin="15"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                ClipToBounds="True"
+                                CornerRadius="{TemplateBinding CornerRadius}">
+                            <ItemsPresenter Name="PART_ItemsPresenter"
+                                            HorizontalAlignment="Left"
+                                            VerticalAlignment="Center"
+                                            ItemsPanel="{TemplateBinding ItemsPanel}"
+                                            KeyboardNavigation.TabNavigation="Continue" />
+                        </Border>
+                    </Grid>
+                </LayoutTransformControl>
             </ControlTemplate>
         </Setter>
         <Style Selector="^[IsOpen=True] /template/ LayoutTransformControl#PART_LayoutTransform">
             <Style.Animations>
-                <Animation Easing="CircularEaseOut" 
+                <Animation Easing="CircularEaseOut"
                            FillMode="Forward"
                            Duration="{StaticResource ShortAnimationDuration}">
                     <KeyFrame Cue="0%">

--- a/SukiUI/Theme/Expander.axaml
+++ b/SukiUI/Theme/Expander.axaml
@@ -39,16 +39,20 @@
                                                   DockPanel.Dock="Right"
                                                   IsChecked="{TemplateBinding IsExpanded,
                                                                               Mode=TwoWay}">
-                                        <PathIcon Name="PART_Icon"
-                                                  Width="10"
-                                                  Height="10"
-                                                  Data="{x:Static content:Icons.Plus}" />
+                                        <Grid ColumnDefinitions="Auto,*">
+                                            <PathIcon Name="PART_Icon"
+                                                      Width="10"
+                                                      Height="10"
+                                                      Data="{x:Static content:Icons.Plus}" />
+                                            <ContentPresenter Grid.Column="1"
+                                                              Margin="10,0,0,0"
+                                                              HorizontalAlignment="Left"
+                                                              VerticalAlignment="Center"
+                                                              Content="{TemplateBinding Header}"
+                                                              FontWeight="DemiBold"
+                                                              IsHitTestVisible="False" />
+                                        </Grid>
                                     </ToggleButton>
-                                    <ContentPresenter Margin="8,7"
-                                                      HorizontalAlignment="Left"
-                                                      VerticalAlignment="Center"
-                                                      Content="{TemplateBinding Header}"
-                                                      FontWeight="DemiBold" />
                                 </DockPanel>
                             </LayoutTransformControl>
                         </Panel>

--- a/SukiUI/Theme/Index.axaml
+++ b/SukiUI/Theme/Index.axaml
@@ -64,6 +64,11 @@
                 <ResourceInclude Source="avares://sukiUI/Theme/FlyoutPresenter.axaml" />
                 <ResourceInclude Source="avares://sukiUI/Theme/AutoCompleteBoxStyles.axaml" />
 
+                <ResourceInclude Source="avares://sukiUI/Theme/Calendar/Calendar.axaml" />
+                <ResourceInclude Source="avares://sukiUI/Theme/Calendar/CalendarButton.axaml" />
+                <ResourceInclude Source="avares://sukiUI/Theme/Calendar/CalendarDayButton.axaml" />
+                <ResourceInclude Source="avares://sukiUI/Theme/Calendar/CalendarItem.axaml" />
+
                 <ResourceInclude Source="avares://sukiUI/Controls/SukiWindow.axaml" />
                 <ResourceInclude Source="avares://sukiUI/Controls/SukiHost.axaml" />
                 <ResourceInclude Source="avares://sukiUI/Controls/SukiToast.axaml" />

--- a/SukiUI/Theme/Menu.axaml
+++ b/SukiUI/Theme/Menu.axaml
@@ -34,20 +34,23 @@
                                Placement="BottomEdgeAlignedLeft">
                             <LayoutTransformControl Name="PART_LayoutTransform">
                                 <Grid Margin="-12,0,0,0">
-                                    <Border BoxShadow="{DynamicResource SukiPopupShadow}" Margin="16,8,8,8"  CornerRadius="6" ></Border>
-                                    <Border Name="PART_Border" BoxShadow="{DynamicResource SukiPopupShadow}" Margin="16,8,8,8"
+                                    <Border Margin="16,8,8,8"
+                                            BoxShadow="{DynamicResource SukiPopupShadow}"
+                                            CornerRadius="6" />
+                                    <Border Name="PART_Border"
+                                            Margin="16,8,8,8"
                                             Background="{DynamicResource SukiCardBackground}"
                                             BorderBrush="{DynamicResource SukiLightBorderBrush}"
                                             BorderThickness="1"
-                                            
+                                            BoxShadow="{DynamicResource SukiPopupShadow}"
                                             ClipToBounds="True"
                                             CornerRadius="6">
-                                    <ScrollViewer>
-                                        <ItemsPresenter Name="PART_ItemsPresenter"
-                                                        Grid.IsSharedSizeScope="True"
-                                                        ItemsPanel="{TemplateBinding ItemsPanel}" />
-                                    </ScrollViewer>
-                                </Border>
+                                        <ScrollViewer>
+                                            <ItemsPresenter Name="PART_ItemsPresenter"
+                                                            Grid.IsSharedSizeScope="True"
+                                                            ItemsPanel="{TemplateBinding ItemsPanel}" />
+                                        </ScrollViewer>
+                                    </Border>
                                 </Grid>
                             </LayoutTransformControl>
                         </Popup>

--- a/SukiUI/Theme/MenuItem.axaml
+++ b/SukiUI/Theme/MenuItem.axaml
@@ -21,8 +21,9 @@
                     <Grid>
                         <DockPanel Margin="5,10">
                             <ContentPresenter Name="PART_Icon"
-                                              Width="15" Margin="5,0"
+                                              Width="15"
                                               Height="15"
+                                              Margin="5,0"
                                               HorizontalAlignment="Center"
                                               VerticalAlignment="Center"
                                               Content="{TemplateBinding Icon}"
@@ -69,20 +70,23 @@
                                VerticalOffset="-1">
                             <LayoutTransformControl Name="PART_LayoutTransform">
                                 <Grid Margin="0,-8,0,0">
-                                    <Border BoxShadow="{DynamicResource SukiPopupShadow}" Margin="16,8,8,8"  CornerRadius="6" ></Border>
+                                    <Border Margin="16,8,8,8"
+                                            BoxShadow="{DynamicResource SukiPopupShadow}"
+                                            CornerRadius="6" />
 
-                                <Border Name="PART_Border" Margin="16,8,8,8"
-                                        Background="{DynamicResource SukiCardBackground}"
-                                        BorderBrush="{DynamicResource SukiLightBorderBrush}"
-                                        BorderThickness="1"
-                                        BoxShadow="{DynamicResource SukiPopupShadow}"
-                                        ClipToBounds="True"
-                                        CornerRadius="5">
-                                    <ScrollViewer>
-                                        <ItemsPresenter Name="PART_ItemsPresenter" ItemsPanel="{TemplateBinding ItemsPanel}" />
-                                    </ScrollViewer>
-                                </Border>
-                                    </Grid>
+                                    <Border Name="PART_Border"
+                                            Margin="16,8,8,8"
+                                            Background="{DynamicResource SukiCardBackground}"
+                                            BorderBrush="{DynamicResource SukiLightBorderBrush}"
+                                            BorderThickness="1"
+                                            BoxShadow="{DynamicResource SukiPopupShadow}"
+                                            ClipToBounds="True"
+                                            CornerRadius="5">
+                                        <ScrollViewer>
+                                            <ItemsPresenter Name="PART_ItemsPresenter" ItemsPanel="{TemplateBinding ItemsPanel}" />
+                                        </ScrollViewer>
+                                    </Border>
+                                </Grid>
                             </LayoutTransformControl>
                         </Popup>
                     </Grid>

--- a/SukiUI/Theme/PathIcon.axaml
+++ b/SukiUI/Theme/PathIcon.axaml
@@ -10,7 +10,13 @@
                     <Viewbox Width="{TemplateBinding Width}" Height="{TemplateBinding Height}">
                         <Path Data="{TemplateBinding Data}"
                               Fill="{TemplateBinding Foreground}"
-                              Stretch="Uniform" />
+                              Stretch="Uniform">
+                            <Path.Transitions>
+                                <Transitions>
+                                    <BrushTransition Property="Fill" Duration="{DynamicResource ShortAnimationDuration}" />
+                                </Transitions>
+                            </Path.Transitions>
+                        </Path>
                     </Viewbox>
                 </Border>
             </ControlTemplate>


### PR DESCRIPTION
***Changes***
- Very rough first draft of the `Calendar` control, it could definitely do with a little tweaking but it's at least in-line with the rest of the library.
- Made the `Expander` control interactive across the entire header to improve interaction.
- Tidied up a few bits and pieces in the demo app, mainly just changing some headers and text values.
- Give `PathIcon` a brush transition by default.
- Switched `GlassCard` to use `Panel` instead of `Grid` internally.
  - Performance seems to be slightly better on pages with lots of `GlassCard` controls but it's probably placebo.

***Outstanding Issues***
- Calendar does rely on a few magic numbers in terms of width/height values for bits and pieces to prevent constant layout shifting but it's fine so I'm loathed to poke around too much.
- The `<` and `>` buttons on the calendar don't feel very interactive, the `:pointerover` scale transform for the `Basic` button style doesn't seem to have any effect on the `PathIcon` which is a little annoying.
- `DatePicker` likes to resize a _lot_ when you switch dates, there might be some scope to try and get that to behave a bit better to prevent the pretty significant UI jerking out of the box, but it would involve some fixed values which might not be particularly nice.