### PR TITLE
Bump Avalonia to 11.0.9

### DIFF
--- a/SukiUI.Demo/Features/ControlsLibrary/ProgressView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/ProgressView.axaml
@@ -148,7 +148,7 @@
 
                 <controls:GlassCard Width="500">
                     <controls:GroupBox Header="Stepper">
-                        <StackPanel  Spacing="15">
+                        <StackPanel Spacing="15">
                             <showMeTheXaml:XamlDisplay Margin="0,20,0,0" UniqueId="Stepper">
                                 <controls:Stepper Index="{Binding StepIndex}" Steps="{Binding Steps}" />
                             </showMeTheXaml:XamlDisplay>
@@ -166,12 +166,14 @@
                         </StackPanel>
                     </controls:GroupBox>
                 </controls:GlassCard>
-                
+
                 <controls:GlassCard Width="500">
                     <controls:GroupBox Header="Alternative Stepper">
                         <StackPanel Spacing="15">
                             <showMeTheXaml:XamlDisplay UniqueId="AltStepper">
-                                <controls:Stepper AlternativeStyle="True" Index="{Binding StepIndex}" Steps="{Binding Steps}" />
+                                <controls:Stepper AlternativeStyle="True"
+                                                  Index="{Binding StepIndex}"
+                                                  Steps="{Binding Steps}" />
                             </showMeTheXaml:XamlDisplay>
                             <!--  Ignore your IDE, x:True and x:False are absolutely valid intrinsics in Avalonia.  -->
                             <Grid ColumnDefinitions="Auto,*,Auto">

--- a/SukiUI.Demo/Features/ControlsLibrary/TextView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/TextView.axaml
@@ -1,17 +1,16 @@
-<UserControl
-    d:DesignHeight="450"
-    d:DesignWidth="800"
-    mc:Ignorable="d"
-    x:Class="SukiUI.Demo.Features.ControlsLibrary.TextView"
-    x:DataType="controlsLibrary:TextViewModel"
-    xmlns="https://github.com/avaloniaui"
-    xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
-    xmlns:controlsLibrary="clr-namespace:SukiUI.Demo.Features.ControlsLibrary"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:showMeTheXaml="clr-namespace:ShowMeTheXaml;assembly=ShowMeTheXaml.Avalonia"
-    xmlns:theme="clr-namespace:SukiUI.Theme;assembly=SukiUI"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+<UserControl x:Class="SukiUI.Demo.Features.ControlsLibrary.TextView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:controlsLibrary="clr-namespace:SukiUI.Demo.Features.ControlsLibrary"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:showMeTheXaml="clr-namespace:ShowMeTheXaml;assembly=ShowMeTheXaml.Avalonia"
+             xmlns:theme="clr-namespace:SukiUI.Theme;assembly=SukiUI"
+             d:DesignHeight="450"
+             d:DesignWidth="800"
+             x:DataType="controlsLibrary:TextViewModel"
+             mc:Ignorable="d">
     <UserControl.Styles>
         <Style Selector="showMeTheXaml|XamlDisplay &gt; TextBox">
             <Setter Property="Text" Value="{Binding TextBoxValue}" />
@@ -21,7 +20,7 @@
             <Setter Property="TextWrapping" Value="Wrap" />
         </Style>
     </UserControl.Styles>
-    <ScrollViewer HorizontalScrollBarVisibility="Disabled">
+    <ScrollViewer>
         <WrapPanel Classes="PageContainer">
             <controls:GlassCard>
                 <controls:GroupBox Header="Text Styles">
@@ -34,16 +33,15 @@
                                 The h and color styles can be combined.
                             </TextBlock>
                         </StackPanel>
-                        <showMeTheXaml:XamlDisplay UniqueId="TextHyperlink">
+                        <showMeTheXaml:XamlDisplay UniqueId="TextBlockWithHyperlink">
                             <TextBlock>
-                                Text With A<InlineUIContainer>
-                                    <Button
-                                        Classes="Hyperlink"
-                                        Command="{Binding HyperlinkClickedCommand}"
-                                        Content="Hyperlink"
-                                        FontSize="32" />
-                                </InlineUIContainer>
-                                Inside.</TextBlock>
+                                Text With A
+                                <!--  BUG: This now causes a `Control already has visual parent` bug.  -->
+                                <!--  <Button Classes="Hyperlink"  -->
+                                <!--  Command="{Binding HyperlinkClickedCommand}"  -->
+                                <!--  Content="Hyperlink" />  -->
+                                Inside.
+                            </TextBlock>
                         </showMeTheXaml:XamlDisplay>
                         <showMeTheXaml:XamlDisplay UniqueId="TextBlock1">
                             <TextBlock Classes="h1" />

--- a/SukiUI.Demo/Features/ControlsLibrary/TextView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/TextView.axaml
@@ -36,7 +36,7 @@
                         <showMeTheXaml:XamlDisplay UniqueId="TextBlockWithHyperlink">
                             <TextBlock>
                                 Text With A
-                                <!--  BUG: This now causes a `Control already has visual parent` bug.  -->
+                                <!--  BUG: This now causes a `Control already has visual parent` exception. Any control you put in here causes it - Regression from 11.0.7+  -->
                                 <!--  <Button Classes="Hyperlink"  -->
                                 <!--  Command="{Binding HyperlinkClickedCommand}"  -->
                                 <!--  Content="Hyperlink" />  -->

--- a/SukiUI.Demo/Features/Splash/SplashView.axaml
+++ b/SukiUI.Demo/Features/Splash/SplashView.axaml
@@ -21,14 +21,14 @@
                        Source="../../Assets/OIG.N5o-removebg-preview.png" />
                 <TextBlock Name="TextBlockWithInline">
                     In this app you'll find a sample page
-                    (<InlineUIContainer>
-                        <Button Classes="Hyperlink"
-                                Command="{Binding OpenDashboardCommand}"
-                                Content="Dashboard"
-                                FontSize="16" />
-                    </InlineUIContainer>
+                    (
+                    <Button Classes="Hyperlink"
+                            Command="{Binding OpenDashboardCommand}"
+                            Content="Dashboard"
+                            FontSize="16" />
                     )
-                    with a variety of controls used together, as well as a control library for testing and demonstration purposes.</TextBlock>
+                    with a variety of controls used together, as well as a control library for testing and demonstration purposes.
+                </TextBlock>
                 <TextBlock>
                     You'll also find in the menu above toggles and other options to control the theme of the app.
                 </TextBlock>

--- a/SukiUI.Demo/SukiUI.Demo.csproj
+++ b/SukiUI.Demo/SukiUI.Demo.csproj
@@ -9,13 +9,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="11.0.8" />
+		<PackageReference Include="Avalonia" Version="11.0.9" />
 		<PackageReference Include="Avalonia.AvaloniaEdit" Version="11.0.6" />
-		<PackageReference Include="Avalonia.Desktop" Version="11.0.8" />
-		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.8" />
-		<PackageReference Include="Avalonia.Fonts.Inter" Version="11.0.8" />
+		<PackageReference Include="Avalonia.Desktop" Version="11.0.9" />
+		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.9" />
+		<PackageReference Include="Avalonia.Fonts.Inter" Version="11.0.9" />
 		<!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.8" />
+		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.9" />
 		<PackageReference Include="AvaloniaEdit.TextMate" Version="11.0.6" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
 		<PackageReference Include="Material.Icons.Avalonia" Version="2.1.0" />

--- a/SukiUI.Demo/SukiUI.Demo.csproj
+++ b/SukiUI.Demo/SukiUI.Demo.csproj
@@ -9,13 +9,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="11.0.6" />
+		<PackageReference Include="Avalonia" Version="11.0.8" />
 		<PackageReference Include="Avalonia.AvaloniaEdit" Version="11.0.6" />
-		<PackageReference Include="Avalonia.Desktop" Version="11.0.6" />
-		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.6" />
-		<PackageReference Include="Avalonia.Fonts.Inter" Version="11.0.6" />
+		<PackageReference Include="Avalonia.Desktop" Version="11.0.8" />
+		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.8" />
+		<PackageReference Include="Avalonia.Fonts.Inter" Version="11.0.8" />
 		<!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.6" />
+		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.8" />
 		<PackageReference Include="AvaloniaEdit.TextMate" Version="11.0.6" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
 		<PackageReference Include="Material.Icons.Avalonia" Version="2.1.0" />

--- a/SukiUI.Demo/SukiUIDemoView.axaml
+++ b/SukiUI.Demo/SukiUIDemoView.axaml
@@ -16,6 +16,7 @@
                  CanMinimize="{Binding !WindowLocked}"
                  CanMove="{Binding !WindowLocked}"
                  CanResize="{Binding !WindowLocked}"
+                 Icon="/Assets/OIG.N5o-removebg-preview.png"
                  IsMenuVisible="True"
                  mc:Ignorable="d">
     <suki:SukiWindow.LogoContent>
@@ -60,9 +61,7 @@
             <MenuItem Command="{Binding CreateCustomThemeCommand}" Header="Create Custom" />
         </MenuItem>
     </suki:SukiWindow.MenuItems>
-    <suki:SukiSideMenu 
-                       ItemsSource="{Binding DemoPages}"
-                       SelectedItem="{Binding ActivePage}">
+    <suki:SukiSideMenu ItemsSource="{Binding DemoPages}" SelectedItem="{Binding ActivePage}">
         <suki:SukiSideMenu.ItemTemplate>
             <DataTemplate>
                 <suki:SukiSideMenuItem Header="{Binding DisplayName}">

--- a/SukiUI.Demo/SukiUIDemoView.axaml.cs
+++ b/SukiUI.Demo/SukiUIDemoView.axaml.cs
@@ -1,15 +1,7 @@
-using System;
-using System.Reflection;
-using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
-using Avalonia.Media;
-using Avalonia.Media.Imaging;
-using Avalonia.Platform;
-using SukiUI.Content;
 using SukiUI.Controls;
-using SukiUI.Demo.Utilities;
 using SukiUI.Models;
 
 namespace SukiUI.Demo;
@@ -19,8 +11,6 @@ public partial class SukiUIDemoView : SukiWindow
     public SukiUIDemoView()
     {
         InitializeComponent();
-        var bitmap = new Bitmap(AssetLoader.Open(new Uri("avares://SukiUI.Demo/Assets/OIG.N5o-removebg-preview.png")));
-        Icon = new WindowIcon(bitmap);
     }
 
     private void MenuItem_OnClick(object? sender, RoutedEventArgs e)

--- a/SukiUI/SukiUI.csproj
+++ b/SukiUI/SukiUI.csproj
@@ -28,11 +28,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="11.0.8" />
-		<PackageReference Include="Avalonia.Skia" Version="11.0.8" />
+		<PackageReference Include="Avalonia" Version="11.0.9" />
+		<PackageReference Include="Avalonia.Skia" Version="11.0.9" />
 		<PackageReference Include="SkiaSharp" Version="2.88.7" />
-		<PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.8" />
-		<PackageReference Include="Avalonia.Themes.Simple" Version="11.0.8" />
+		<PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.9" />
+		<PackageReference Include="Avalonia.Themes.Simple" Version="11.0.9" />
 		<PackageReference Include="ReactiveUI" Version="19.2.1" />
 	</ItemGroup>
 

--- a/SukiUI/SukiUI.csproj
+++ b/SukiUI/SukiUI.csproj
@@ -28,11 +28,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="11.0.5" />
-		<PackageReference Include="Avalonia.Skia" Version="11.0.5" />
-		<PackageReference Include="SkiaSharp" Version="2.88.6" />
-		<PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.5" />
-		<PackageReference Include="Avalonia.Themes.Simple" Version="11.0.5" />
+		<PackageReference Include="Avalonia" Version="11.0.8" />
+		<PackageReference Include="Avalonia.Skia" Version="11.0.8" />
+		<PackageReference Include="SkiaSharp" Version="2.88.7" />
+		<PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.8" />
+		<PackageReference Include="Avalonia.Themes.Simple" Version="11.0.8" />
 		<PackageReference Include="ReactiveUI" Version="19.2.1" />
 	</ItemGroup>
 


### PR DESCRIPTION
This is a PR with the change and I think should serve as a discussion point about what is best for SukiUI going forward, should we continue to keep pace with Avalonia's minor versions/revisions and follow major versions with our own major version changes?  (I.E Avalonia 12 would be SukiUI 7.0). Will failing to keep up with Avalonia's minor versions/revisions cause significant issues for users? I think it's worth discussing before making this change, because I'm not sure what to do for the best long term.

As a note, somewhere along the line Avalonia introduced a regression which causes `TextBlock` runs to have a brand new bug. This can be seen in `TextView.axaml` the offending code has been commented out, nothing I have tried seems to work to fix it even though that exact same button setup works fine in other pages.

This PR is up so it can be checked out locally and probably shouldn't be merged until a decision is made.