### PR TITLE
`SukiHost`  internals rewrite.

### DIFF
--- a/SukiUI.Demo/App.axaml
+++ b/SukiUI.Demo/App.axaml
@@ -11,12 +11,12 @@
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceInclude Source="Styles/CompletionWindowStyles.axaml"></ResourceInclude>
+                <ResourceInclude Source="Styles/CompletionWindowStyles.axaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>
     <Application.Styles>
-     <FluentTheme></FluentTheme>
+        <FluentTheme />
         <StyleInclude Source="avares://Avalonia.Controls.ColorPicker/Themes/Fluent/Fluent.xaml" />
         <StyleInclude Source="avares://AvaloniaEdit/Themes/Fluent/AvaloniaEdit.xaml" />
         <sukiUi:SukiTheme ThemeColor="Red" />
@@ -26,5 +26,5 @@
         <StyleInclude Source="avares://SukiUI.Demo/Styles/GlassCardStyles.axaml" />
         <avalonia:MaterialIconStyles />
     </Application.Styles>
-    
+
 </Application>

--- a/SukiUI.Demo/Features/ControlsLibrary/CollectionsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/CollectionsView.axaml
@@ -5,9 +5,8 @@
              xmlns:controlsLibrary="clr-namespace:SukiUI.Demo.Features.ControlsLibrary"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:showMeTheXaml="clr-namespace:ShowMeTheXaml;assembly=ShowMeTheXaml.Avalonia"
-             xmlns:theme="clr-namespace:SukiUI.Theme;assembly=SukiUI"
              xmlns:objectModel="clr-namespace:System.Collections.ObjectModel;assembly=System.ObjectModel"
+             xmlns:showMeTheXaml="clr-namespace:ShowMeTheXaml;assembly=ShowMeTheXaml.Avalonia"
              xmlns:system="clr-namespace:System;assembly=System.Runtime"
              d:DesignHeight="450"
              d:DesignWidth="800"
@@ -44,11 +43,11 @@
                         </showMeTheXaml:XamlDisplay>
                     </controls:GroupBox>
                 </controls:GlassCard>
-                
+
                 <controls:GlassCard>
                     <controls:GroupBox Header="AutoCompleteBox">
                         <showMeTheXaml:XamlDisplay UniqueId="AutoCompleteBox">
-                            <AutoCompleteBox >
+                            <AutoCompleteBox>
                                 <AutoCompleteBox.ItemsSource>
                                     <objectModel:ObservableCollection x:TypeArguments="system:String">
                                         <system:String>USA 1</system:String>

--- a/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogWindowDemo.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogWindowDemo.axaml
@@ -1,10 +1,10 @@
-<controls:SukiWindow x:Class="SukiUI.Demo.Features.ControlsLibrary.Toasts.ToastWindowDemo"
+<controls:SukiWindow x:Class="SukiUI.Demo.Features.ControlsLibrary.Dialogs.DialogWindowDemo"
                      xmlns="https://github.com/avaloniaui"
                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                      xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
                      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                     Title="Toast Window Demo"
+                     Title="Dialog Window Demo"
                      Width="550"
                      Height="400"
                      d:DesignHeight="450"
@@ -15,7 +15,7 @@
             <controls:GroupBox Header="Toasts">
                 <StackPanel Classes="HeaderContent">
                     <TextBlock>
-                        Demos the ability for individual windows (or the main window) to be addressed by the toast system.
+                        Demos the ability for individual windows (or the main window) to be addressed by the dialog system.
                     </TextBlock>
                 </StackPanel>
             </controls:GroupBox>
@@ -25,15 +25,15 @@
                 <controls:GlassCard>
                     <controls:GroupBox Header="Show In This Window">
                         <Button Margin="15,10,15,0"
-                                Click="ShowToastInThisWindowClicked"
-                                Content="Show Toast" />
+                                Click="ShowDialogInThisWindowClicked"
+                                Content="Show Dialog" />
                     </controls:GroupBox>
                 </controls:GlassCard>
                 <controls:GlassCard>
                     <controls:GroupBox Header="Show In MainWindow">
                         <Button Margin="15,10,15,0"
-                                Click="ShowToastInMainWindowClicked"
-                                Content="Show Toast" />
+                                Click="ShowDialogInMainWindowClicked"
+                                Content="Show Dialog" />
                     </controls:GroupBox>
                 </controls:GlassCard>
             </WrapPanel>

--- a/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogWindowDemo.axaml.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogWindowDemo.axaml.cs
@@ -1,0 +1,19 @@
+using Avalonia.Interactivity;
+using SukiUI.Controls;
+
+namespace SukiUI.Demo.Features.ControlsLibrary.Dialogs
+{
+    public partial class DialogWindowDemo : SukiWindow
+    {
+        public DialogWindowDemo()
+        {
+            InitializeComponent();
+        }
+
+        private void ShowDialogInThisWindowClicked(object? sender, RoutedEventArgs e) => 
+            SukiHost.ShowDialog(this, "A simple dialog that is shown in the demo window.\r\nClick outside dialog to close.", allowBackgroundClose: true);
+
+        private void ShowDialogInMainWindowClicked(object? sender, RoutedEventArgs e) => 
+            SukiHost.ShowDialog("A simple dialog that was shown from the demo window.\r\nClick outside dialog to close.", allowBackgroundClose: true);
+    }
+}

--- a/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsView.axaml
@@ -1,13 +1,13 @@
-<UserControl x:Class="SukiUI.Demo.Features.ControlsLibrary.DialogsView"
+<UserControl x:Class="SukiUI.Demo.Features.ControlsLibrary.Dialogs.DialogsView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
-             xmlns:controlsLibrary="clr-namespace:SukiUI.Demo.Features.ControlsLibrary"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:dialogs="clr-namespace:SukiUI.Demo.Features.ControlsLibrary.Dialogs"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              d:DesignHeight="450"
              d:DesignWidth="800"
-             x:DataType="controlsLibrary:DialogsViewModel"
+             x:DataType="dialogs:DialogsViewModel"
              mc:Ignorable="d">
     <Grid RowDefinitions="Auto,*">
         <controls:GlassCard Classes="HeaderCard">
@@ -34,20 +34,27 @@
                     <controls:GroupBox Header="Standard Dialog">
                         <Button Margin="15,10,15,0"
                                 Command="{Binding OpenStandardDialogCommand}"
-                                Content="Open" />
+                                Content="Show Dialog" />
                     </controls:GroupBox>
                 </controls:GlassCard>
                 <controls:GlassCard>
                     <controls:GroupBox Header="Background Closable Dialog">
                         <Button Margin="15,10,15,0"
                                 Command="{Binding OpenBackgroundCloseDialogCommand}"
-                                Content="Open" />
+                                Content="Show Dialog" />
                     </controls:GroupBox>
                 </controls:GlassCard>
                 <controls:GlassCard>
                     <controls:GroupBox Header="ViewModel Dialog">
                         <Button Margin="15,10,15,0"
                                 Command="{Binding OpenViewModelDialogCommand}"
+                                Content="Show Dialog" />
+                    </controls:GroupBox>
+                </controls:GlassCard>
+                <controls:GlassCard>
+                    <controls:GroupBox Header="Window Dialog Demo">
+                        <Button Margin="15,10,15,0"
+                                Command="{Binding OpenDialogWindowDemoCommand}"
                                 Content="Open" />
                     </controls:GroupBox>
                 </controls:GlassCard>

--- a/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsView.axaml.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsView.axaml.cs
@@ -1,8 +1,6 @@
-using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
 
-namespace SukiUI.Demo.Features.ControlsLibrary
+namespace SukiUI.Demo.Features.ControlsLibrary.Dialogs
 {
     public partial class DialogsView : UserControl
     {

--- a/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsViewModel.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsViewModel.cs
@@ -1,28 +1,31 @@
 using CommunityToolkit.Mvvm.Input;
 using Material.Icons;
 using SukiUI.Controls;
-using SukiUI.Demo.Features.ControlsLibrary.Dialogs;
 using SukiUI.Demo.Utilities;
 
-namespace SukiUI.Demo.Features.ControlsLibrary
+namespace SukiUI.Demo.Features.ControlsLibrary.Dialogs
 {
     public partial class DialogsViewModel() : DemoPageBase("Dialogs", MaterialIconKind.Forum)
     {
         [RelayCommand]
-        public void OpenStandardDialog() =>
+        private void OpenStandardDialog() =>
             SukiHost.ShowDialog(new StandardDialog());
 
         [RelayCommand]
-        public void OpenBackgroundCloseDialog() =>
+        private void OpenBackgroundCloseDialog() =>
             SukiHost.ShowDialog(new BackgroundCloseDialog(), allowBackgroundClose: true);
         
         [RelayCommand]
-        public void OpenViewModelDialog() =>
+        private void OpenViewModelDialog() =>
             SukiHost.ShowDialog(new VmDialogViewModel(), allowBackgroundClose: true);
 
         [RelayCommand]
-        public void OpenSourceURL() =>
+        private void OpenDialogWindowDemo() => new DialogWindowDemo().Show();
+
+        [RelayCommand]
+        private void OpenSourceURL() =>
             UrlUtilities.OpenURL(
                 $"https://github.com/kikipoulet/SukiUI/blob/main/SukiUI.Demo/Features/ControlsLibrary/{nameof(DialogsViewModel)}.cs");
+        
     }
 }

--- a/SukiUI.Demo/Features/ControlsLibrary/DialogsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/DialogsView.axaml
@@ -5,7 +5,6 @@
              xmlns:controlsLibrary="clr-namespace:SukiUI.Demo.Features.ControlsLibrary"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:theme="clr-namespace:SukiUI.Theme;assembly=SukiUI"
              d:DesignHeight="450"
              d:DesignWidth="800"
              x:DataType="controlsLibrary:DialogsViewModel"

--- a/SukiUI.Demo/Features/ControlsLibrary/IconsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/IconsView.axaml
@@ -5,7 +5,6 @@
              xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
              xmlns:controlsLibrary="clr-namespace:SukiUI.Demo.Features.ControlsLibrary"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:generic="clr-namespace:System.Collections.Generic;assembly=System.Runtime"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:showMeTheXaml="clr-namespace:ShowMeTheXaml;assembly=ShowMeTheXaml.Avalonia"
              xmlns:theme="clr-namespace:SukiUI.Theme;assembly=SukiUI"

--- a/SukiUI.Demo/Features/ControlsLibrary/ProgressView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/ProgressView.axaml
@@ -6,7 +6,6 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:showMeTheXaml="clr-namespace:ShowMeTheXaml;assembly=ShowMeTheXaml.Avalonia"
-             xmlns:theme="clr-namespace:SukiUI.Theme;assembly=SukiUI"
              d:DesignHeight="450"
              d:DesignWidth="800"
              x:DataType="controlsLibrary:ProgressViewModel"
@@ -148,7 +147,7 @@
 
                 <controls:GlassCard Width="500">
                     <controls:GroupBox Header="Stepper">
-                        <StackPanel  Spacing="15">
+                        <StackPanel Spacing="15">
                             <showMeTheXaml:XamlDisplay Margin="0,20,0,0" UniqueId="Stepper">
                                 <controls:Stepper Index="{Binding StepIndex}" Steps="{Binding Steps}" />
                             </showMeTheXaml:XamlDisplay>
@@ -166,12 +165,14 @@
                         </StackPanel>
                     </controls:GroupBox>
                 </controls:GlassCard>
-                
+
                 <controls:GlassCard Width="500">
                     <controls:GroupBox Header="Alternative Stepper">
                         <StackPanel Spacing="15">
                             <showMeTheXaml:XamlDisplay UniqueId="AltStepper">
-                                <controls:Stepper AlternativeStyle="True" Index="{Binding StepIndex}" Steps="{Binding Steps}" />
+                                <controls:Stepper AlternativeStyle="True"
+                                                  Index="{Binding StepIndex}"
+                                                  Steps="{Binding Steps}" />
                             </showMeTheXaml:XamlDisplay>
                             <!--  Ignore your IDE, x:True and x:False are absolutely valid intrinsics in Avalonia.  -->
                             <Grid ColumnDefinitions="Auto,*,Auto">

--- a/SukiUI.Demo/Features/ControlsLibrary/PropertyGridView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/PropertyGridView.axaml
@@ -5,7 +5,6 @@
              xmlns:controlsLibrary="clr-namespace:SukiUI.Demo.Features.ControlsLibrary"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:showMeTheXaml="clr-namespace:ShowMeTheXaml;assembly=ShowMeTheXaml.Avalonia"
              xmlns:theme="clr-namespace:SukiUI.Theme;assembly=SukiUI"
              d:DesignHeight="1050"
              d:DesignWidth="800"

--- a/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastWindowDemo.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastWindowDemo.axaml
@@ -1,0 +1,42 @@
+<controls:SukiWindow x:Class="SukiUI.Demo.Features.ControlsLibrary.Toasts.ToastWindowDemo"
+                     xmlns="https://github.com/avaloniaui"
+                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                     xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+                     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                     Title="Toast Window Demo"
+                     Width="550"
+                     Height="400"
+                     d:DesignHeight="450"
+                     d:DesignWidth="800"
+                     mc:Ignorable="d">
+    <Grid RowDefinitions="Auto,*">
+        <controls:GlassCard Classes="HeaderCard">
+            <controls:GroupBox Header="Toasts">
+                <StackPanel Classes="HeaderContent">
+                    <TextBlock>
+                        Demos the ability for individual windows (or the main window) to be addressed by the dialog system.
+                    </TextBlock>
+                </StackPanel>
+            </controls:GroupBox>
+        </controls:GlassCard>
+        <ScrollViewer Grid.Row="1">
+            <WrapPanel Classes="PageContainer">
+                <controls:GlassCard>
+                    <controls:GroupBox Header="Show In This Window">
+                        <Button Margin="15,10,15,0"
+                                Click="ShowToastInThisWindowClicked"
+                                Content="Show Toast" />
+                    </controls:GroupBox>
+                </controls:GlassCard>
+                <controls:GlassCard>
+                    <controls:GroupBox Header="Show In MainWindow">
+                        <Button Margin="15,10,15,0"
+                                Click="ShowToastInMainWindowClicked"
+                                Content="Show Toast" />
+                    </controls:GroupBox>
+                </controls:GlassCard>
+            </WrapPanel>
+        </ScrollViewer>
+    </Grid>
+</controls:SukiWindow>

--- a/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastWindowDemo.axaml.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastWindowDemo.axaml.cs
@@ -1,0 +1,20 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using SukiUI.Controls;
+
+namespace SukiUI.Demo.Features.ControlsLibrary.Toasts
+{
+    public partial class ToastWindowDemo : SukiWindow
+    {
+        public ToastWindowDemo()
+        {
+            InitializeComponent();
+        }
+
+        private void ShowToastInThisWindowClicked(object? sender, RoutedEventArgs e) => 
+            SukiHost.ShowToast(this, "Window Toast", "Toast shown in a specific window.");
+
+        private void ShowToastInMainWindowClicked(object? sender, RoutedEventArgs e) => 
+            SukiHost.ShowToast("Window Toast", "Toast shown in the earliest open window from the demo window.");
+    }
+}

--- a/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastsView.axaml
@@ -61,7 +61,7 @@
                     <controls:GroupBox Header="Separate Toast Window">
                         <Button Margin="15,10,15,0"
                                 Command="{Binding ShowToastWindowCommand}"
-                                Content="Show Window" />
+                                Content="Open" />
                     </controls:GroupBox>
                 </controls:GlassCard>
             </WrapPanel>

--- a/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastsView.axaml
@@ -1,13 +1,13 @@
-<UserControl x:Class="SukiUI.Demo.Features.ControlsLibrary.ToastsView"
+<UserControl x:Class="SukiUI.Demo.Features.ControlsLibrary.Toasts.ToastsView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
-             xmlns:controlsLibrary="clr-namespace:SukiUI.Demo.Features.ControlsLibrary"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:toasts="clr-namespace:SukiUI.Demo.Features.ControlsLibrary.Toasts"
              d:DesignHeight="450"
              d:DesignWidth="800"
-             x:DataType="controlsLibrary:ToastsViewModel"
+             x:DataType="toasts:ToastsViewModel"
              mc:Ignorable="d">
     <Grid RowDefinitions="Auto,*">
         <controls:GlassCard Classes="HeaderCard">
@@ -55,6 +55,13 @@
                         <Button Margin="15,10,15,0"
                                 Command="{Binding ShowToastWithCallbackCommand}"
                                 Content="Show Toast" />
+                    </controls:GroupBox>
+                </controls:GlassCard>
+                <controls:GlassCard>
+                    <controls:GroupBox Header="Separate Toast Window">
+                        <Button Margin="15,10,15,0"
+                                Command="{Binding ShowToastWindowCommand}"
+                                Content="Show Window" />
                     </controls:GroupBox>
                 </controls:GlassCard>
             </WrapPanel>

--- a/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastsView.axaml.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastsView.axaml.cs
@@ -1,8 +1,6 @@
-using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
 
-namespace SukiUI.Demo.Features.ControlsLibrary
+namespace SukiUI.Demo.Features.ControlsLibrary.Toasts
 {
     public partial class ToastsView : UserControl
     {

--- a/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastsViewModel.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastsViewModel.cs
@@ -1,12 +1,12 @@
+using System;
+using System.Threading.Tasks;
 using Avalonia.Controls;
 using CommunityToolkit.Mvvm.Input;
 using Material.Icons;
 using SukiUI.Controls;
 using SukiUI.Demo.Utilities;
-using System;
-using System.Threading.Tasks;
 
-namespace SukiUI.Demo.Features.ControlsLibrary
+namespace SukiUI.Demo.Features.ControlsLibrary.Toasts
 {
     public partial class ToastsViewModel() : DemoPageBase("Toasts", MaterialIconKind.BellRing)
     {
@@ -34,5 +34,8 @@ namespace SukiUI.Demo.Features.ControlsLibrary
                     new TextBlock { Text = "You clicked the toast! - Click anywhere outside of this dialog to close." },
                     allowBackgroundClose: true));
         }
+
+        [RelayCommand]
+        public void ShowToastWindow() => new ToastWindowDemo().Show();
     }
 }

--- a/SukiUI.Demo/Features/ControlsLibrary/TogglesView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/TogglesView.axaml
@@ -6,7 +6,6 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:showMeTheXaml="clr-namespace:ShowMeTheXaml;assembly=ShowMeTheXaml.Avalonia"
-             xmlns:theme="clr-namespace:SukiUI.Theme;assembly=SukiUI"
              d:DesignHeight="450"
              d:DesignWidth="800"
              x:DataType="controlsLibrary:TogglesViewModel"

--- a/SukiUI.Demo/Features/Playground/PlaygroundView.axaml
+++ b/SukiUI.Demo/Features/Playground/PlaygroundView.axaml
@@ -1,53 +1,89 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
+﻿<UserControl x:Class="SukiUI.Demo.Features.Playground.PlaygroundView"
+             xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
+             xmlns:avaloniaEdit="https://github.com/avaloniaui/avaloniaedit"
+             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:avaloniaEdit="https://github.com/avaloniaui/avaloniaedit" x:DataType="playground:PlaygroundViewModel"
-             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
-             xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
              xmlns:playground="clr-namespace:SukiUI.Demo.Features.Playground"
              xmlns:theme="clr-namespace:SukiUI.Theme;assembly=SukiUI"
-             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
-             x:Class="SukiUI.Demo.Features.Playground.PlaygroundView">
+             d:DesignHeight="450"
+             d:DesignWidth="800"
+             x:DataType="playground:PlaygroundViewModel"
+             mc:Ignorable="d">
     <controls:SukiStackPage>
         <controls:SukiStackPage.Content>
-            
-            <SplitView IsPaneOpen="False" Name="Playground" DisplayMode="CompactInline" OpenPaneLength="250" CompactPaneLength="50">
+
+            <SplitView Name="Playground"
+                       CompactPaneLength="50"
+                       DisplayMode="CompactInline"
+                       IsPaneOpen="False"
+                       OpenPaneLength="250">
                 <SplitView.Pane>
                     <Grid>
-                        
-                        <DockPanel IsHitTestVisible="False" Opacity="0"  Name="TabControls" >
-                            <Button DockPanel.Dock="Top" Click="ClosePane" Margin="0,25" IsHitTestVisible="True" Opacity="1" Padding="0" HorizontalAlignment="Center" VerticalAlignment="Top" Classes="Basic">
+
+                        <DockPanel Name="TabControls"
+                                   IsHitTestVisible="False"
+                                   Opacity="0">
+                            <Button Margin="0,25"
+                                    Padding="0"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Top"
+                                    Classes="Basic"
+                                    Click="ClosePane"
+                                    DockPanel.Dock="Top"
+                                    IsHitTestVisible="True"
+                                    Opacity="1">
                                 <StackPanel>
-                                    <TextBlock  HorizontalAlignment="Center"  Foreground="{DynamicResource SukiLowText}" FontSize="12" Text="Close"></TextBlock>
-                                    <avalonia:MaterialIcon Kind="ChevronLeft" Foreground="{DynamicResource SukiLowText}"></avalonia:MaterialIcon>
+                                    <TextBlock HorizontalAlignment="Center"
+                                               FontSize="12"
+                                               Foreground="{DynamicResource SukiLowText}"
+                                               Text="Close" />
+                                    <avalonia:MaterialIcon Foreground="{DynamicResource SukiLowText}" Kind="ChevronLeft" />
                                 </StackPanel>
                             </Button>
-                            <TabControl Margin="0,20,0,0" TabStripPlacement="Left" >
-                           
+                            <TabControl Margin="0,20,0,0" TabStripPlacement="Left">
+
                                 <TabItem Header="Buttons">
-                                <ScrollViewer>
-                                <ItemsControl theme:ItemsControlExtensions.AnimatedScroll="True" ItemsSource="{Binding ButtonsElements }">
-                                    <ItemsControl.ItemTemplate>
-                                        <DataTemplate>
-                                            <controls:GlassCard Tag="{Binding}" PointerPressed="AddNewControls" CornerRadius="10" IsInteractive="True" Margin="0,8" MinHeight="100">
-                                                <Viewbox StretchDirection="DownOnly">
-                                                    <ContentControl IsHitTestVisible="False" HorizontalAlignment="Center" VerticalAlignment="Center" Content="{Binding, Converter={x:Static playground:StringToControlConverter.Instance}}"></ContentControl>
-                                                </Viewbox>
-                                            </controls:GlassCard>
-                                        </DataTemplate>
-                                    </ItemsControl.ItemTemplate>
-                                </ItemsControl>
-                                </ScrollViewer>
-                            </TabItem>
-                                <TabItem Header="Layout">
                                     <ScrollViewer>
-                                        <ItemsControl theme:ItemsControlExtensions.AnimatedScroll="True" ItemsSource="{Binding LayoutElements }">
+                                        <ItemsControl theme:ItemsControlExtensions.AnimatedScroll="True" ItemsSource="{Binding ButtonsElements}">
                                             <ItemsControl.ItemTemplate>
                                                 <DataTemplate>
-                                                    <controls:GlassCard Tag="{Binding}" PointerPressed="AddNewControls" CornerRadius="10" IsInteractive="True" Margin="0,8" MinHeight="100">
+                                                    <controls:GlassCard MinHeight="100"
+                                                                        Margin="0,8"
+                                                                        CornerRadius="10"
+                                                                        IsInteractive="True"
+                                                                        PointerPressed="AddNewControls"
+                                                                        Tag="{Binding}">
                                                         <Viewbox StretchDirection="DownOnly">
-                                                            <ContentControl IsHitTestVisible="False" HorizontalAlignment="Center" VerticalAlignment="Center" Content="{Binding, Converter={x:Static playground:StringToControlConverter.Instance}}"></ContentControl>
+                                                            <ContentControl HorizontalAlignment="Center"
+                                                                            VerticalAlignment="Center"
+                                                                            Content="{Binding, Converter={x:Static playground:StringToControlConverter.Instance}}"
+                                                                            IsHitTestVisible="False" />
+                                                        </Viewbox>
+                                                    </controls:GlassCard>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </ScrollViewer>
+                                </TabItem>
+                                <TabItem Header="Layout">
+                                    <ScrollViewer>
+                                        <ItemsControl theme:ItemsControlExtensions.AnimatedScroll="True" ItemsSource="{Binding LayoutElements}">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate>
+                                                    <controls:GlassCard MinHeight="100"
+                                                                        Margin="0,8"
+                                                                        CornerRadius="10"
+                                                                        IsInteractive="True"
+                                                                        PointerPressed="AddNewControls"
+                                                                        Tag="{Binding}">
+                                                        <Viewbox StretchDirection="DownOnly">
+                                                            <ContentControl HorizontalAlignment="Center"
+                                                                            VerticalAlignment="Center"
+                                                                            Content="{Binding, Converter={x:Static playground:StringToControlConverter.Instance}}"
+                                                                            IsHitTestVisible="False" />
                                                         </Viewbox>
                                                     </controls:GlassCard>
                                                 </DataTemplate>
@@ -57,27 +93,43 @@
                                 </TabItem>
                                 <TabItem Header="Input">
                                     <ScrollViewer>
-                                        <ItemsControl theme:ItemsControlExtensions.AnimatedScroll="True" ItemsSource="{Binding InputsElements }">
-                                        <ItemsControl.ItemTemplate>
-                                            <DataTemplate>
-                                                <controls:GlassCard Tag="{Binding}" PointerPressed="AddNewControls" IsInteractive="True" Margin="0,8" CornerRadius="10" MinHeight="100">
-                                                    <Viewbox StretchDirection="DownOnly">
-                                                        <ContentControl IsHitTestVisible="False" HorizontalAlignment="Center" VerticalAlignment="Center" Content="{Binding, Converter={x:Static playground:StringToControlConverter.Instance}}"></ContentControl>
-                                                    </Viewbox>
-                                                </controls:GlassCard>
-                                            </DataTemplate>
-                                        </ItemsControl.ItemTemplate>
-                                    </ItemsControl>
-                                        </ScrollViewer>
+                                        <ItemsControl theme:ItemsControlExtensions.AnimatedScroll="True" ItemsSource="{Binding InputsElements}">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate>
+                                                    <controls:GlassCard MinHeight="100"
+                                                                        Margin="0,8"
+                                                                        CornerRadius="10"
+                                                                        IsInteractive="True"
+                                                                        PointerPressed="AddNewControls"
+                                                                        Tag="{Binding}">
+                                                        <Viewbox StretchDirection="DownOnly">
+                                                            <ContentControl HorizontalAlignment="Center"
+                                                                            VerticalAlignment="Center"
+                                                                            Content="{Binding, Converter={x:Static playground:StringToControlConverter.Instance}}"
+                                                                            IsHitTestVisible="False" />
+                                                        </Viewbox>
+                                                    </controls:GlassCard>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </ScrollViewer>
                                 </TabItem>
                                 <TabItem Header="Progress">
                                     <ScrollViewer>
-                                        <ItemsControl theme:ItemsControlExtensions.AnimatedScroll="True" ItemsSource="{Binding ProgressElements }">
+                                        <ItemsControl theme:ItemsControlExtensions.AnimatedScroll="True" ItemsSource="{Binding ProgressElements}">
                                             <ItemsControl.ItemTemplate>
                                                 <DataTemplate>
-                                                    <controls:GlassCard Tag="{Binding}" PointerPressed="AddNewControls" IsInteractive="True" Margin="0,8" CornerRadius="10" MinHeight="100">
+                                                    <controls:GlassCard MinHeight="100"
+                                                                        Margin="0,8"
+                                                                        CornerRadius="10"
+                                                                        IsInteractive="True"
+                                                                        PointerPressed="AddNewControls"
+                                                                        Tag="{Binding}">
                                                         <Viewbox StretchDirection="DownOnly">
-                                                            <ContentControl IsHitTestVisible="False" HorizontalAlignment="Center" VerticalAlignment="Center" Content="{Binding, Converter={x:Static playground:StringToControlConverter.Instance}}"></ContentControl>
+                                                            <ContentControl HorizontalAlignment="Center"
+                                                                            VerticalAlignment="Center"
+                                                                            Content="{Binding, Converter={x:Static playground:StringToControlConverter.Instance}}"
+                                                                            IsHitTestVisible="False" />
                                                         </Viewbox>
                                                     </controls:GlassCard>
                                                 </DataTemplate>
@@ -87,12 +139,20 @@
                                 </TabItem>
                                 <TabItem Header="Lists">
                                     <ScrollViewer>
-                                        <ItemsControl theme:ItemsControlExtensions.AnimatedScroll="True" ItemsSource="{Binding ListsElements }">
+                                        <ItemsControl theme:ItemsControlExtensions.AnimatedScroll="True" ItemsSource="{Binding ListsElements}">
                                             <ItemsControl.ItemTemplate>
                                                 <DataTemplate>
-                                                    <controls:GlassCard Tag="{Binding}" PointerPressed="AddNewControls" IsInteractive="True" Margin="0,8" CornerRadius="10" MinHeight="100">
+                                                    <controls:GlassCard MinHeight="100"
+                                                                        Margin="0,8"
+                                                                        CornerRadius="10"
+                                                                        IsInteractive="True"
+                                                                        PointerPressed="AddNewControls"
+                                                                        Tag="{Binding}">
                                                         <Viewbox StretchDirection="DownOnly">
-                                                            <ContentControl IsHitTestVisible="False" HorizontalAlignment="Center" VerticalAlignment="Center" Content="{Binding, Converter={x:Static playground:StringToControlConverter.Instance}}"></ContentControl>
+                                                            <ContentControl HorizontalAlignment="Center"
+                                                                            VerticalAlignment="Center"
+                                                                            Content="{Binding, Converter={x:Static playground:StringToControlConverter.Instance}}"
+                                                                            IsHitTestVisible="False" />
                                                         </Viewbox>
                                                     </controls:GlassCard>
                                                 </DataTemplate>
@@ -100,31 +160,48 @@
                                         </ItemsControl>
                                     </ScrollViewer>
                                 </TabItem>
-                        </TabControl>
+                            </TabControl>
                         </DockPanel>
-                        
-                        <Button Click="OpenPane" Name="OpenPaneButton" Margin="0,25" IsHitTestVisible="True" Opacity="1" Padding="0" HorizontalAlignment="Center" VerticalAlignment="Top" Classes="Basic">
+
+                        <Button Name="OpenPaneButton"
+                                Margin="0,25"
+                                Padding="0"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Top"
+                                Classes="Basic"
+                                Click="OpenPane"
+                                IsHitTestVisible="True"
+                                Opacity="1">
                             <StackPanel>
-                                <TextBlock HorizontalAlignment="Center" Foreground="{DynamicResource SukiLowText}" FontSize="12" Text="Add"></TextBlock>
-                                <TextBlock  HorizontalAlignment="Center"  Foreground="{DynamicResource SukiLowText}" FontSize="12" Text="Controls"></TextBlock>
-                                <avalonia:MaterialIcon Kind="ChevronRight" Foreground="{DynamicResource SukiLowText}"></avalonia:MaterialIcon>
+                                <TextBlock HorizontalAlignment="Center"
+                                           FontSize="12"
+                                           Foreground="{DynamicResource SukiLowText}"
+                                           Text="Add" />
+                                <TextBlock HorizontalAlignment="Center"
+                                           FontSize="12"
+                                           Foreground="{DynamicResource SukiLowText}"
+                                           Text="Controls" />
+                                <avalonia:MaterialIcon Foreground="{DynamicResource SukiLowText}" Kind="ChevronRight" />
                             </StackPanel>
                         </Button>
                     </Grid>
                 </SplitView.Pane>
-                <Grid  ColumnDefinitions="*, 4, *" RowDefinitions="*, Auto">
-        <controls:GlassCard Margin="20">
-        <avaloniaEdit:TextEditor TextChanged="Editor_OnTextChanged"  Text="" Name="Editor"
-                                 ShowLineNumbers="True"
-        />
-        </controls:GlassCard>
-        <GridSplitter Grid.Column="1" Background="Transparent" ResizeDirection="Columns"/>
-        <controls:GlassCard Name="GlassExample" Grid.Column="2" Margin="20">
-        </controls:GlassCard>
-        
-            
-        
-    </Grid>
+                <Grid ColumnDefinitions="*, 4, *" RowDefinitions="*, Auto">
+                    <controls:GlassCard Margin="20">
+                        <avaloniaEdit:TextEditor Name="Editor"
+                                                 ShowLineNumbers="True"
+                                                 Text=""
+                                                 TextChanged="Editor_OnTextChanged" />
+                    </controls:GlassCard>
+                    <GridSplitter Grid.Column="1"
+                                  Background="Transparent"
+                                  ResizeDirection="Columns" />
+                    <controls:GlassCard Name="GlassExample"
+                                        Grid.Column="2"
+                                        Margin="20" />
+
+
+                </Grid>
             </SplitView>
         </controls:SukiStackPage.Content>
     </controls:SukiStackPage>

--- a/SukiUI.Demo/Styles/CompletionWindowStyles.axaml
+++ b/SukiUI.Demo/Styles/CompletionWindowStyles.axaml
@@ -2,11 +2,12 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:cc="clr-namespace:AvaloniaEdit.CodeCompletion;assembly=AvaloniaEdit"
                     xmlns:theme="clr-namespace:SukiUI.Theme;assembly=SukiUI">
-    <ControlTheme x:Key="{x:Type cc:CompletionListBox}" TargetType="cc:CompletionListBox"
-                  BasedOn="{StaticResource {x:Type ListBox}}">
+    <ControlTheme x:Key="{x:Type cc:CompletionListBox}"
+                  BasedOn="{StaticResource {x:Type ListBox}}"
+                  TargetType="cc:CompletionListBox">
         <Setter Property="Padding" Value="0" />
         <Setter Property="ItemContainerTheme">
-            <ControlTheme TargetType="ListBoxItem" BasedOn="{StaticResource {x:Type ListBoxItem}}">
+            <ControlTheme BasedOn="{StaticResource {x:Type ListBoxItem}}" TargetType="ListBoxItem">
                 <Setter Property="TextBlock.Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
                 <Setter Property="Background" Value="Red" />
                 <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
@@ -14,8 +15,8 @@
                 <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
                 <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
                 <Setter Property="Padding" Value="4,1" />
-                <Setter Property="FontSize" Value="12"></Setter>
-                <Setter Property="FontWeight" Value="DemiBold"></Setter>
+                <Setter Property="FontSize" Value="12" />
+                <Setter Property="FontWeight" Value="DemiBold" />
             </ControlTheme>
         </Setter>
         <Setter Property="Template">
@@ -51,20 +52,23 @@
     <ControlTheme x:Key="{x:Type cc:CompletionList}" TargetType="cc:CompletionList">
         <Setter Property="Template">
             <ControlTemplate>
-                <Border Margin="10" BoxShadow="{DynamicResource SukiPopupShadow}" ClipToBounds="True" CornerRadius="8" >
-                <cc:CompletionListBox Name="PART_ListBox">
-                    <cc:CompletionListBox.ItemTemplate>
-                        <DataTemplate x:DataType="cc:ICompletionData">
-                            <StackPanel Orientation="Horizontal" Margin="0">
-                                <Image Source="{Binding Image}"
-                                       Width="16"
-                                       Height="16"
-                                       Margin="0,0,2,0" />
-                                <ContentPresenter Content="{Binding Content}" />
-                            </StackPanel>
-                        </DataTemplate>
-                    </cc:CompletionListBox.ItemTemplate>
-                </cc:CompletionListBox>
+                <Border Margin="10"
+                        BoxShadow="{DynamicResource SukiPopupShadow}"
+                        ClipToBounds="True"
+                        CornerRadius="8">
+                    <cc:CompletionListBox Name="PART_ListBox">
+                        <cc:CompletionListBox.ItemTemplate>
+                            <DataTemplate x:DataType="cc:ICompletionData">
+                                <StackPanel Margin="0" Orientation="Horizontal">
+                                    <Image Width="16"
+                                           Height="16"
+                                           Margin="0,0,2,0"
+                                           Source="{Binding Image}" />
+                                    <ContentPresenter Content="{Binding Content}" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </cc:CompletionListBox.ItemTemplate>
+                    </cc:CompletionListBox>
                 </Border>
             </ControlTemplate>
         </Setter>

--- a/SukiUI.Demo/SukiUI.Demo.csproj
+++ b/SukiUI.Demo/SukiUI.Demo.csproj
@@ -32,4 +32,11 @@
 	  <None Remove="Assets\OIG.N5o-removebg-preview.png" />
 	  <AvaloniaResource Include="Assets\OIG.N5o-removebg-preview.png" />
 	</ItemGroup>
+
+	<ItemGroup>
+	  <Compile Update="Features\ControlsLibrary\Toasts\ToastsView.axaml.cs">
+	    <DependentUpon>ToastsView.axaml</DependentUpon>
+	    <SubType>Code</SubType>
+	  </Compile>
+	</ItemGroup>
 </Project>

--- a/SukiUI.Demo/SukiUI.Demo.csproj
+++ b/SukiUI.Demo/SukiUI.Demo.csproj
@@ -38,5 +38,9 @@
 	    <DependentUpon>ToastsView.axaml</DependentUpon>
 	    <SubType>Code</SubType>
 	  </Compile>
+	  <Compile Update="Features\ControlsLibrary\Dialogs\DialogsView.axaml.cs">
+	    <DependentUpon>DialogsView.axaml</DependentUpon>
+	    <SubType>Code</SubType>
+	  </Compile>
 	</ItemGroup>
 </Project>

--- a/SukiUI/Controls/SukiHost.axaml.cs
+++ b/SukiUI/Controls/SukiHost.axaml.cs
@@ -116,13 +116,14 @@ public class SukiHost : ContentControl
     // This goes for other APIs like the background and theming.
 
     /// <summary>
-    /// 
+    /// Shows a dialog in the <see cref="SukiHost"/>
+    /// Can display ViewModels if provided, if a suitable ViewLocator has been registered with Avalonia.
     /// </summary>
-    /// <param name="window"></param>
-    /// <param name="content"></param>
-    /// <param name="showCardBehind"></param>
-    /// <param name="allowBackgroundClose"></param>
-    /// <exception cref="InvalidOperationException"></exception>
+    /// <param name="window">The window who's SukiHost should be used to display the toast.</param>
+    /// <param name="content">Content to display.</param>
+    /// <param name="showCardBehind">Whether or not to show a card behind the content.</param>
+    /// <param name="allowBackgroundClose">Allows the dialog to be closed by clicking outside of it.</param>
+    /// <exception cref="InvalidOperationException">Thrown if there is no SukiHost associated with the specified window.</exception>
     public static void ShowDialog(Window window, object? content, bool showCardBehind = true,
         bool allowBackgroundClose = false)
     {
@@ -136,8 +137,7 @@ public class SukiHost : ContentControl
     }
     
     /// <summary>
-    /// Shows a dialog in the <see cref="SukiHost"/>
-    /// Can display ViewModels if provided, if a suitable ViewLocator has been registered with Avalonia.
+    /// <inheritdoc cref="ShowDialog(Avalonia.Controls.Window,object?,bool,bool)"/>
     /// </summary>
     /// <param name="content">Content to display.</param>
     /// <param name="showCardBehind">Whether or not to show a card behind the content.</param>
@@ -170,11 +170,12 @@ public class SukiHost : ContentControl
     }
     
     /// <summary>
-    /// 
+    /// Shows a toast in the SukiHost - The default location is in the bottom right.
+    /// This can be changed with an attached property in SukiWindow.
     /// </summary>
-    /// <param name="window"></param>
-    /// <param name="model"></param>
-    /// <exception cref="InvalidOperationException"></exception>
+    /// <param name="window">The window who's SukiHost should be used to display the toast.</param>
+    /// <param name="model">A pre-constructed <see cref="SukiToastModel"/>.</param>
+    /// <exception cref="InvalidOperationException">Thrown if there is no SukiHost associated with the specified window.</exception>
     public static async Task ShowToast(Window window, SukiToastModel model)
     {
         if (!Instances.TryGetValue(window, out var host))
@@ -194,15 +195,16 @@ public class SukiHost : ContentControl
     }
     
     /// <summary>
-    /// <inheritdoc cref="ShowToast(string,object,System.Nullable{System.TimeSpan},System.Action?)"/>
+    /// <inheritdoc cref="ShowToast(Window, SukiToastModel)"/>
+    /// This method will show the toast in the earliest opened window.
     /// </summary>
     /// <param name="model">A pre-constructed <see cref="SukiToastModel"/>.</param>
     public static Task ShowToast(SukiToastModel model) => 
         ShowToast(_mainWindow, model);
     
     /// <summary>
-    /// Shows a toast in the SukiHost - The default location is in the bottom right.
-    /// This can be changed with an attached property in SukiWindow.
+    /// <inheritdoc cref="ShowToast(Window, SukiToastModel)"/>
+    /// This method will show the toast in the earliest opened window.
     /// </summary>
     /// <param name="title">The title to display in the toast.</param>
     /// <param name="content">The content of the toast, this can be any control or ViewModel.</param>
@@ -216,14 +218,14 @@ public class SukiHost : ContentControl
             onClicked));
 
     /// <summary>
-    /// 
+    /// <inheritdoc cref="ShowToast(Window, SukiToastModel)"/>
+    /// This method will show the toast in a specific window.
     /// </summary>
-    /// <param name="window"></param>
-    /// <param name="title"></param>
-    /// <param name="content"></param>
-    /// <param name="duration"></param>
-    /// <param name="onClicked"></param>
-    /// <returns></returns>
+    /// <param name="window">The window who's SukiHost should be used to display the toast.</param>
+    /// <param name="title">The title to display in the toast.</param>
+    /// <param name="content">The content of the toast, this can be any control or ViewModel.</param>
+    /// <param name="duration">Duration for this toast to be active. Default is 2 seconds.</param>
+    /// <param name="onClicked">A callback that will be fired if the Toast is cleared by clicking.</param>
     public static Task ShowToast(Window window, string title, object content, TimeSpan? duration = null,
         Action? onClicked = null) =>
         ShowToast(window, new SukiToastModel(

--- a/SukiUI/Controls/SukiHost.axaml.cs
+++ b/SukiUI/Controls/SukiHost.axaml.cs
@@ -101,7 +101,7 @@ public class SukiHost : ContentControl
         _maxToasts = GetToastLimit(window);
         var toastLoc = GetToastLocation(window);
 
-        e.NameScope.Get<Border>("PART_DialogBackground").PointerPressed += (_, _) => BackgroundRequestClose();
+        e.NameScope.Get<Border>("PART_DialogBackground").PointerPressed += (_, _) => BackgroundRequestClose(this);
 
         e.NameScope.Get<ItemsControl>("PART_ToastPresenter").HorizontalAlignment =
             toastLoc == ToastLocation.BottomLeft
@@ -163,18 +163,11 @@ public class SukiHost : ContentControl
     /// <summary>
     /// Used to close the open dialog when the background is clicked, if this is allowed.
     /// </summary>
-    private static void BackgroundRequestClose(Window window)
+    private static void BackgroundRequestClose(SukiHost host)
     {
-        if (!Instances.TryGetValue(window, out var host))
-            throw new InvalidOperationException("No SukiHost present in this window");
         if (!host.AllowBackgroundClose) return;
         host.IsDialogOpen = false;
     }
-
-    /// <summary>
-    /// Used to close the open dialog when the background is clicked, if this is allowed.
-    /// </summary>
-    private static void BackgroundRequestClose() => BackgroundRequestClose(_mainWindow);
     
     /// <summary>
     /// 

--- a/SukiUI/Controls/SukiToast.axaml.cs
+++ b/SukiUI/Controls/SukiToast.axaml.cs
@@ -14,6 +14,8 @@ public class SukiToast : ContentControl
 
     public static readonly StyledProperty<string> TitleProperty =
         AvaloniaProperty.Register<SukiToast, string>(nameof(Title));
+    
+    internal SukiHost Host { get; private set; }
 
     private readonly Timer _timer = new();
 
@@ -50,8 +52,9 @@ public class SukiToast : ContentControl
         await SukiHost.ClearToast(this);
     }
 
-    public void Initialize(SukiToastModel model)
+    public void Initialize(SukiToastModel model, SukiHost host)
     {
+        Host = host;
         Title = model.Title;
         Content = model.Content;
         _onClickedCallback = model.OnClicked;

--- a/SukiUI/Theme/Index.axaml
+++ b/SukiUI/Theme/Index.axaml
@@ -63,9 +63,10 @@
                 <ResourceInclude Source="avares://sukiUI/Theme/ContextMenu.axaml" />
                 <ResourceInclude Source="avares://sukiUI/Theme/MenuItem.axaml" />
                 <ResourceInclude Source="avares://sukiUI/Theme/FlyoutPresenter.axaml" />
+                <ResourceInclude Source="avares://sukiUI/Theme/MenuFlyoutPresenter.axaml" />
                 <ResourceInclude Source="avares://sukiUI/Theme/AutoCompleteBoxStyles.axaml" />
-                
-                <ResourceInclude Source="avares://sukiUI/Theme/TimePickerStyle.axaml"></ResourceInclude>
+
+                <ResourceInclude Source="avares://sukiUI/Theme/TimePickerStyle.axaml" />
                 <ResourceInclude Source="avares://sukiUI/Theme/Calendar/Calendar.axaml" />
                 <ResourceInclude Source="avares://sukiUI/Theme/Calendar/CalendarButton.axaml" />
                 <ResourceInclude Source="avares://sukiUI/Theme/Calendar/CalendarDayButton.axaml" />

--- a/SukiUI/Theme/MenuFlyoutPresenter.axaml
+++ b/SukiUI/Theme/MenuFlyoutPresenter.axaml
@@ -1,0 +1,35 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <ControlTheme x:Key="SukiMenuFlyoutPresenterStyle" TargetType="MenuFlyoutPresenter">
+        <Setter Property="Background" Value="{DynamicResource SukiCardBackground}" />
+        <Setter Property="CornerRadius" Value="6" />
+        <Setter Property="BorderBrush" Value="{DynamicResource SukiLightBorderBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Panel Margin="1,0,0,0">
+                    <Border Margin="16"
+                            BoxShadow="{DynamicResource SukiPopupShadow}"
+                            CornerRadius="{TemplateBinding CornerRadius}" />
+                    <Border Margin="15"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            ClipToBounds="True"
+                            CornerRadius="{TemplateBinding CornerRadius}">
+                        <ItemsPresenter Name="PART_ItemsPresenter"
+                                        HorizontalAlignment="Left"
+                                        VerticalAlignment="Center"
+                                        ItemsPanel="{TemplateBinding ItemsPanel}"
+                                        KeyboardNavigation.TabNavigation="Continue" />
+                    </Border>
+                </Panel>
+            </ControlTemplate>
+        </Setter>
+        <Style Selector="^ /template/ MenuItem">
+            <Setter Property="Padding" Value="10,0,0,0" />
+        </Style>
+    </ControlTheme>
+    <ControlTheme x:Key="{x:Type MenuFlyoutPresenter}"
+                  BasedOn="{StaticResource SukiMenuFlyoutPresenterStyle}"
+                  TargetType="MenuFlyoutPresenter" />
+</ResourceDictionary>


### PR DESCRIPTION
***Changes***
- `SukiHost` is now correctly localised per-window.
- When windows are closed, the earliest opened window takes it's place as what `SukiHost` considers the `MainWindow`.
- Existing API for `SukiHost` is unchanged, but additional methods now exist for showing toasts and dialogs in specific windows.
- Demos for separate window dialogs/toasts are provided.
- Documentation provided via XMLDocs for all the new methods.

***Fixes***
- Include basic `MenuFlyoutPresenter` style - Fixes #136 
- `SukiHost` by default now falls-back to the earliest open window - Fixes #134 

***Oustanding Issues***
- This is a fairly hard change to test really robustly just with simple manual integration testing, as far as I can tell the new system is fairly bulletproof but I can't be sure there isn't some weird edgecase.
- Documentation is a little messy, but it should be clear enough.
- This API isn't ideal and really it needs rewriting, however this will do the job and won't introduce a breaking change to the existing 6.0 API.
- `MenuFlyoutPresenter` has awkward margins because it has awkward custom `MenuItem` styles inside it. Probably needs a bit more work but it's basically functional now at least.