### PR TITLE
Refactor xaml data storage/retrieval from playground control code into utility class

### DIFF
--- a/SukiUI.Demo/Features/Playground/PlaygroundView.axaml.cs
+++ b/SukiUI.Demo/Features/Playground/PlaygroundView.axaml.cs
@@ -15,6 +15,7 @@ using AvaloniaEdit.Editing;
 using AvaloniaEdit.Indentation.CSharp;
 using SukiUI.Controls;
 using TextMateSharp.Grammars;
+using SukiUI.Demo.Utilities;
 
 namespace SukiUI.Demo.Features.Playground
 {
@@ -44,7 +45,7 @@ namespace SukiUI.Demo.Features.Playground
             _glassPlayground = this.FindControl<GlassCard>("GlassExample");
             _textEditor.TextArea.TextEntered += TextEditor_TextArea_TextEntered;
             _textEditor.TextArea.TextEntering += TextEditor_TextArea_TextEntering;
-            _textEditor.Text = StartingString;
+            _textEditor.Text = XamlData.PlaygroundStartingCode;
             _textEditor.TextArea.IndentationStrategy = new CSharpIndentationStrategy(_textEditor.Options);
             _textEditor.TextArea.RightClickMovesCaret = true;
 
@@ -100,19 +101,7 @@ namespace SukiUI.Demo.Features.Playground
 
         private void Editor_OnTextChanged(object? sender, EventArgs e)
         {
-            const string HeaderCode =
-                """
-                <Grid HorizontalAlignment="Center" VerticalAlignment="Center"
-                    	xmlns:system="clr-namespace:System;assembly=netstandard"
-                    	xmlns:objectModel="clr-namespace:System.Collections.ObjectModel;assembly=System.ObjectModel"
-                    	xmlns:icons="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
-                    	xmlns:suki="clr-namespace:SukiUI.Controls;assembly=SukiUI"
-                    	xmlns='https://github.com/avaloniaui'
-                    	xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
-                
-                """;
-
-            string previewCode = HeaderCode + _textEditor.Text + "</Grid>";
+            string previewCode = XamlData.InsertIntoGridControl(_textEditor.Text);
 
             try
             {
@@ -124,23 +113,6 @@ namespace SukiUI.Demo.Features.Playground
                 // here were are ignoring XmlException, InvalidCastException, XamlLoadException
             }
         }
-
-        private const string StartingString =
-            """
-              <suki:GlassCard Width="300" Height="320" Margin="15" VerticalAlignment="Top">
-                  <Grid>
-                      <TextBlock FontSize="16" FontWeight="DemiBold" Text="Humidity" />
-                      <Viewbox Width="175" Height="175" Margin="0,0,0,5" HorizontalAlignment="Center" VerticalAlignment="Center">
-                          <suki:WaveProgress Value="{Binding Value, ElementName=SliderT}" />
-                      </Viewbox>
-                      <DockPanel VerticalAlignment="Bottom">
-                          <icons:MaterialIcon Width="20" Height="20" DockPanel.Dock="Left" Foreground="#666666" Kind="TemperatureLow" />
-                          <icons:MaterialIcon Width="20" Height="20" DockPanel.Dock="Right" Foreground="#666666" Kind="TemperatureHigh" />
-                          <Slider Name="SliderT" Margin="8,0" Maximum="100" Minimum="0" Value="23" />
-                      </DockPanel>
-                  </Grid>
-              </suki:GlassCard>
-            """;
 
         private void OpenPane(object? sender, RoutedEventArgs e)
         {

--- a/SukiUI.Demo/Features/Playground/PlaygroundViewModel.cs
+++ b/SukiUI.Demo/Features/Playground/PlaygroundViewModel.cs
@@ -4,140 +4,76 @@ using System.Globalization;
 using Avalonia.Controls;
 using Avalonia.Data.Converters;
 using Avalonia.Markup.Xaml;
-using CommunityToolkit.Mvvm.ComponentModel;
 using Material.Icons;
-using SukiUI.Theme;
+using SukiUI.Demo.Utilities;
 
 namespace SukiUI.Demo.Features.Playground
 {
-    public class PlaygroundViewModel : DemoPageBase
+    internal class PlaygroundViewModel() : DemoPageBase("Playground", MaterialIconKind.Pencil, -150)
     {
-        public PlaygroundViewModel() : base("Playground", MaterialIconKind.Pencil, -150)
-        {
-        }
-        
-        public ObservableCollection<string> ButtonsElements { get; set; } = new ObservableCollection<string>()
-        {
-            "<Button Classes=\"Flat\" Content=\"Flat\" />",
-            "<Button Classes=\"Flat Rounded\" Content=\"Rounded\" />",
-            "<Button Classes=\"Basic\" Content=\"Basic\" />",
-            "<Button Content=\"Neutral\" />",
-            "<Button Classes=\"Outlined\" Content=\"Outlined\" />",
-            "<Button Classes=\"Flat Large\" Content=\"Button\" />"
-        };
-        
-        public ObservableCollection<string> InputsElements { get; set; } = new ObservableCollection<string>()
-        {
-            "<TextBox Text=\"Textbox\" />",
-            "<ToggleSwitch />",
-            "<ToggleButton Content=\"Toggle Me\" />",
-            "<Slider MinWidth=\"120\" IsSnapToTickEnabled=\"True\" Maximum=\"100\" Minimum=\"0\" TickFrequency=\"1\" Value=\"50\"></Slider>", 
-            
-            "<ComboBox PlaceholderText=\"Select a Color\">\n" +
-            "   <ComboBoxItem>\n" +
-            "      <TextBlock>Red</TextBlock>\n" +
-            "   </ComboBoxItem>\n" +
-            "</ComboBox>\n" ,
-            
-            "<CheckBox IsChecked=\"True\" />\n" ,
-            
-            
-            "<RadioButton >Item 1</RadioButton>",
-            
-            "<NumericUpDown></NumericUpDown>",
-            "<DatePicker />"
-            
-            
-            
-        };
-        
-        public ObservableCollection<string> ProgressElements { get; set; } = new ObservableCollection<string>()
-        {
-            "<suki:WaveProgress Value=\"40\" IsTextVisible=\"True\" />\n" ,
-            
-            "<suki:Stepper Margin=\"30,15\" Index=\"1\">\n" +
-            "  <suki:Stepper.Steps>\n" +
-            "    <objectModel:ObservableCollection x:TypeArguments=\"system:String\">\n" +
-            "      <system:String>Step One</system:String>\n" +
-            "      <system:String>Step Two</system:String>\n" +
-            "      </objectModel:ObservableCollection>\n" +
-            "  </suki:Stepper.Steps>\n" +
-            "</suki:Stepper>\n" ,
-            
-            "<suki:Stepper AlternativeStyle=\"True\" Margin=\"30,15\" Index=\"1\">\n" +
-            "  <suki:Stepper.Steps>\n" +
-            "    <objectModel:ObservableCollection x:TypeArguments=\"system:String\">\n" +
-            "      <system:String>Step One</system:String>\n" +
-            "      <system:String>Step Two</system:String>\n" +
-  
-            "      </objectModel:ObservableCollection>\n" +
-            "  </suki:Stepper.Steps>\n" +
-            "</suki:Stepper>\n" ,
-            
-            "<suki:CircleProgressBar Height=\"130\" StrokeWidth=\"11\" Value=\"60\" Width=\"130\">\n" +
-            "   <TextBlock Margin=\"0,1,0,0\" Classes=\"h3\">60%</TextBlock>\n" +
-            "</suki:CircleProgressBar>\n" ,
-            
-            "<suki:CircleProgressBar IsIndeterminate=\"True\" />",
-            
-            "<suki:Loading />",
-            
-            "<ProgressBar  Value=\"60\" />" ,
-            "<ProgressBar  Value=\"50\" ShowProgressText=\"True\" />",
-            "<ProgressBar IsIndeterminate=\"True\" />",
-        };
+        public ObservableCollection<string> ButtonsElements { get; init; } =
+        [
+            XamlData.Buttons["ButtonFlat"],
+            XamlData.Buttons["ButtonFlatRounded"],
+            XamlData.Buttons["ButtonFlatLarge"],
+            XamlData.Buttons["ButtonBasic"],
+            XamlData.Buttons["ButtonBasicAccent"],
+            XamlData.Buttons["ButtonNeutral"],
+            XamlData.Buttons["ButtonOutlined"]
+        ];
 
-        public ObservableCollection<string> ListsElements { get; set; } = new ObservableCollection<string>()
-        {
-            "<ListBox>\n" +
-            "   <TextBlock>item 1</TextBlock>\n" +
-            "   <TextBlock>item 2</TextBlock>\n" +
-            "   <TextBlock>item 3</TextBlock>\n" +
-            "</ListBox>",
-            
-            "<TreeView >\n" +
-            "  <TreeViewItem Header=\"Test 1\">\n" +
-            "    <TreeViewItem Header=\"Test 2\" />\n" +
-            "    <TreeViewItem Header=\"Test 3\" />\n" +
-            "  </TreeViewItem>\n" +
-            "  <TreeViewItem Header=\"Test 4\" />\n" +
-            "</TreeView>"
-        };
-        
-        public ObservableCollection<string> LayoutElements { get; set; } = new ObservableCollection<string>()
-        {
-            "<suki:GlassCard />",
-            
-            "<suki:GroupBox Header=\"Header\">\n" +
-            "  <Grid Height=\"100\" Width=\"300\">\n" +
-            "    <TextBlock VerticalAlignment=\"Center\" HorizontalAlignment=\"Center\">Test Content</TextBlock>\n" +
-            "  </Grid>\n" +
-            "</suki:GroupBox>" ,
-            
-            "<Expander Header=\"Click To Expand\">\n" +
-            "   <TextBlock>Expanded</TextBlock>\n" +
-            "</Expander>",
-            
-            "<TabControl>\n" +
-            "  <TabItem Header=\"Red Tab\">\n" +
-            "    <Grid Background=\"#44ff0000\" />\n" +
-            "  </TabItem>\n" +
-            "</TabControl>"
-        };
+        public ObservableCollection<string> InputsElements { get; init; } =
+        [
+            XamlData.Inputs["TextBox"],
+            XamlData.Inputs["ToggleSwitch"],
+            XamlData.Inputs["ToggleButton"],
+            XamlData.Inputs["Slider"],
+            XamlData.Inputs["ComboBox"],
+            XamlData.Inputs["CheckBox"],
+            XamlData.Inputs["RadioButton"],
+            XamlData.Inputs["NumericUpDown"],
+            XamlData.Inputs["DatePicker"]
+        ];
 
+        public ObservableCollection<string> ProgressElements { get; init; } =
+        [
+            XamlData.Progress["WaveProgress"],
+            XamlData.Progress["Stepper"],
+            XamlData.Progress["CircleProgressBar"],
+            XamlData.Progress["StepperAlternativeStyle"],
+            XamlData.Progress["CircleProgressBarIndeterminate"],
+            XamlData.Progress["Loading"],
+            XamlData.Progress["ProgressBar60"],
+            XamlData.Progress["ProgressBar50WithProgressText"],
+            XamlData.Progress["ProgressBarIndeterminate"]
+        ];
+
+        public ObservableCollection<string> ListsElements { get; init; } =
+        [
+            XamlData.Lists["ListBox"],
+            XamlData.Lists["TreeView"]
+        ];
+
+        public ObservableCollection<string> LayoutElements { get; init; } =
+        [
+            XamlData.Layout["GlassCard"],
+            XamlData.Layout["GroupBox"],
+            XamlData.Layout["Expander"],
+            XamlData.Layout["TabControl"]
+        ];
     }
-    
-    public class StringToControlConverter : IValueConverter
+
+    public sealed class StringToControlConverter : IValueConverter
     {
         public static readonly StringToControlConverter Instance = new();
 
         public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
-            string PreviewCode = "<Grid HorizontalAlignment=\"Center\" VerticalAlignment=\"Center\" xmlns:system=\"clr-namespace:System;assembly=netstandard\" xmlns:objectModel=\"clr-namespace:System.Collections.ObjectModel;assembly=System.ObjectModel\" xmlns:icons=\"clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia\" xmlns:suki=\"clr-namespace:SukiUI.Controls;assembly=SukiUI\" xmlns='https://github.com/avaloniaui' xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>" +
-                                 value + "</Grid>";
+            if (value is not string xamlCode) return null;
+            if (string.IsNullOrWhiteSpace(xamlCode)) return null;
 
-            return AvaloniaRuntimeXamlLoader.Parse<Grid>(PreviewCode);
-              
+            var previewCode = XamlData.InsertIntoGridControl(xamlCode);
+            return AvaloniaRuntimeXamlLoader.Parse<Grid>(previewCode);
         }
 
         public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)

--- a/SukiUI.Demo/Utilities/XamlData.cs
+++ b/SukiUI.Demo/Utilities/XamlData.cs
@@ -1,0 +1,221 @@
+﻿using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace SukiUI.Demo.Utilities
+{
+    internal static class XamlData
+    {
+        internal static readonly FrozenDictionary<string, string> Buttons =
+            new Dictionary<string, string>
+            {
+                {
+                    "ButtonFlat", """<Button Classes="Flat" Content="Flat" />"""
+                },
+                {
+                    "ButtonFlatRounded", """<Button Classes="Flat Rounded" Content="Rounded" />"""
+                },
+                {
+                    "ButtonFlatLarge", """<Button Classes="Flat Large" Content="Large" />"""
+                },
+                {
+                    "ButtonBasic", """<Button Classes="Basic" Content="Basic" />"""
+                },
+                {
+                    "ButtonBasicAccent", """<Button Classes="Basic Accent" Content="Basic Accent" />"""
+                },
+                {
+                    "ButtonNeutral", """<Button Content="Neutral" />"""
+                },
+                {
+                    "ButtonOutlined", """<Button Classes="Outlined" Content="Outlined" />"""
+                }
+            }.ToFrozenDictionary();
+
+        internal static readonly FrozenDictionary<string, string> Inputs =
+            new Dictionary<string, string>
+            {
+                {
+                    "TextBox", """<TextBox Text="Text box" />"""
+                },
+                {
+                    "ToggleSwitch", "<ToggleSwitch />"
+                },
+                {
+                    "ToggleButton", """<ToggleButton Content="Toggle Me" />"""
+                },
+                {
+                    "Slider", """
+                              <Slider MinWidth="120" IsSnapToTickEnabled="True"
+                               Maximum="100" Minimum="0" TickFrequency="1" Value="50">
+                              </Slider>
+                              """
+                },
+                {
+                    "ComboBox", """
+                                 <ComboBox PlaceholderText="Select a Color">
+                                    <ComboBoxItem>
+                                       <TextBlock>Red</TextBlock>
+                                    </ComboBoxItem>
+                                 </ComboBox>
+                                """
+                },
+                {
+                    "CheckBox", """<CheckBox IsChecked="True" />"""
+                },
+                {
+                    "RadioButton", "<RadioButton>Item 1</RadioButton>"
+                },
+                {
+                    "NumericUpDown", "<NumericUpDown></NumericUpDown>"
+                },
+                {
+                    "DatePicker", "<DatePicker />"
+                }
+            }.ToFrozenDictionary();
+
+        internal static readonly FrozenDictionary<string, string> Progress =
+            new Dictionary<string, string>
+            {
+                {
+                    "WaveProgress", """
+                                    <suki:WaveProgress Value="40" IsTextVisible="True" />
+                                    """
+                },
+                {
+                    "Stepper", """
+                               <suki:Stepper Margin="30,15" Index="1">
+                                 <suki:Stepper.Steps>
+                                   <objectModel:ObservableCollection x:TypeArguments="system:String">
+                                     <system:String>Step One</system:String>
+                                     <system:String>Step Two</system:String>
+                                     </objectModel:ObservableCollection>
+                                 </suki:Stepper.Steps>
+                               </suki:Stepper>
+                               """
+                },
+                {
+                    "CircleProgressBar", """
+                                         <suki:CircleProgressBar Height="130" StrokeWidth="11" Value="60" Width="130">
+                                            <TextBlock Margin="0,1,0,0" Classes="h3">60%</TextBlock>
+                                         </suki:CircleProgressBar>
+                                         """
+                },
+                {
+                    "StepperAlternativeStyle", """
+                                               <suki:Stepper AlternativeStyle="True" Margin="30,15" Index="1">
+                                                 <suki:Stepper.Steps>
+                                                   <objectModel:ObservableCollection x:TypeArguments="system:String">
+                                                     <system:String>Step One</system:String>
+                                                     <system:String>Step Two</system:String>
+                                                     </objectModel:ObservableCollection>
+                                                 </suki:Stepper.Steps>
+                                               </suki:Stepper>
+                                               """
+                },
+                {
+                    "CircleProgressBarIndeterminate", """<suki:CircleProgressBar IsIndeterminate="True" />"""
+                },
+                {
+                    "Loading", "<suki:Loading />"
+                },
+                {
+                    "ProgressBar60", """<ProgressBar  Value="60" />"""
+                },
+                {
+                    "ProgressBar50WithProgressText", """<ProgressBar  Value="50" ShowProgressText="True" />"""
+                },
+                {
+                    "ProgressBarIndeterminate", """<ProgressBar IsIndeterminate="True" />"""
+                }
+            }.ToFrozenDictionary();
+
+        internal static readonly FrozenDictionary<string, string> Lists =
+            new Dictionary<string, string>
+            {
+                {
+                    "ListBox", """
+                               <ListBox>
+                                  <TextBlock>item 1</TextBlock>
+                                  <TextBlock>item 2</TextBlock>
+                                  <TextBlock>item 3</TextBlock>
+                               </ListBox>
+                               """
+                },
+                {
+                    "TreeView", """
+                                <TreeView >
+                                  <TreeViewItem Header="Test 1">
+                                    <TreeViewItem Header="Test 2" />
+                                    <TreeViewItem Header="Test 3" />
+                                  </TreeViewItem>
+                                  <TreeViewItem Header="Test 4" />
+                                </TreeView>
+                                """
+                }
+            }.ToFrozenDictionary();
+
+        internal static readonly FrozenDictionary<string, string> Layout =
+            new Dictionary<string, string>
+            {
+                {
+                    "GlassCard", "<suki:GlassCard />"
+                },
+                {
+                    "GroupBox", """
+                                <suki:GroupBox Header="Header">
+                                  <Grid Height="100" Width="300">
+                                    <TextBlock VerticalAlignment="Center" HorizontalAlignment="Center">Test Content</TextBlock>
+                                  </Grid>
+                                </suki:GroupBox>
+                                """
+                },
+                {
+                    "Expander", """
+                                <Expander Header="Click To Expand">
+                                   <TextBlock>Expanded</TextBlock>
+                                </Expander>
+                                """
+                },
+                {
+                    "TabControl", """
+                                  <TabControl>
+                                    <TabItem Header="Red Tab">
+                                      <Grid Background="#44ff0000" />
+                                    </TabItem>
+                                   </TabControl>
+                                  """
+                }
+            }.ToFrozenDictionary();
+
+        internal const string PlaygroundStartingCode =
+            """
+              <suki:GlassCard Width="300" Height="320" Margin="15" VerticalAlignment="Top">
+                  <Grid>
+                      <TextBlock FontSize="16" FontWeight="DemiBold" Text="Humidity" />
+                      <Viewbox Width="175" Height="175" Margin="0,0,0,5" HorizontalAlignment="Center" VerticalAlignment="Center">
+                          <suki:WaveProgress Value="{Binding Value, ElementName=SliderT}" />
+                      </Viewbox>
+                      <DockPanel VerticalAlignment="Bottom">
+                          <icons:MaterialIcon Width="20" Height="20" DockPanel.Dock="Left" Foreground="#666666" Kind="TemperatureLow" />
+                          <icons:MaterialIcon Width="20" Height="20" DockPanel.Dock="Right" Foreground="#666666" Kind="TemperatureHigh" />
+                          <Slider Name="SliderT" Margin="8,0" Maximum="100" Minimum="0" Value="23" />
+                      </DockPanel>
+                  </Grid>
+              </suki:GlassCard>
+            """;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static string InsertIntoGridControl(string xamlCode)
+            => """
+               <Grid HorizontalAlignment="Center" VerticalAlignment="Center"
+                   	xmlns:system="clr-namespace:System;assembly=netstandard"
+                   	xmlns:objectModel="clr-namespace:System.Collections.ObjectModel;assembly=System.ObjectModel"
+                   	xmlns:icons="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
+                   	xmlns:suki="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+                   	xmlns='https://github.com/avaloniaui'
+                   	xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+
+               """ + xamlCode + "</Grid>";
+    }
+}


### PR DESCRIPTION
- XamlData class defines lookup tables for the xaml code wich is stored in WYSIWYG format
- PlaygroundViewModel initializes the observable collections by searching for selected keys in the lookup tables
- Duplicit code for inserting xaml code into grid was extracted into a method and put into XamlData class
- StringToControlConvertor was refactored to use the extracted method, added guards against invalid input.
- Fix typos in xaml code