### PR TITLE
Tiny fix and refactor

### DIFF
--- a/SukiUI.Demo/Features/ControlsLibrary/ProgressViewModel.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/ProgressViewModel.cs
@@ -17,7 +17,7 @@ namespace SukiUI.Demo.Features.ControlsLibrary
         [ObservableProperty] private int _stepIndex = 1;
         [ObservableProperty] [Range(0d, 100d)] private double _progressValue = 50;
         [ObservableProperty] private bool _isTextVisible = true;
-        [ObservableProperty] private bool _isIndeterminate = false;
+        [ObservableProperty] private bool _isIndeterminate;
 
         [RelayCommand]
         public void ChangeStep(bool isIncrement)
@@ -35,8 +35,12 @@ namespace SukiUI.Demo.Features.ControlsLibrary
 
         partial void OnIsIndeterminateChanged(bool value)
         {
-            if (value && IsTextVisible)
-                IsTextVisible = false;
+            IsTextVisible = value switch
+            {
+                true when IsTextVisible => false,
+                false when IsTextVisible == false => true,
+                _ => IsTextVisible
+            };
         }
 
         partial void OnIsTextVisibleChanged(bool value)

--- a/SukiUI/Theme/ScrollViewerStyles.axaml
+++ b/SukiUI/Theme/ScrollViewerStyles.axaml
@@ -1,35 +1,37 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:converters="clr-namespace:SukiUI.Converters">
-          
+
     <Style Selector="ScrollViewer">
         <Setter Property="Template">
             <ControlTemplate>
-                <Grid ColumnDefinitions="*,Auto"
-                      RowDefinitions="*,Auto">
+                <Grid ColumnDefinitions="*,Auto" RowDefinitions="*,Auto">
                     <ScrollContentPresenter Name="PART_ContentPresenter"
                                             Padding="{TemplateBinding Padding}"
-                                            HorizontalSnapPointsType="{TemplateBinding HorizontalSnapPointsType}"
-                                            VerticalSnapPointsType="{TemplateBinding VerticalSnapPointsType}"
-                                            HorizontalSnapPointsAlignment="{TemplateBinding HorizontalSnapPointsAlignment}"
-                                            VerticalSnapPointsAlignment="{TemplateBinding VerticalSnapPointsAlignment}"
                                             Background="{TemplateBinding Background}"
-                                            ScrollViewer.IsScrollInertiaEnabled="{TemplateBinding IsScrollInertiaEnabled}">
+                                            HorizontalSnapPointsAlignment="{TemplateBinding HorizontalSnapPointsAlignment}"
+                                            HorizontalSnapPointsType="{TemplateBinding HorizontalSnapPointsType}"
+                                            ScrollViewer.IsScrollInertiaEnabled="{TemplateBinding IsScrollInertiaEnabled}"
+                                            VerticalSnapPointsAlignment="{TemplateBinding VerticalSnapPointsAlignment}"
+                                            VerticalSnapPointsType="{TemplateBinding VerticalSnapPointsType}">
                         <ScrollContentPresenter.GestureRecognizers>
                             <ScrollGestureRecognizer CanHorizontallyScroll="{Binding CanHorizontallyScroll, ElementName=PART_ContentPresenter}"
                                                      CanVerticallyScroll="{Binding CanVerticallyScroll, ElementName=PART_ContentPresenter}"
-                                                     IsScrollInertiaEnabled="{Binding (ScrollViewer.IsScrollInertiaEnabled), ElementName=PART_ContentPresenter}"/>
+                                                     IsScrollInertiaEnabled="{Binding (ScrollViewer.IsScrollInertiaEnabled), ElementName=PART_ContentPresenter}" />
                         </ScrollContentPresenter.GestureRecognizers>
                     </ScrollContentPresenter>
                     <ScrollBar Name="PART_HorizontalScrollBar"
                                Grid.Row="1"
-                               Orientation="Horizontal"/>
+                               Grid.Column="0"
+                               Orientation="Horizontal" />
                     <ScrollBar Name="PART_VerticalScrollBar"
+                               Grid.Row="0"
                                Grid.Column="1"
-                               Orientation="Vertical"/>
-                    <Panel Grid.Row="1"
+                               Orientation="Vertical" />
+                    <Panel Name="PART_ScrollBarsSeparator"
+                           Grid.Row="1"
                            Grid.Column="1"
-                           Background="Transparent"/>
+                           Background="Transparent" />
                 </Grid>
             </ControlTemplate>
         </Setter>


### PR DESCRIPTION
- Fix formatting of scollviewer style, honor the separator official name
- Fix progress demo page not returning to original text visibility after flipping indeterminate switch
- Default value of bool is false, no need to initialize to same value as default value