### PR TITLE
Fix dateTime not being properly initialized on PropertyGrid

### DIFF
--- a/SukiUI/Controls/PropertyGrid/DateTimePickerSelectedDateConverter.cs
+++ b/SukiUI/Controls/PropertyGrid/DateTimePickerSelectedDateConverter.cs
@@ -10,20 +10,19 @@ namespace SukiUI.Controls
 
         public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
-            if (value is null)
-            {
-                return null;
-            }
+            if (value is not (DateTime or DateTimeOffset)) return null;
 
             try
             {
-                if (value is DateTime dateTime)
+                switch (value)
                 {
-                    return new DateTimeOffset(dateTime);
-                }
-                else if (value is DateTimeOffset dateTimeOffset)
-                {
-                    return dateTimeOffset;
+                    // It is not allowed to add positive/negative LocalTimeOffset to a min/max Value of non-UTC DateTime
+                    case DateTime dateTime when dateTime == DateTime.MinValue || dateTime == DateTime.MaxValue:
+                        return new DateTimeOffset(dateTime, TimeSpan.Zero);
+                    case DateTime dateTime:
+                        return new DateTimeOffset(dateTime);
+                    case DateTimeOffset dateTimeOffset:
+                        return dateTimeOffset;
                 }
             }
             catch (ArgumentOutOfRangeException)
@@ -34,60 +33,21 @@ namespace SukiUI.Controls
             return null;
         }
 
-        public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
-            if (value is null)
+            return value switch
             {
-                return null!;
-            }
-
-            if (value is DateTimeOffset dateTimeOffset)
-            {
-                if (targetType == typeof(DateTimeOffset))
-                {
-                    return dateTimeOffset;
-                }
-
-                if (targetType == typeof(DateTimeOffset?))
-                {
-                    return dateTimeOffset;
-                }
-
-                if (targetType == typeof(DateTime))
-                {
-                    return dateTimeOffset.DateTime;
-                }
-
-                if (targetType == typeof(DateTime?))
-                {
-                    return dateTimeOffset.DateTime;
-                }
-            }
-
-            if (value is DateTime dateTime)
-            {
-                if (targetType == typeof(DateTimeOffset))
-                {
-                    return new DateTimeOffset(dateTime);
-                }
-
-                if (targetType == typeof(DateTimeOffset?))
-                {
-                    return new DateTimeOffset(dateTime);
-                }
-
-                if (targetType == typeof(DateTime))
-                {
-                    return dateTime;
-                }
-
-                if (targetType == typeof(DateTime?))
-                {
-                    return dateTime;
-                }
-            }
-
-            throw new NotSupportedException();
+                null => null,
+                DateTimeOffset dateTimeOffset when targetType == typeof(DateTimeOffset) => dateTimeOffset,
+                DateTimeOffset dateTimeOffset when targetType == typeof(DateTimeOffset?) => dateTimeOffset,
+                DateTimeOffset dateTimeOffset when targetType == typeof(DateTime) => dateTimeOffset.DateTime,
+                DateTimeOffset dateTimeOffset when targetType == typeof(DateTime?) => dateTimeOffset.DateTime,
+                DateTime dateTime when targetType == typeof(DateTimeOffset) => new DateTimeOffset(dateTime),
+                DateTime dateTime when targetType == typeof(DateTimeOffset?) => new DateTimeOffset(dateTime),
+                DateTime dateTime when targetType == typeof(DateTime) => dateTime,
+                DateTime dateTime when targetType == typeof(DateTime?) => dateTime,
+                _ => throw new NotSupportedException()
+            };
         }
     }
 }


### PR DESCRIPTION
- Add check for mix/max DateTime value being offseted with LocalTimeOffset.
- Refactor guard into pattern matching expression.
- Refactor decision tree into switch expression.
