### PR TITLE
Fix NumericUpDown in PropertyGrid binding wrong property

### DIFF
--- a/SukiUI/Controls/PropertyGrid/PropertyGrid.axaml
+++ b/SukiUI/Controls/PropertyGrid/PropertyGrid.axaml
@@ -27,7 +27,7 @@
             <Setter Property="VerticalAlignment" Value="Center" />
             <Setter Property="HorizontalContentAlignment" Value="Right" />
             <Setter Property="FontSize" Value="14" />
-            <Setter Property="Text" Value="{Binding Value}" />
+            <Setter Property="Value" Value="{Binding Value}" />
             <Setter Property="Grid.Column" Value="2" />
             <Setter Property="IsReadOnly" Value="{Binding IsReadOnly}" />
             <Setter Property="Height" Value="36" />


### PR DESCRIPTION
Because NumericUpDown is binding to the wrong property, the numerical template of PropertyGrid displays incorrect values.