### PR TITLE
UI: Better looking ToggleButton rotation in TreeViewItem

### DIFF
--- a/SukiUI/Theme/TreeViewStyles.xaml
+++ b/SukiUI/Theme/TreeViewStyles.xaml
@@ -44,12 +44,12 @@
                                           BorderThickness="0"
                                           Classes="Basic"
                                           Focusable="False"
+                                          RenderTransformOrigin="65% 50%" 
                                           IsChecked="{TemplateBinding IsExpanded,
                                                                       Mode=TwoWay}">
                                 <ToggleButton.Transitions>
                                     <Transitions>
                                         <TransformOperationsTransition Property="RenderTransform" Duration="0.25" />
-                                        <ThicknessTransition Property="Margin" Duration="0.25" />
                                     </Transitions>
                                 </ToggleButton.Transitions>
                                 <PathIcon Width="7"
@@ -133,6 +133,5 @@
 
     <Style Selector="TreeViewItem[IsExpanded=True] /template/ ToggleButton#PART_ExpandCollapseChevron">
         <Setter Property="RenderTransform" Value="rotate(90deg)" />
-        <Setter Property="Margin" Value="0,-5,0,0" />
     </Style>
 </Styles>


### PR DESCRIPTION
### Behavior
- Before
![before](https://github.com/kikipoulet/SukiUI/assets/69903523/f318342a-232b-4a0c-a162-f0bed8b6d907)

- After
![after](https://github.com/kikipoulet/SukiUI/assets/69903523/b2c61011-446c-43f6-ba22-608aa9c26ac4)

### Cause

The center point of the original SVG image is to the upper left, but in order not to modify the original design of Material Design, only the RenderTransformOrigin is modified.

![image](https://github.com/kikipoulet/SukiUI/assets/69903523/2f0be5f8-cd29-4556-ab08-974cdb81ce66)
