### PR TITLE
Align paceage version of SkiaSharp to Avalonia.Skia

### DIFF
--- a/SukiUI/SukiUI.csproj
+++ b/SukiUI/SukiUI.csproj
@@ -30,7 +30,6 @@
 	<ItemGroup>
 		<PackageReference Include="Avalonia" Version="11.1.0-beta2" />
 		<PackageReference Include="Avalonia.Skia" Version="11.1.0-beta2" />
-		<PackageReference Include="SkiaSharp" Version="3.0.0-preview.3.1" />
 		<PackageReference Include="Avalonia.Controls.DataGrid" Version="11.1.0-beta2" />
 		<PackageReference Include="Avalonia.Themes.Simple" Version="11.1.0-beta2" />
 		<PackageReference Include="ReactiveUI" Version="19.6.12" />


### PR DESCRIPTION
To avoid errors when building WASM.

this PR fix #180 