### PR TITLE
Visual Optimization of `SukiSideMenu`

### DIFF
--- a/SukiUI/Controls/SukiSideMenu.axaml.cs
+++ b/SukiUI/Controls/SukiSideMenu.axaml.cs
@@ -24,7 +24,14 @@ public class SukiSideMenu : SelectingItemsControl
         set => SetValue(IsMenuExpandedProperty, value);
     }
 
- 
+    public static readonly StyledProperty<bool> IsSelectedItemContentMovableProperty =
+        AvaloniaProperty.Register<SukiSideMenu, bool>(nameof(IsSelectedItemContentMovable), defaultValue: true);
+
+    public bool IsSelectedItemContentMovable
+    {
+        get => GetValue(IsSelectedItemContentMovableProperty);
+        set => SetValue(IsSelectedItemContentMovableProperty, value);
+    }
 
     public static readonly StyledProperty<double> HeaderMinHeightProperty =
         AvaloniaProperty.Register<SukiSideMenu, double>(nameof(HeaderMinHeight));
@@ -131,7 +138,7 @@ public class SukiSideMenu : SelectingItemsControl
              ItemTemplate.Build(item) is SukiSideMenuItem sukiMenuItem)
                 ? sukiMenuItem
                 : new SukiSideMenuItem();
-        
+        menuItem.IsContentMovable = IsSelectedItemContentMovable;
         _SideMenuItems.Add(menuItem);
         return menuItem;
     }

--- a/SukiUI/Controls/SukiSideMenuItem.axaml
+++ b/SukiUI/Controls/SukiSideMenuItem.axaml
@@ -73,30 +73,35 @@
         <Style Selector="^:pointerover">
             <Style Selector="^ /template/ Border#PART_Border">
                 <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor5}" />
-			    <Setter Property="Cursor"  Value="Hand" />
+                <Setter Property="Cursor" Value="Hand" />
             </Style>
         </Style>
         <Style Selector="^[IsSelected=True]">
             <Style Selector="^ /template/ Border#PART_Border">
                 <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor10}" />
-
-            </Style>
-            <Style Selector="^[IsTopMenuExpanded=True] /template/ Border#PART_Border">
-                <Setter Property="Padding" Value="-10,15,15,15" />
             </Style>
             <Style Selector="^ /template/ TextBlock#PART_Header">
                 <Setter Property="FontWeight" Value="Bold" />
                 <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
             </Style>
-
-            <Style Selector="^[IsTopMenuExpanded=True] /template/ ContentControl#PART_Icon">
-                <Setter Property="Opacity" Value="0" />
+            <Style Selector="^[IsContentMovable=True]">
+                <Style Selector="^[IsTopMenuExpanded=True] /template/ Border#PART_Border">
+                    <Setter Property="Padding" Value="-10,15,15,15" />
+                </Style>
+                <Style Selector="^[IsTopMenuExpanded=True] /template/ ContentControl#PART_Icon">
+                    <Setter Property="Opacity" Value="0" />
+                </Style>
+                <Style Selector="^[IsTopMenuExpanded=False] /template/ ContentControl#PART_Icon">
+                    <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
+                    <Setter Property="RenderTransform">
+                        <ScaleTransform ScaleX="1.12" ScaleY="1.12" />
+                    </Setter>
+                </Style>
             </Style>
-            <Style Selector="^[IsTopMenuExpanded=False] /template/ ContentControl#PART_Icon">
-                <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
-                <Setter Property="RenderTransform">
-                    <ScaleTransform ScaleX="1.12" ScaleY="1.12" />
-                </Setter>
+            <Style Selector="^[IsContentMovable=False]">
+                <Style Selector="^ /template/ ContentControl#PART_Icon">
+                    <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
+                </Style>
             </Style>
         </Style>
     </ControlTheme>

--- a/SukiUI/Controls/SukiSideMenuItem.axaml
+++ b/SukiUI/Controls/SukiSideMenuItem.axaml
@@ -34,7 +34,9 @@
                     <Border.Transitions>
                         <Transitions>
                             <BrushTransition Property="Background" Duration="0:0:0.35" />
-                            <ThicknessTransition Property="Padding" Duration="0:0:0.35" />
+                            <ThicknessTransition Property="Padding" Duration="0:0:0.35">
+                                <ThicknessTransition.Easing>CubicEaseInOut</ThicknessTransition.Easing>
+                            </ThicknessTransition>
                         </Transitions>
                     </Border.Transitions>
                     <Panel>

--- a/SukiUI/Controls/SukiSideMenuItem.axaml.cs
+++ b/SukiUI/Controls/SukiSideMenuItem.axaml.cs
@@ -73,7 +73,14 @@ public class SukiSideMenuItem : ListBoxItem
         }
     }
     
-    
+    public static readonly StyledProperty<bool> IsContentMovableProperty =
+        AvaloniaProperty.Register<SukiSideMenuItem, bool>(nameof(IsContentMovable), defaultValue: true);
+
+    public bool IsContentMovable
+    {
+        get => GetValue(IsContentMovableProperty);
+        set => SetValue(IsContentMovableProperty, value);
+    }
     
     public static readonly StyledProperty<bool> IsTopMenuExpandedProperty =
         AvaloniaProperty.Register<SukiSideMenuItem, bool>(nameof(IsTopMenuExpanded), defaultValue: true);


### PR DESCRIPTION
## Description

This PR will result in two changes:
  - Able to set whether the movement animation of `SukiSideMenuItem` content is enabled or not
  - `SukiSideMenuItem` content movement using non-linear animation

Current Animation:
![before](https://github.com/kikipoulet/SukiUI/assets/69903523/b3d42929-a915-46f9-b19b-bc64ff66164e)

### First Change

I added a new property to `SukiSideMenu`: `IsSelectedItemContentMovable` (Default value = true)

This property implies whether or not the content of the Item triggers a movement animation when it is selected (Padding)

For each `SukiSideMenuItem`, the property is `IsContentMovable`

When `IsSelectedItemContentMovable` is false, the behavior is as follows:

![after](https://github.com/kikipoulet/SukiUI/assets/69903523/3dd8510b-89d9-4cc4-95cc-4948ffac4684)

### Second Change

When `IsSelectedItemContentMovable` of `SukiSideMenu` is true, movement animation of `Item` is nonlinear (CubicEaseInOut)

![after2](https://github.com/kikipoulet/SukiUI/assets/69903523/01af97ec-ddd6-4187-8c2b-d07c9a8c874c)




