### PR TITLE
Fix and more kinds of toasts

### DIFF
--- a/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastsView.axaml
@@ -37,16 +37,37 @@
         <ScrollViewer Grid.Row="1">
             <WrapPanel Classes="PageContainer">
                 <controls:GlassCard>
-                    <controls:GroupBox Header="Single Standard Toast">
+                    <controls:GroupBox Header="Info Toast">
                         <Button Margin="15,10,15,0"
-                                Command="{Binding ShowSingleStandardToastCommand}"
+                                Command="{Binding ShowInfoToastCommand}"
                                 Content="Show Toast" />
                     </controls:GroupBox>
                 </controls:GlassCard>
                 <controls:GlassCard>
-                    <controls:GroupBox Header="3 Standard Toasts">
+                    <controls:GroupBox Header="Success Toast">
                         <Button Margin="15,10,15,0"
-                                Command="{Binding ShowThreeStandardToastsCommand}"
+                                Command="{Binding ShowSuccessToastCommand}"
+                                Content="Show Toast" />
+                    </controls:GroupBox>
+                </controls:GlassCard>
+                <controls:GlassCard>
+                    <controls:GroupBox Header="Warning Toast">
+                        <Button Margin="15,10,15,0"
+                                Command="{Binding ShowWarningToastCommand}"
+                                Content="Show Toast" />
+                    </controls:GroupBox>
+                </controls:GlassCard>
+                <controls:GlassCard>
+                    <controls:GroupBox Header="Error Toast">
+                        <Button Margin="15,10,15,0"
+                                Command="{Binding ShowErrorToastCommand}"
+                                Content="Show Toast" />
+                    </controls:GroupBox>
+                </controls:GlassCard>
+                <controls:GlassCard>
+                    <controls:GroupBox Header="3 Info Toasts">
+                        <Button Margin="15,10,15,0"
+                                Command="{Binding ShowThreeInfoToastsCommand}"
                                 Content="Show Toasts" />
                     </controls:GroupBox>
                 </controls:GlassCard>

--- a/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastsViewModel.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastsViewModel.cs
@@ -5,6 +5,7 @@ using CommunityToolkit.Mvvm.Input;
 using Material.Icons;
 using SukiUI.Controls;
 using SukiUI.Demo.Utilities;
+using SukiUI.Enums;
 
 namespace SukiUI.Demo.Features.ControlsLibrary.Toasts
 {
@@ -18,9 +19,25 @@ namespace SukiUI.Demo.Features.ControlsLibrary.Toasts
         [RelayCommand]
         public Task ShowSingleStandardToast() =>
             SukiHost.ShowToast("A Simple Toast", "This is the content of a toast.");
+        
+        [RelayCommand]
+        public Task ShowInfoToast() =>
+            SukiHost.ShowToast("A Simple Toast", "This is the content of an info toast.", SukiToastType.Info);
+        
+        [RelayCommand]
+        public Task ShowSuccessToast() =>
+            SukiHost.ShowToast("A Simple Toast", "This is the content of a success toast.", SukiToastType.Success);
+        
+        [RelayCommand]
+        public Task ShowWarningToast() =>
+            SukiHost.ShowToast("A Simple Toast", "This is the content of a warning toast.", SukiToastType.Warning);
+        
+        [RelayCommand]
+        public Task ShowErrorToast() =>
+            SukiHost.ShowToast("A Simple Toast", "This is the content of an error toast.", SukiToastType.Error);
 
         [RelayCommand]
-        public async Task ShowThreeStandardToasts()
+        public async Task ShowThreeInfoToasts()
         {
             for (var i = 1; i <= 3; i++)
                 await SukiHost.ShowToast("A Simple Toast", $"This is toast number {i} of 3.");
@@ -29,7 +46,7 @@ namespace SukiUI.Demo.Features.ControlsLibrary.Toasts
         [RelayCommand]
         public Task ShowToastWithCallback()
         {
-            return SukiHost.ShowToast("Click This Toast", "Click this toast to open a dialog.", TimeSpan.FromSeconds(15),
+            return SukiHost.ShowToast("Click This Toast", "Click this toast to open a dialog.", SukiToastType.Info, TimeSpan.FromSeconds(15),
                 () => SukiHost.ShowDialog(
                     new TextBlock { Text = "You clicked the toast! - Click anywhere outside of this dialog to close." },
                     allowBackgroundClose: true));

--- a/SukiUI/Content/Icons.cs
+++ b/SukiUI/Content/Icons.cs
@@ -101,5 +101,11 @@ public static class Icons
     // Material Icons
     public static readonly StreamGeometry Star = Parse("M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z");
 
+    // Material Icons
+    public static readonly StreamGeometry InformationOutline = Parse("M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M11,17H13V11H11V17Z");
+
+    // Material Icons
+    public static readonly StreamGeometry AlertOutline = Parse("M12,2L1,21H23M12,6L19.53,19H4.47M11,10V14H13V10M11,16V18H13V16");
+
     private static StreamGeometry Parse(string path) => StreamGeometry.Parse(path);
 }

--- a/SukiUI/Controls/SukiHost.axaml.cs
+++ b/SukiUI/Controls/SukiHost.axaml.cs
@@ -201,19 +201,21 @@ public class SukiHost : ContentControl
     /// <param name="model">A pre-constructed <see cref="SukiToastModel"/>.</param>
     public static Task ShowToast(SukiToastModel model) => 
         ShowToast(_mainWindow, model);
-    
+
     /// <summary>
     /// <inheritdoc cref="ShowToast(Window, SukiToastModel)"/>
     /// This method will show the toast in the earliest opened window.
     /// </summary>
     /// <param name="title">The title to display in the toast.</param>
     /// <param name="content">The content of the toast, this can be any control or ViewModel.</param>
+    /// <param name="type">The type of the toast, including Info, Success, Warning and Error</param>
     /// <param name="duration">Duration for this toast to be active. Default is 2 seconds.</param>
     /// <param name="onClicked">A callback that will be fired if the Toast is cleared by clicking.</param>
-    public static Task ShowToast(string title, object content, TimeSpan? duration = null, Action? onClicked = null) =>
+    public static Task ShowToast(string title, object content, SukiToastType? type = SukiToastType.Info, TimeSpan? duration = null, Action? onClicked = null) =>
         ShowToast(new SukiToastModel(
             title,
             content as Control ?? ViewLocator.TryBuild(content),
+            type ?? SukiToastType.Info,
             duration ?? TimeSpan.FromSeconds(4),
             onClicked));
 
@@ -224,13 +226,15 @@ public class SukiHost : ContentControl
     /// <param name="window">The window who's SukiHost should be used to display the toast.</param>
     /// <param name="title">The title to display in the toast.</param>
     /// <param name="content">The content of the toast, this can be any control or ViewModel.</param>
+    /// <param name="type">The type of the toast, including Info, Success, Warning and Error</param>
     /// <param name="duration">Duration for this toast to be active. Default is 2 seconds.</param>
     /// <param name="onClicked">A callback that will be fired if the Toast is cleared by clicking.</param>
-    public static Task ShowToast(Window window, string title, object content, TimeSpan? duration = null,
+    public static Task ShowToast(Window window, string title, object content, SukiToastType? type = SukiToastType.Info, TimeSpan? duration = null,
         Action? onClicked = null) =>
         ShowToast(window, new SukiToastModel(
             title,
             content as Control ?? ViewLocator.TryBuild(content),
+            type ?? SukiToastType.Info,
             duration ?? TimeSpan.FromSeconds(4),
             onClicked));
 

--- a/SukiUI/Controls/SukiToast.axaml
+++ b/SukiUI/Controls/SukiToast.axaml
@@ -1,23 +1,32 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:content="clr-namespace:SukiUI.Content"
                     xmlns:suki="clr-namespace:SukiUI.Controls">
     <ControlTheme x:Key="SukiToastTheme" TargetType="suki:SukiToast">
         <Setter Property="Template">
             <ControlTemplate>
                 <Border Name="PART_ToastCard"
-                        Width="250"
+                        Width="270"
                         Margin="30,5,30,10"
                         Padding="0"
                         BoxShadow="{DynamicResource SukiPopupShadow}"
                         Classes="Card"
                         CornerRadius="6">
                     <DockPanel Margin="0,-7" LastChildFill="True">
-                        <TextBlock DockPanel.Dock="Top"
-                                   FontSize="15"
-                                   FontWeight="DemiBold"
-                                   Text="{TemplateBinding Title}" />
+                        <StackPanel DockPanel.Dock="Top" Orientation="Horizontal">
+                            <PathIcon Width="16"
+                                      Height="16"
+                                      Data="{TemplateBinding Icon}"
+                                      Foreground="{TemplateBinding Foreground}" />
+                            <TextBlock Margin="7,0,0,0"
+                                       FontSize="15"
+                                       FontWeight="DemiBold"
+                                       Foreground="{DynamicResource SukiText}"
+                                       Text="{TemplateBinding Title}" />
+                        </StackPanel>
                         <ContentPresenter Margin="0,10,0,0"
                                           Content="{TemplateBinding Content}"
+                                          Foreground="{DynamicResource SukiText}"
                                           TextWrapping="Wrap" />
                     </DockPanel>
                 </Border>

--- a/SukiUI/Controls/SukiToast.axaml.cs
+++ b/SukiUI/Controls/SukiToast.axaml.cs
@@ -5,15 +5,15 @@ using Avalonia.Input;
 using SukiUI.Models;
 using System;
 using System.Timers;
+using Avalonia.Media;
+using SukiUI.Content;
+using SukiUI.Enums;
 
 namespace SukiUI.Controls;
 
 public class SukiToast : ContentControl
 {
     protected override Type StyleKeyOverride => typeof(SukiToast);
-
-    public static readonly StyledProperty<string> TitleProperty =
-        AvaloniaProperty.Register<SukiToast, string>(nameof(Title));
     
     internal SukiHost Host { get; private set; }
 
@@ -31,6 +31,18 @@ public class SukiToast : ContentControl
         _timer.Stop();
         await SukiHost.ClearToast(this);
     }
+    
+    public static readonly StyledProperty<object?> IconProperty =
+        AvaloniaProperty.Register<SukiToast, object?>(nameof(Icon));
+
+    public object? Icon
+    {
+        get => GetValue(IconProperty);
+        set => SetValue(IconProperty, value);
+    }
+    
+    public static readonly StyledProperty<string> TitleProperty =
+        AvaloniaProperty.Register<SukiToast, string>(nameof(Title));
 
     public string Title
     {
@@ -51,12 +63,35 @@ public class SukiToast : ContentControl
         _onClickedCallback = null;
         await SukiHost.ClearToast(this);
     }
+    
+    // Icon Foreground Brushes
+    // Note: it would be better to place them into a resource dictionary, but findResource performs slightly slower
+    private readonly SolidColorBrush _infoIconForeground = new(Color.FromRgb(20,140,232));
+    private readonly SolidColorBrush _successIconForeground = new(Color.FromRgb(35,143,35));
+    private readonly SolidColorBrush _warningIconForeground = new(Color.FromRgb(177,113,20));
+    private readonly SolidColorBrush _errorIconForeground = new(Color.FromRgb(216,63,48));
 
     public void Initialize(SukiToastModel model, SukiHost host)
     {
         Host = host;
         Title = model.Title;
         Content = model.Content;
+        Icon = model.Type switch
+        {
+            SukiToastType.Info => Icons.InformationOutline,
+            SukiToastType.Success => Icons.CircleOutlineCheck,
+            SukiToastType.Warning => Icons.AlertOutline,
+            SukiToastType.Error => Icons.CircleOutlineMinus,
+            _ => Icons.InformationOutline
+        };
+        Foreground = model.Type switch
+        {
+            SukiToastType.Info => _infoIconForeground,
+            SukiToastType.Success => _successIconForeground,
+            SukiToastType.Warning => _warningIconForeground,
+            SukiToastType.Error => _errorIconForeground,
+            _ => _infoIconForeground
+        };
         _onClickedCallback = model.OnClicked;
         _timer.Interval = model.Lifetime.TotalMilliseconds;
         _timer.Start();

--- a/SukiUI/Enums/SukiToastType.cs
+++ b/SukiUI/Enums/SukiToastType.cs
@@ -1,0 +1,9 @@
+﻿namespace SukiUI.Enums;
+
+public enum SukiToastType
+{
+    Info,
+    Success,
+    Warning,
+    Error
+}

--- a/SukiUI/Models/SukiToastModel.cs
+++ b/SukiUI/Models/SukiToastModel.cs
@@ -1,11 +1,13 @@
 using System;
+using SukiUI.Enums;
 
 namespace SukiUI.Models;
 
-public readonly record struct SukiToastModel(string Title, object Content, TimeSpan Lifetime, Action? OnClicked)
+public readonly record struct SukiToastModel(string Title, object Content, SukiToastType Type, TimeSpan Lifetime, Action? OnClicked)
 {
     public string Title { get; } = Title;
     public object Content { get; } = Content;
+    public SukiToastType Type { get; } = Type;
     public TimeSpan Lifetime { get; } = Lifetime;
     public Action? OnClicked { get; } = OnClicked;
 }

--- a/SukiUI/SukiUI.csproj
+++ b/SukiUI/SukiUI.csproj
@@ -38,7 +38,6 @@
 
 	<ItemGroup>
 		<AvaloniaResource Include="**\*.xaml" />
-		<None Remove="Content\Images\icons8-file-explorer-new-48.png" />
 		<AvaloniaResource Include="Content\Images\icons8-file-explorer-new-48.png" />
 	</ItemGroup>
 
@@ -50,17 +49,12 @@
 		<AvaloniaResource Include="CustomFont\Quicksand-Medium.ttf" />
 		<AvaloniaResource Include="CustomFont\Quicksand-Regular.ttf" />
 		<AvaloniaResource Include="CustomFont\Quicksand-SemiBold.ttf" />
-		<Content Include="suki_photo.ico" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <Content Include="..\LICENSE" Link="LICENSE" />
 	</ItemGroup>
 
 	<ItemGroup>
 	  <None Update="OIG.N5o-removebg-preview.png">
 	    <Pack>True</Pack>
-	    <PackagePath></PackagePath>
+	    <PackagePath />
 	  </None>
 	</ItemGroup>
 


### PR DESCRIPTION
## First Change

Issue #184 

I don't know if the attributes of these two files are set this way on purpose or not.

If it was on purpose, I would have withdrawn the change.

## Second Change

Support 4 kinds of toast with different icon and color *Info, Success, Warning and Error*

Screenshot:

![effect](https://github.com/kikipoulet/SukiUI/assets/69903523/b74225aa-38ac-42b3-a5d8-64ee16c987ed)

Concern:

I'm still learning Avalonia, so I'm not sure if there's a better way to implement this code.

![image](https://github.com/kikipoulet/SukiUI/assets/69903523/e13c1629-7d7f-41fc-8c63-fa42a0ef0d56)

