### PR TITLE
Fixes about maximized window behavior

### DIFF
--- a/SukiUI.Demo/Program.cs
+++ b/SukiUI.Demo/Program.cs
@@ -15,11 +15,16 @@ internal class Program
         .StartWithClassicDesktopLifetime(args);
 
     // Avalonia configuration, don't remove; also used by visual designer.
-    public static AppBuilder BuildAvaloniaApp() =>
-        AppBuilder.Configure<App>()
+    public static AppBuilder BuildAvaloniaApp()
+    {
+        var app = AppBuilder.Configure<App>()
             .UsePlatformDetect()
-            .UseManagedSystemDialogs()
             .WithInterFont()
             .LogToTrace()
             .UseXamlDisplay();
+
+        if (OperatingSystem.IsWindows() || OperatingSystem.IsMacOS() || OperatingSystem.IsLinux())
+            app.UseManagedSystemDialogs();
+        return app;
+    }
 }

--- a/SukiUI/Controls/SukiSideMenuItem.axaml.cs
+++ b/SukiUI/Controls/SukiSideMenuItem.axaml.cs
@@ -57,7 +57,7 @@ public class SukiSideMenuItem : ListBoxItem
         if (e.Handled)
             return;
 
-        if (!e.Handled && ItemsControl.ItemsControlFromItemContaner(this) is SukiSideMenu owner)
+        if (!e.Handled && ItemsControl.ItemsControlFromItemContainer(this) is SukiSideMenu owner)
         {
             var p = e.GetCurrentPoint(this);
 

--- a/SukiUI/Controls/SukiWindow.axaml
+++ b/SukiUI/Controls/SukiWindow.axaml
@@ -3,105 +3,101 @@
                     xmlns:icons="clr-namespace:SukiUI.Content"
                     xmlns:suki="clr-namespace:SukiUI.Controls">
     <ControlTheme x:Key="SukiWindowTheme" TargetType="suki:SukiWindow">
-        <Setter Property="SystemDecorations" Value="BorderOnly"></Setter>
-        <Setter Property="ExtendClientAreaChromeHints" Value="NoChrome" />
+        <Setter Property="SystemDecorations" Value="BorderOnly" />
+        <Setter Property="ExtendClientAreaChromeHints" Value="PreferSystemChrome" />
         <Setter Property="ExtendClientAreaTitleBarHeightHint" Value="-1" />
         <Setter Property="ExtendClientAreaToDecorationsHint" Value="True" />
         <Setter Property="TextElement.Foreground" Value="{DynamicResource SukiText}" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Border ClipToBounds="True" CornerRadius="{OnPlatform '0', Linux='10', x:TypeArguments=CornerRadius}" >
-                <Panel IsHitTestVisible="True">
-                    <VisualLayerManager Name="PART_VisualLayerManager" IsHitTestVisible="True">
-                        <suki:SukiHost>
-                            <Panel x:Name="PART_Root">
-                                <suki:SukiBackground Name="PART_Background" IsHitTestVisible="False" />
-                                <DockPanel LastChildFill="True">
-                                    <Panel DockPanel.Dock="Top">
-                                        <Panel.Styles>
-                                            <Style Selector="suki|SukiWindow[ShowBottomBorder=True] /template/ Border#PART_BottomBorder">
-                                                <Setter Property="BorderThickness" Value="0,0,0,1" />
-                                            </Style>
-                                            <Style Selector="suki|SukiWindow[ShowBottomBorder=False] /template/ Border#PART_BottomBorder">
-                                                <Setter Property="BorderThickness" Value="0,0,0,0" />
-                                            </Style>
-                                        </Panel.Styles>
-                                        <StackPanel>
-                                            <LayoutTransformControl Name="PART_LayoutTransform" RenderTransformOrigin="0%,0%">
-                                                <Panel>
-                                                    <suki:GlassCard Name="PART_TitleBarBackground"
-                                                                    BorderThickness="0"
-                                                                    CornerRadius="0" />
-                                                    <DockPanel Margin="12,9" LastChildFill="True">
-                                                        <StackPanel VerticalAlignment="Center"
-                                                                    DockPanel.Dock="Right"
-                                                                    FlowDirection="RightToLeft"
-                                                                    Orientation="Horizontal"
-                                                                    Spacing="7">
-                                                            <StackPanel.Styles>
-                                                                <Style Selector="PathIcon">
-                                                                    <Setter Property="Height" Value="10" />
-                                                                    <Setter Property="Width" Value="10" />
-                                                                </Style>
-                                                            </StackPanel.Styles>
-                                                            <Button Name="PART_CloseButton" Classes="Basic Rounded WindowControlsButton Close">
-                                                                <PathIcon Data="{x:Static icons:Icons.WindowClose}" />
-                                                            </Button>
-                                                            <Button Name="PART_MaximizeButton"
-                                                                    Classes="Basic Rounded WindowControlsButton"
-                                                                    IsVisible="{TemplateBinding CanResize}">
-                                                                <PathIcon x:Name="MaximizeIcon" Data="{x:Static icons:Icons.WindowMaximize}" />
-                                                            </Button>
-                                                            <Button Name="PART_MinimizeButton"
-                                                                    VerticalContentAlignment="Bottom"
-                                                                    Classes="Basic Rounded WindowControlsButton"
-                                                                    IsVisible="{TemplateBinding CanMinimize}">
-                                                                <PathIcon Margin="0,0,0,4"
-                                                                          VerticalAlignment="Bottom"
-                                                                          Data="{x:Static icons:Icons.WindowMinimize}" />
-                                                            </Button>
-                                                        </StackPanel>
-                                                        <StackPanel VerticalAlignment="Center"
-                                                                    IsHitTestVisible="False"
-                                                                    Orientation="Horizontal"
-                                                                    Spacing="10">
-                                                            <ContentPresenter HorizontalAlignment="Left"
-                                                                              Content="{TemplateBinding LogoContent}"
-                                                                              IsHitTestVisible="False" />
-                                                            <TextBlock VerticalAlignment="Center"
-                                                                       FontSize="{TemplateBinding TitleFontSize}"
-                                                                       FontWeight="{TemplateBinding TitleFontWeight}"
-                                                                       IsHitTestVisible="False"
-                                                                       Text="{TemplateBinding Title}" />
-                                                        </StackPanel>
-                                                    </DockPanel>
-                                                </Panel>
-                                            </LayoutTransformControl>
-                                            <Menu IsEnabled="{TemplateBinding IsMenuVisible}" ItemsSource="{TemplateBinding MenuItems}" />
-                                            <Border Name="PART_BottomBorder" BorderBrush="{DynamicResource SukiBorderBrush}" />
-                                        </StackPanel>
-                                    </Panel>
-                                    <ContentPresenter x:Name="PART_ContentPresenter"
-                                                      HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                      VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                      Content="{TemplateBinding Content}"
-                                                      ContentTemplate="{TemplateBinding ContentTemplate}"
-                                                      CornerRadius="10"
-                                                      IsHitTestVisible="True" />
-                                </DockPanel>
-                            </Panel>
-                        </suki:SukiHost>
-                    </VisualLayerManager>
-                </Panel>
+                <Border ClipToBounds="True" CornerRadius="{OnPlatform '0', Linux='10', x:TypeArguments=CornerRadius}">
+                    <Panel IsHitTestVisible="True">
+                        <VisualLayerManager Name="PART_VisualLayerManager" IsHitTestVisible="True">
+                            <suki:SukiHost>
+                                <Panel x:Name="PART_Root">
+                                    <suki:SukiBackground Name="PART_Background" IsHitTestVisible="False" />
+                                    <DockPanel LastChildFill="True">
+                                        <Panel DockPanel.Dock="Top">
+                                            <Panel.Styles>
+                                                <Style Selector="suki|SukiWindow[ShowBottomBorder=True] /template/ Border#PART_BottomBorder">
+                                                    <Setter Property="BorderThickness" Value="0,0,0,1" />
+                                                </Style>
+                                                <Style Selector="suki|SukiWindow[ShowBottomBorder=False] /template/ Border#PART_BottomBorder">
+                                                    <Setter Property="BorderThickness" Value="0,0,0,0" />
+                                                </Style>
+                                            </Panel.Styles>
+                                            <StackPanel>
+                                                <LayoutTransformControl Name="PART_LayoutTransform" RenderTransformOrigin="0%,0%">
+                                                    <Panel>
+                                                        <suki:GlassCard Name="PART_TitleBarBackground"
+                                                                        BorderThickness="0"
+                                                                        CornerRadius="0" />
+                                                        <DockPanel Margin="12,9" LastChildFill="True">
+                                                            <StackPanel VerticalAlignment="Center"
+                                                                        DockPanel.Dock="Right"
+                                                                        FlowDirection="RightToLeft"
+                                                                        Orientation="Horizontal"
+                                                                        Spacing="7">
+                                                                <StackPanel.Styles>
+                                                                    <Style Selector="PathIcon">
+                                                                        <Setter Property="Height" Value="10" />
+                                                                        <Setter Property="Width" Value="10" />
+                                                                    </Style>
+                                                                </StackPanel.Styles>
+                                                                <Button Name="PART_CloseButton" Classes="Basic Rounded WindowControlsButton Close">
+                                                                    <PathIcon Data="{x:Static icons:Icons.WindowClose}" />
+                                                                </Button>
+                                                                <Button Name="PART_MaximizeButton"
+                                                                        Classes="Basic Rounded WindowControlsButton"
+                                                                        IsVisible="{TemplateBinding CanResize}">
+                                                                    <PathIcon x:Name="MaximizeIcon" Data="{x:Static icons:Icons.WindowMaximize}" />
+                                                                </Button>
+                                                                <Button Name="PART_MinimizeButton"
+                                                                        VerticalContentAlignment="Bottom"
+                                                                        Classes="Basic Rounded WindowControlsButton"
+                                                                        IsVisible="{TemplateBinding CanMinimize}">
+                                                                    <PathIcon Margin="0,0,0,4"
+                                                                              VerticalAlignment="Bottom"
+                                                                              Data="{x:Static icons:Icons.WindowMinimize}" />
+                                                                </Button>
+                                                            </StackPanel>
+                                                            <StackPanel VerticalAlignment="Center"
+                                                                        IsHitTestVisible="False"
+                                                                        Orientation="Horizontal"
+                                                                        Spacing="10">
+                                                                <ContentPresenter HorizontalAlignment="Left"
+                                                                                  Content="{TemplateBinding LogoContent}"
+                                                                                  IsHitTestVisible="False" />
+                                                                <TextBlock VerticalAlignment="Center"
+                                                                           FontSize="{TemplateBinding TitleFontSize}"
+                                                                           FontWeight="{TemplateBinding TitleFontWeight}"
+                                                                           IsHitTestVisible="False"
+                                                                           Text="{TemplateBinding Title}" />
+                                                            </StackPanel>
+                                                        </DockPanel>
+                                                    </Panel>
+                                                </LayoutTransformControl>
+                                                <Menu IsEnabled="{TemplateBinding IsMenuVisible}" ItemsSource="{TemplateBinding MenuItems}" />
+                                                <Border Name="PART_BottomBorder" BorderBrush="{DynamicResource SukiBorderBrush}" />
+                                            </StackPanel>
+                                        </Panel>
+                                        <ContentPresenter x:Name="PART_ContentPresenter"
+                                                          HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                          Content="{TemplateBinding Content}"
+                                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                          CornerRadius="10"
+                                                          IsHitTestVisible="True" />
+                                    </DockPanel>
+                                </Panel>
+                            </suki:SukiHost>
+                        </VisualLayerManager>
+                    </Panel>
                 </Border>
             </ControlTemplate>
         </Setter>
         <Style Selector="^[WindowState=Maximized] /template/ PathIcon#MaximizeIcon">
             <Setter Property="Data" Value="{x:Static icons:Icons.WindowRestore}" />
-        </Style>
-        <!--  Necessary to offset Windows' behaviour with windows that have no system borders.  -->
-        <Style Selector="^[WindowState=Maximized] /template/ VisualLayerManager#PART_VisualLayerManager">
-            <Setter Property="Padding" Value="{OnPlatform '0', Windows='8', x:TypeArguments=Thickness}" />
         </Style>
         <Style Selector="^[WindowState=Normal] /template/ PathIcon#MaximizeIcon">
             <Setter Property="Data" Value="{x:Static icons:Icons.WindowMaximize}" />

--- a/SukiUI/Controls/SukiWindow.axaml
+++ b/SukiUI/Controls/SukiWindow.axaml
@@ -4,7 +4,7 @@
                     xmlns:suki="clr-namespace:SukiUI.Controls">
     <ControlTheme x:Key="SukiWindowTheme" TargetType="suki:SukiWindow">
         <Setter Property="SystemDecorations" Value="BorderOnly" />
-        <Setter Property="ExtendClientAreaChromeHints" Value="PreferSystemChrome" />
+        <Setter Property="ExtendClientAreaChromeHints" Value="NoChrome" />
         <Setter Property="ExtendClientAreaTitleBarHeightHint" Value="-1" />
         <Setter Property="ExtendClientAreaToDecorationsHint" Value="True" />
         <Setter Property="TextElement.Foreground" Value="{DynamicResource SukiText}" />

--- a/SukiUI/Controls/SukiWindow.axaml.cs
+++ b/SukiUI/Controls/SukiWindow.axaml.cs
@@ -169,7 +169,7 @@ public class SukiWindow : Window
             _subscriptionDisposables = bgObs.Subscribe();
         }
     }
-
+    
     private void OnWindowStateChanged(WindowState state)
     {
         if (state == WindowState.FullScreen)
@@ -188,7 +188,22 @@ public class SukiWindow : Window
                 : WindowState.Maximized;
         }
         else if (CanMove)
+        { 
+            // It may be necessary to adjust the pointer position to account for scaling
+            // If you try to tug the window further to the right of the title bar, the behavior looks strange
+            var pointerPosition = e.GetCurrentPoint(this).Position;
+            var pointerPositionRelativeToWindow = e.GetPosition(this);
+            var scaling = VisualRoot?.RenderScaling ?? 1.0;
+            pointerPosition = new Point(pointerPosition.X * scaling, pointerPosition.Y * scaling);
+            if (WindowState == WindowState.Maximized)
+            {
+                var newX = pointerPosition.X - pointerPositionRelativeToWindow.X;
+                var newY = pointerPosition.Y - pointerPositionRelativeToWindow.Y;
+                WindowState = WindowState.Normal;
+                Position = new PixelPoint((int)newX, (int)newY);
+            }
             BeginMoveDrag(e);
+        }
     }
 
     protected override void OnUnloaded(RoutedEventArgs e)


### PR DESCRIPTION
Related Issue: #186 

These fixes might work

Dragging the title bar in maximized mode will bring the window back to normal, but the calculation of the window's position may be slightly inaccurate (especially when dragging with the position of the title bar to the right of it)