### PR TITLE
[Feat] Customize `OpenPaneLength` and `TogglePaneButton` Position

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -10,8 +10,6 @@ body:
       options:
         - label: I have looked up relevant Issue
           required: false
-        - label: I've read [How To Ask Questions](https://github.com/betaseeker/How-To-Ask-Questions)
-          required: false
   - type: textarea
     id: description
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -10,8 +10,6 @@ body:
       options:
         - label: I have looked up relevant Issue
           required: false
-        - label: I've read [How To Ask Questions](https://github.com/betaseeker/How-To-Ask-Questions)
-          required: false
   - type: textarea
     id: description
     attributes:

--- a/SukiUI/Controls/SukiSideMenu.axaml
+++ b/SukiUI/Controls/SukiSideMenu.axaml
@@ -2,7 +2,6 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:content="clr-namespace:SukiUI.Content"
                     xmlns:suki="clr-namespace:SukiUI.Controls"
-                    xmlns:sukiUi="clr-namespace:SukiUI"
                     xmlns:theme="clr-namespace:SukiUI.Theme">
     <ControlTheme x:Key="SukiSideMenuStyle" TargetType="suki:SukiSideMenu">
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
@@ -10,7 +9,7 @@
             <ControlTemplate>
                 <SplitView DisplayMode="CompactInline"
                            IsPaneOpen="{TemplateBinding IsMenuExpanded}"
-                           OpenPaneLength="220">
+                           OpenPaneLength="{TemplateBinding OpenPaneLength}">
                     <SplitView.Pane>
                         <Border>
                             <Grid Background="Transparent">
@@ -20,7 +19,7 @@
                                 <DockPanel>
                                     <Button Name="PART_SidebarToggleButton"
                                             Margin="7"
-                                            HorizontalAlignment="Right"
+                                            HorizontalAlignment="{TemplateBinding TogglePaneButtonPosition}"
                                             VerticalAlignment="Top"
                                             Classes="Basic"
                                             DockPanel.Dock="Top">

--- a/SukiUI/Controls/SukiSideMenu.axaml.cs
+++ b/SukiUI/Controls/SukiSideMenu.axaml.cs
@@ -1,7 +1,6 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
-using Avalonia.Input;
 using Avalonia.Threading;
 using System;
 using System.Collections.Generic;
@@ -9,7 +8,8 @@ using System.Linq;
 using System.Reactive;
 using System.Reactive.Linq;
 using Avalonia.Interactivity;
-using Avalonia.VisualTree;
+using Avalonia.Layout;
+using SukiUI.Enums;
 
 namespace SukiUI.Controls;
 
@@ -22,6 +22,38 @@ public class SukiSideMenu : SelectingItemsControl
     {
         get => GetValue(IsMenuExpandedProperty);
         set => SetValue(IsMenuExpandedProperty, value);
+    }
+    
+    public static readonly StyledProperty<int> OpenPaneLengthProperty =
+        AvaloniaProperty.Register<SukiSideMenu, int>(nameof(OpenPaneLength), defaultValue: 220);
+
+    public int OpenPaneLength
+    {
+        get => GetValue(OpenPaneLengthProperty);
+        set => SetValue(OpenPaneLengthProperty, value switch
+        {
+            >= 200 => value,
+            _ => throw new ArgumentOutOfRangeException($"OpenPaneLength must be greater than or equal to 200, but was {value}")
+        });
+    }
+    
+    public static readonly StyledProperty<HorizontalAlignment> TogglePaneButtonPositionProperty =
+        AvaloniaProperty.Register<SukiSideMenu, HorizontalAlignment>(nameof(TogglePaneButtonPosition), defaultValue: HorizontalAlignment.Right);
+
+    public SideMenuTogglePaneButtonPositionOptions TogglePaneButtonPosition
+    {
+        get => GetValue(TogglePaneButtonPositionProperty) switch
+        {
+            HorizontalAlignment.Right => SideMenuTogglePaneButtonPositionOptions.Right,
+            HorizontalAlignment.Left => SideMenuTogglePaneButtonPositionOptions.Left,
+            _ => SideMenuTogglePaneButtonPositionOptions.Right
+        };
+        set => SetValue(TogglePaneButtonPositionProperty, value switch
+        {
+            SideMenuTogglePaneButtonPositionOptions.Right => HorizontalAlignment.Right,
+            SideMenuTogglePaneButtonPositionOptions.Left => HorizontalAlignment.Left,
+            _ => HorizontalAlignment.Right
+        });
     }
 
     public static readonly StyledProperty<bool> IsSelectedItemContentMovableProperty =
@@ -75,13 +107,13 @@ public class SukiSideMenu : SelectingItemsControl
     {
         IsMenuExpanded = !IsMenuExpanded;
         
-        if(_SideMenuItems.Any())
-            foreach (SukiSideMenuItem item in _SideMenuItems)
+        if(_sideMenuItems.Any())
+            foreach (var item in _sideMenuItems)
                 item.IsTopMenuExpanded = IsMenuExpanded;
         
         else if(Items.FirstOrDefault() is SukiSideMenuItem)
-            foreach (SukiSideMenuItem item in Items)
-                item.IsTopMenuExpanded = IsMenuExpanded;
+            foreach (SukiSideMenuItem? item in Items)
+                item!.IsTopMenuExpanded = IsMenuExpanded;
     }
     
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
@@ -139,11 +171,11 @@ public class SukiSideMenu : SelectingItemsControl
                 ? sukiMenuItem
                 : new SukiSideMenuItem();
         menuItem.IsContentMovable = IsSelectedItemContentMovable;
-        _SideMenuItems.Add(menuItem);
+        _sideMenuItems.Add(menuItem);
         return menuItem;
     }
 
-    private List<SukiSideMenuItem> _SideMenuItems = new List<SukiSideMenuItem>();
+    private List<SukiSideMenuItem> _sideMenuItems = new();
 
     protected override bool NeedsContainerOverride(object? item, int index, out object? recycleKey)
     {

--- a/SukiUI/Enums/SideMenuTogglePaneButtonPositionOptions.cs
+++ b/SukiUI/Enums/SideMenuTogglePaneButtonPositionOptions.cs
@@ -1,0 +1,7 @@
+﻿namespace SukiUI.Enums;
+
+public enum SideMenuTogglePaneButtonPositionOptions
+{
+    Left,
+    Right
+}


### PR DESCRIPTION
`TogglePaneButton` only accepts `Right` (default value) or `Left`

![image](https://github.com/kikipoulet/SukiUI/assets/69903523/30c03432-03ce-45bc-8e38-bb244cfaae99)

---

`OpenPaneLength` accepts int value that greater than or equal to 200 (<200 looks strange and will raise an exception)

*image below shows `OpenPaneLength=500`*

![image](https://github.com/kikipoulet/SukiUI/assets/69903523/50728290-55a3-40d1-b55d-51ba7a1c136e)
