### PR TITLE
Include some more demanding shaders in the demo app.

### DIFF
--- a/SukiUI.Demo/Assets/clouds.sksl
+++ b/SukiUI.Demo/Assets/clouds.sksl
@@ -1,0 +1,110 @@
+const float cloudscale = 1.1;
+const float speed = 0.03;
+const float clouddark = 0.5;
+const float cloudlight = 0.3;
+const float cloudcover = 0.2;
+const float cloudalpha = 8.0;
+const float skytint = 0.5;
+const vec3 skycolour1 = vec3(0.2, 0.4, 0.6);
+const vec3 skycolour2 = vec3(0.4, 0.7, 1.0);
+
+const mat2 m = mat2( 1.6,  1.2, -1.2,  1.6 );
+
+vec2 hash( vec2 p ) {
+    p = vec2(dot(p,vec2(127.1,311.7)), dot(p,vec2(269.5,183.3)));
+    return -1.0 + 2.0*fract(sin(p)*43758.5453123);
+}
+
+float noise( in vec2 p ) {
+    const float K1 = 0.366025404; // (sqrt(3)-1)/2;
+    const float K2 = 0.211324865; // (3-sqrt(3))/6;
+    vec2 i = floor(p + (p.x+p.y)*K1);
+    vec2 a = p - i + (i.x+i.y)*K2;
+    vec2 o = (a.x>a.y) ? vec2(1.0,0.0) : vec2(0.0,1.0); //vec2 of = 0.5 + 0.5*vec2(sign(a.x-a.y), sign(a.y-a.x));
+    vec2 b = a - o + K2;
+    vec2 c = a - 1.0 + 2.0*K2;
+    vec3 h = max(0.5-vec3(dot(a,a), dot(b,b), dot(c,c) ), 0.0 );
+    vec3 n = h*h*h*h*vec3( dot(a,hash(i+0.0)), dot(b,hash(i+o)), dot(c,hash(i+1.0)));
+    return dot(n, vec3(70.0));
+}
+
+float fbm(vec2 n) {
+    float total = 0.0, amplitude = 0.1;
+    for (int i = 0; i < 7; i++) {
+        total += noise(n) * amplitude;
+        n = m * n;
+        amplitude *= 0.4;
+    }
+    return total;
+}
+
+// -----------------------------------------------
+
+half4 main( vec2 fragCoord ) {
+    vec2 p = fragCoord.xy / iResolution.xy;
+    vec2 uv = p*vec2(iResolution.x/iResolution.y,1.0);
+    float time = iTime * speed;
+    float q = fbm(uv * cloudscale * 0.5);
+
+    //ridged noise shape
+    float r = 0.0;
+    uv *= cloudscale;
+    uv -= q - time;
+    float weight = 0.8;
+    for (int i=0; i<8; i++){
+        r += abs(weight*noise( uv ));
+        uv = m*uv + time;
+        weight *= 0.7;
+    }
+
+    //noise shape
+    float f = 0.0;
+    uv = p*vec2(iResolution.x/iResolution.y,1.0);
+    uv *= cloudscale;
+    uv -= q - time;
+    weight = 0.7;
+    for (int i=0; i<8; i++){
+        f += weight*noise( uv );
+        uv = m*uv + time;
+        weight *= 0.6;
+    }
+
+    f *= r + f;
+
+    //noise colour
+    float c = 0.0;
+    time = iTime * speed * 2.0;
+    uv = p*vec2(iResolution.x/iResolution.y,1.0);
+    uv *= cloudscale*2.0;
+    uv -= q - time;
+    weight = 0.4;
+    for (int i=0; i<7; i++){
+        c += weight*noise( uv );
+        uv = m*uv + time;
+        weight *= 0.6;
+    }
+
+    //noise ridge colour
+    float c1 = 0.0;
+    time = iTime * speed * 3.0;
+    uv = p*vec2(iResolution.x/iResolution.y,1.0);
+    uv *= cloudscale*3.0;
+    uv -= q - time;
+    weight = 0.4;
+    for (int i=0; i<7; i++){
+        c1 += abs(weight*noise( uv ));
+        uv = m*uv + time;
+        weight *= 0.6;
+    }
+
+    c += c1;
+
+    vec3 skycolour = mix(skycolour2, skycolour1, p.y);
+    vec3 cloudcolour = vec3(1.1, 1.1, 0.9) * clamp((clouddark + cloudlight*c), 0.0, 1.0);
+
+    f = cloudcover + cloudalpha*f*r;
+
+    vec3 result = mix(skycolour, clamp(skytint * skycolour + cloudcolour, 0.0, 1.0), clamp(f + c, 0.0, 1.0));
+
+    return vec4( result, 1.0 );
+}

--- a/SukiUI.Demo/Assets/space.sksl
+++ b/SukiUI.Demo/Assets/space.sksl
@@ -1,0 +1,67 @@
+const int iterations = 17;
+const float formuparam = 0.53;
+
+const int volsteps = 25;
+const float stepsize = 0.1;
+
+const float zoom  = 0.100;
+const float tile  = 0.850;
+const float speed =0.010 ;
+
+const float brightness =0.0015;
+const float darkmatter =0.300;
+const float distfading =0.730;
+const float saturation =0.850;
+
+float mod(float x, float y) {
+    return x - y * floor(x / y);
+}
+
+vec3 mod(vec3 x, vec3 y) {
+    return vec3(mod(x.x,y.x), mod(x.y,y.y), mod(x.z,y.z));
+}
+
+half4 main( vec2 fragCoord )
+{
+    //get coords and direction
+    vec2 uv=fragCoord.xy/iResolution.xy-.5;
+    uv.y*=iResolution.y/iResolution.x;
+    vec3 dir=vec3(uv*zoom,1.);
+    float time=iTime*speed+.25;
+
+    //mouse rotation
+    float a1=.5/iResolution.x*2.;
+    float a2=.8/iResolution.y*2.;
+    mat2 rot1=mat2(cos(a1),sin(a1),-sin(a1),cos(a1));
+    mat2 rot2=mat2(cos(a2),sin(a2),-sin(a2),cos(a2));
+    dir.xz*=rot1;
+    dir.xy*=rot2;
+    vec3 from=vec3(1.,.5,0.5);
+    from+=vec3(time*2.,time,-2.);
+    from.xz*=rot1;
+    from.xy*=rot2;
+
+    //volumetric rendering
+    float s=0.1,fade=1.;
+    vec3 v=vec3(0.);
+    for (int r=0; r<volsteps; r++) {
+        vec3 p=from+s*dir*.5;
+        p = abs(vec3(tile)-mod(p,vec3(tile*2.))); // tiling fold
+        float pa,a=pa=0.;
+    for (int i=0; i<iterations; i++) {
+    p=abs(p)/dot(p,p)-formuparam; // the magic formula
+    a+=abs(length(p)-pa); // absolute sum of average change
+    pa=length(p);
+    }
+    float dm=max(0.,darkmatter-a*a*.001); //dark matter
+    a*=a*a; // add contrast
+    if (r>6) fade*=1.-dm; // dark matter, don't render near
+    //v+=vec3(dm,dm*.5,0.);
+    v+=fade;
+    v+=vec3(s,s*s,s*s*s*s)*a*brightness*fade; // coloring based on distance
+    fade*=distfading; // distance fading
+    s+=stepsize;
+    }
+    v=mix(vec3(length(v)),v,saturation); //color adjust
+    return vec4(v*.01,1.);
+}

--- a/SukiUI.Demo/Assets/weird.sksl
+++ b/SukiUI.Demo/Assets/weird.sksl
@@ -1,0 +1,43 @@
+mat2 rotate2D(float r){
+    return mat2(cos(r), sin(r), -sin(r), cos(r));
+}
+
+mat3 rotate3D(float angle, vec3 axis){
+    vec3 a = normalize(axis);
+    float s = sin(angle);
+    float c = cos(angle);
+    float r = 1.0 - c;
+    return mat3(
+        a.x * a.x * r + c,
+        a.y * a.x * r + a.z * s,
+        a.z * a.x * r - a.y * s,
+        a.x * a.y * r - a.z * s,
+        a.y * a.y * r + c,
+        a.z * a.y * r + a.x * s,
+        a.x * a.z * r + a.y * s,
+        a.y * a.z * r - a.x * s,
+        a.z * a.z * r + c
+    );
+}
+
+half4 main(float2 FC) {
+    vec4 o = vec4(0);
+    vec2 r = iResolution.xy;
+    vec3 v = vec3(1,3,7), p = vec3(0);
+    float t=iTime, n=0, e=0, g=0, k=t*.2;
+    for (float i=0; i<100; ++i) {
+        p = vec3((FC.xy-r*.5)/r.y*g,g)*rotate3D(k,cos(k+v));
+        p.z += t;
+        p = asin(sin(p)) - 3.;
+        n = 0;
+        for (float j=0; j<9.; ++j) {
+            p.xz *= rotate2D(g/8.);
+            p = abs(p);
+            p = p.x<p.y ? n++, p.zxy : p.zyx;
+        p += p-v;
+        }
+        g += e = max(p.x,p.z) / 1e3 - .01;
+        o.rgb += .1/exp(cos(v*g*.1+n)+3.+1e4*e);
+    }
+    return o.xyz1;
+}

--- a/SukiUI.Demo/Features/Theming/ThemingView.axaml
+++ b/SukiUI.Demo/Features/Theming/ThemingView.axaml
@@ -96,37 +96,64 @@
                         <controls:SettingsLayoutItem Header="Background">
                             <controls:SettingsLayoutItem.Content>
                                 <controls:GlassCard Margin="0,25,0,0">
-                                <StackPanel Spacing="25">
-                                    <DockPanel>
-                                        <ToggleButton VerticalAlignment="Top"
-                                                      Classes="Switch"
-                                                      DockPanel.Dock="Right"
-                                                      IsChecked="{Binding BackgroundAnimations}" />
-                                        <StackPanel HorizontalAlignment="Left">
-                                            <TextBlock FontSize="16"
-                                                       FontWeight="DemiBold"
-                                                       Text="Animated Background" />
-                                            <TextBlock Margin="0,12,70,0"
-                                                       Foreground="{DynamicResource SukiLowText}"
-                                                       Text="Enable/disable the animations for the background, which are driven by the currently active effect."
-                                                       TextWrapping="Wrap" />
-                                        </StackPanel>
-                                    </DockPanel>
-                                    <DockPanel>
-                                        <ComboBox DockPanel.Dock="Right"
-                                                  ItemsSource="{Binding AvailableBackgroundStyles}"
-                                                  SelectedItem="{Binding BackgroundStyle}" />
-                                        <StackPanel HorizontalAlignment="Left">
-                                            <TextBlock FontSize="16"
-                                                       FontWeight="DemiBold"
-                                                       Text="Background Style" />
-                                            <TextBlock Margin="0,12,70,0"
-                                                       Foreground="{DynamicResource SukiLowText}"
-                                                       Text="Select from the included background styles."
-                                                       TextWrapping="Wrap" />
-                                        </StackPanel>
-                                    </DockPanel>
-                                </StackPanel>
+                                    <StackPanel Spacing="25">
+                                        <DockPanel>
+                                            <ToggleButton VerticalAlignment="Top"
+                                                          Classes="Switch"
+                                                          DockPanel.Dock="Right"
+                                                          IsChecked="{Binding BackgroundAnimations}" />
+                                            <StackPanel HorizontalAlignment="Left">
+                                                <TextBlock FontSize="16"
+                                                           FontWeight="DemiBold"
+                                                           Text="Animated Background" />
+                                                <TextBlock Margin="0,12,70,0"
+                                                           Foreground="{DynamicResource SukiLowText}"
+                                                           Text="Enable/disable the animations for the background, which are driven by the currently active effect."
+                                                           TextWrapping="Wrap" />
+                                            </StackPanel>
+                                        </DockPanel>
+                                        <DockPanel>
+                                            <ComboBox DockPanel.Dock="Right"
+                                                      ItemsSource="{Binding AvailableBackgroundStyles}"
+                                                      SelectedItem="{Binding BackgroundStyle}" />
+                                            <StackPanel HorizontalAlignment="Left">
+                                                <TextBlock FontSize="16"
+                                                           FontWeight="DemiBold"
+                                                           Text="Background Style" />
+                                                <TextBlock Margin="0,12,70,0"
+                                                           Foreground="{DynamicResource SukiLowText}"
+                                                           Text="Select from the included background styles."
+                                                           TextWrapping="Wrap" />
+                                            </StackPanel>
+                                        </DockPanel>
+                                        <DockPanel>
+                                            <StackPanel HorizontalAlignment="Left" DockPanel.Dock="Top">
+                                                <TextBlock FontSize="16"
+                                                           FontWeight="DemiBold"
+                                                           Text="Custom Shaders" />
+                                                <TextBlock Margin="0,12,70,0"
+                                                           Foreground="{DynamicResource SukiLowText}"
+                                                           Text="Click any of the buttons below to enable a background shader. Click it again to disable it. These are likely to put quite a load on your GPU and are purely to demonstrate and test the capabilities of the background renderer."
+                                                           TextWrapping="Wrap" />
+                                            </StackPanel>
+                                            <ItemsControl ItemsSource="{Binding CustomShaders}">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <Button Margin="10"
+                                                                Classes="Flat"
+                                                                Command="{Binding $parent[theming:ThemingView].((theming:ThemingViewModel)DataContext).TryCustomShaderCommand}"
+                                                                CommandParameter="{Binding}"
+                                                                Content="{Binding}" />
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                                <ItemsControl.ItemsPanel>
+                                                    <ItemsPanelTemplate>
+                                                        <UniformGrid Rows="1" />
+                                                    </ItemsPanelTemplate>
+                                                </ItemsControl.ItemsPanel>
+                                            </ItemsControl>
+                                        </DockPanel>
+                                    </StackPanel>
                                 </controls:GlassCard>
                             </controls:SettingsLayoutItem.Content>
                         </controls:SettingsLayoutItem>

--- a/SukiUI.Demo/Features/Theming/ThemingViewModel.cs
+++ b/SukiUI.Demo/Features/Theming/ThemingViewModel.cs
@@ -13,9 +13,11 @@ public partial class ThemingViewModel : DemoPageBase
 {
     public Action<SukiBackgroundStyle> BackgroundStyleChanged { get; set; }
     public Action<bool> BackgroundAnimationsChanged { get; set; }
+    public Action<string?> CustomBackgroundStyleChanged { get; set; }
     
     public IAvaloniaReadOnlyList<SukiColorTheme> AvailableColors { get; }
     public IAvaloniaReadOnlyList<SukiBackgroundStyle> AvailableBackgroundStyles { get; }
+    public IAvaloniaReadOnlyList<string> CustomShaders { get; } = new AvaloniaList<string> { "Space", "Weird", "Clouds" };
 
     private readonly SukiTheme _theme = SukiTheme.GetInstance();
 
@@ -23,6 +25,8 @@ public partial class ThemingViewModel : DemoPageBase
     [ObservableProperty] private SukiBackgroundStyle _backgroundStyle ;
     [ObservableProperty] private bool _backgroundAnimations;
 
+    private string? _customShader = null;
+    
     public ThemingViewModel() : base("Theming", MaterialIconKind.PaletteOutline, -200)
     {
         AvailableBackgroundStyles = new AvaloniaList<SukiBackgroundStyle>(Enum.GetValues<SukiBackgroundStyle>());
@@ -38,10 +42,9 @@ public partial class ThemingViewModel : DemoPageBase
 
     partial void OnIsLightThemeChanged(bool value) =>
         _theme.ChangeBaseTheme(value ? ThemeVariant.Light : ThemeVariant.Dark);
-
-
+    
     [RelayCommand]
-    public void SwitchToColorTheme(SukiColorTheme colorTheme) =>
+    private void SwitchToColorTheme(SukiColorTheme colorTheme) =>
         _theme.ChangeColorTheme(colorTheme);
 
     partial void OnBackgroundStyleChanged(SukiBackgroundStyle value) => 
@@ -49,4 +52,11 @@ public partial class ThemingViewModel : DemoPageBase
 
     partial void OnBackgroundAnimationsChanged(bool value) => 
         BackgroundAnimationsChanged?.Invoke(value);
+    
+    [RelayCommand]
+    private void TryCustomShader(string shaderType)
+    {
+        _customShader = _customShader == shaderType ? null : shaderType;
+        CustomBackgroundStyleChanged?.Invoke(_customShader);
+    }
 }

--- a/SukiUI.Demo/SukiUI.Demo.csproj
+++ b/SukiUI.Demo/SukiUI.Demo.csproj
@@ -55,4 +55,10 @@
 	    <SubType>Code</SubType>
 	  </Compile>
 	</ItemGroup>
+
+	<ItemGroup>
+	  <EmbeddedResource Include="Assets\space.sksl" />
+	  <EmbeddedResource Include="Assets\clouds.sksl" />
+	  <EmbeddedResource Include="Assets\weird.sksl" />
+	</ItemGroup>
 </Project>

--- a/SukiUI.Demo/SukiUIDemoView.axaml
+++ b/SukiUI.Demo/SukiUIDemoView.axaml
@@ -13,6 +13,7 @@
                  d:DesignWidth="800"
                  x:DataType="demo:SukiUIDemoViewModel"
                  BackgroundAnimationEnabled="{Binding AnimationsEnabled}"
+                 BackgroundShaderFile="{Binding CustomShaderFile}"
                  BackgroundStyle="{Binding BackgroundStyle}"
                  CanMinimize="{Binding !WindowLocked}"
                  CanMove="{Binding !WindowLocked}"

--- a/SukiUI.Demo/SukiUIDemoViewModel.cs
+++ b/SukiUI.Demo/SukiUIDemoViewModel.cs
@@ -31,6 +31,7 @@ public partial class SukiUIDemoViewModel : ObservableObject
     [ObservableProperty] private bool _titleBarVisible = true;
     [ObservableProperty] private SukiBackgroundStyle _backgroundStyle = SukiBackgroundStyle.Gradient;
     [ObservableProperty] private bool _animationsEnabled;
+    [ObservableProperty] private string? _customShaderFile;
 
     private readonly SukiTheme _theme;
     private readonly ThemingViewModel _theming;
@@ -41,6 +42,7 @@ public partial class SukiUIDemoViewModel : ObservableObject
         _theming = (ThemingViewModel)DemoPages.First(x => x is ThemingViewModel);
         _theming.BackgroundStyleChanged += style => BackgroundStyle = style;
         _theming.BackgroundAnimationsChanged += enabled => AnimationsEnabled = enabled;
+        _theming.CustomBackgroundStyleChanged += shader => CustomShaderFile = shader;
         
         BackgroundStyles = new AvaloniaList<SukiBackgroundStyle>(Enum.GetValues<SukiBackgroundStyle>());
         _theme = SukiTheme.GetInstance();

--- a/SukiUI/Content/Shaders/gradient.sksl
+++ b/SukiUI/Content/Shaders/gradient.sksl
@@ -9,13 +9,13 @@ vec3 blendOverlay(vec3 base, vec3 blend) {
         base.g < 0.5 ? (2.0 * base.g * blend.g) : (1.0 - 2.0 * (1.0 - base.g) * (1.0 - blend.g)),
         base.b < 0.5 ? (2.0 * base.b * blend.b) : (1.0 - 2.0 * (1.0 - base.b) * (1.0 - blend.b))
     );
-} 
+}
 
 vec3 blendOverlayDark(vec3 base, vec3 blend) {
     vec3 result;
     result.r = (base.r < 0.5) ? (4 * base.r * blend.r) : (3.5 - 2.0 * (3 - base.r) * (3.5 - blend.r));
     result.g = (base.g < 0.5) ? (4 * base.g * blend.g) : (3.5 - 2.0 * (3 - base.g) * (3.5 - blend.g));
-    result.b = (base.b < 0.5) ? (4 * base.b * blend.b) : (3.5- 2.0 * (3 - base.b) * (3.5 - blend.b));
+    result.b = (base.b < 0.5) ? (4 * base.b * blend.b) : (3.5 - 2.0 * (3 - base.b) * (3.5 - blend.b));
     return mix(base, clamp(result, 0.0, 1.0), 0.5); // Mélange avec la couleur de base pour réduire l'assombrissement
 }
 
@@ -60,37 +60,29 @@ vec4 main(vec2 fragCoord) {
     tuv *= Rot(radians((degree - .5) * 720. + 180.));
     tuv.y *= ratio;
 
-   float frequency = 1.;
-       float amplitude = 155.;
+    float frequency = 1.;
+    float amplitude = 155.;
     float speed = iTime * 0.1;
     tuv.x += sin(tuv.y * frequency + speed) / amplitude;
     tuv.y += sin(tuv.x * frequency * 1.5 + speed) / (amplitude * .5);
-
-     
-     
-     
-   
-    float opacityLayer1 = 0.95;
-        float opacityLayer2 = 0.85 - (iDark/2); 
-   
-   vec3 layer1Color = mix(vec3(0.0), iPrimary, opacityLayer1);
-     vec3 layer1 = mix(layer1Color, iAccent * 0.85, smoothstep(-.3, .4, (tuv * Rot(radians(-5.))).x));
-     
-     
-     vec3 layer2Color = mix(vec3(0.0), iAccent, opacityLayer2);
-     vec3 layer2 = mix(layer2Color, iPrimary * 0.65, smoothstep(-.2, .3, (tuv * Rot(radians(-5.))).x)); 
-     
-     
     
-     vec3 finalComp = mix(layer1, layer2, smoothstep(.8, -.5, tuv.y));
-     
-     
-     vec3 col;
-     if(iDark == 0){
-      col = blendOverlay(iBase, finalComp); 
-      }else{
-      col =  blendOverlayDark(iBase, finalComp); 
-      }
+    float opacityLayer1 = 0.95;
+    float opacityLayer2 = 0.85 - (iDark / 2);
+
+    vec3 layer1Color = mix(vec3(0.0), iPrimary, opacityLayer1);
+    vec3 layer1 = mix(layer1Color, iAccent * 0.85, smoothstep(-.3, .4, (tuv * Rot(radians(-5.))).x));
+    
+    vec3 layer2Color = mix(vec3(0.0), iAccent, opacityLayer2);
+    vec3 layer2 = mix(layer2Color, iPrimary * 0.65, smoothstep(-.2, .3, (tuv * Rot(radians(-5.))).x));
+    
+    vec3 finalComp = mix(layer1, layer2, smoothstep(.8, -.5, tuv.y));
+    
+    vec3 col;
+    if (iDark == 0) {
+        col = blendOverlay(iBase, finalComp);
+    } else {
+        col = blendOverlayDark(iBase, finalComp);
+    }
 
     return vec4(col, 1.0);
 }


### PR DESCRIPTION
I grabbed some far more demanding and complex shaders that were available on https://shaders.skia.org/ and included them in the demo app itself (not the library) so they can be used to gauge performance and demonstrate the capabilities now on offer.

Currently they run from left-to-right in terms of how demanding they are on the GPU and are a good way to see what the reasonable limits of a shader might be. It'll also help gauge any performance improvements we might see in the future when SkiaSharp 3.0 becomes available.

I'm currently investigating the possibility of fading between two shaders, or at least opening up the background drawing API enough to allow devs to implement that if they want it, what exact form that'll take I'm not sure and it might turn out to be far too costly in terms of performance anyway but I'd like to make sure this feature is nicely rounded out before I move on from it.