### PR TITLE
Add the ability to transition between background shaders.

### DIFF
--- a/SukiUI.Demo/Assets/clouds.sksl
+++ b/SukiUI.Demo/Assets/clouds.sksl
@@ -106,5 +106,5 @@ half4 main( vec2 fragCoord ) {
 
     vec3 result = mix(skycolour, clamp(skytint * skycolour + cloudcolour, 0.0, 1.0), clamp(f + c, 0.0, 1.0));
 
-    return vec4( result, 1.0 );
+    return vec4( result, iAlpha);
 }

--- a/SukiUI.Demo/Assets/space.sksl
+++ b/SukiUI.Demo/Assets/space.sksl
@@ -63,5 +63,5 @@ half4 main( vec2 fragCoord )
     s+=stepsize;
     }
     v=mix(vec3(length(v)),v,saturation); //color adjust
-    return vec4(v*.01,1.);
+    return vec4(v*.01,iAlpha);
 }

--- a/SukiUI.Demo/Assets/weird.sksl
+++ b/SukiUI.Demo/Assets/weird.sksl
@@ -39,5 +39,5 @@ half4 main(float2 FC) {
         g += e = max(p.x,p.z) / 1e3 - .01;
         o.rgb += .1/exp(cos(v*g*.1+n)+3.+1e4*e);
     }
-    return o.xyz1;
+    return half4(o.xyz, iAlpha);
 }

--- a/SukiUI.Demo/Features/Theming/ThemingView.axaml
+++ b/SukiUI.Demo/Features/Theming/ThemingView.axaml
@@ -75,7 +75,6 @@
                                     </ItemsControl.ItemsPanel>
                                     <ItemsControl.ItemTemplate>
                                         <DataTemplate x:DataType="models:SukiColorTheme">
-
                                             <RadioButton Width="50"
                                                          Height="50"
                                                          Classes="GigaChips"
@@ -109,6 +108,21 @@
                                                 <TextBlock Margin="0,12,70,0"
                                                            Foreground="{DynamicResource SukiLowText}"
                                                            Text="Enable/disable the animations for the background, which are driven by the currently active effect."
+                                                           TextWrapping="Wrap" />
+                                            </StackPanel>
+                                        </DockPanel>
+                                        <DockPanel>
+                                            <ToggleButton VerticalAlignment="Top"
+                                                          Classes="Switch"
+                                                          DockPanel.Dock="Right"
+                                                          IsChecked="{Binding BackgroundTransitions}" />
+                                            <StackPanel HorizontalAlignment="Left">
+                                                <TextBlock FontSize="16"
+                                                           FontWeight="DemiBold"
+                                                           Text="Background Transitions" />
+                                                <TextBlock Margin="0,12,70,0"
+                                                           Foreground="{DynamicResource SukiLowText}"
+                                                           Text="Enable/disable the transitions for the background, these will fade between the active effects when changed."
                                                            TextWrapping="Wrap" />
                                             </StackPanel>
                                         </DockPanel>

--- a/SukiUI.Demo/Features/Theming/ThemingViewModel.cs
+++ b/SukiUI.Demo/Features/Theming/ThemingViewModel.cs
@@ -11,9 +11,10 @@ namespace SukiUI.Demo.Features.Theming;
 
 public partial class ThemingViewModel : DemoPageBase
 {
-    public Action<SukiBackgroundStyle> BackgroundStyleChanged { get; set; }
-    public Action<bool> BackgroundAnimationsChanged { get; set; }
-    public Action<string?> CustomBackgroundStyleChanged { get; set; }
+    public Action<SukiBackgroundStyle>? BackgroundStyleChanged { get; set; }
+    public Action<bool>? BackgroundAnimationsChanged { get; set; }
+    public Action<bool>? BackgroundTransitionsChanged { get; set; }
+    public Action<string?>? CustomBackgroundStyleChanged { get; set; }
     
     public IAvaloniaReadOnlyList<SukiColorTheme> AvailableColors { get; }
     public IAvaloniaReadOnlyList<SukiBackgroundStyle> AvailableBackgroundStyles { get; }
@@ -24,6 +25,7 @@ public partial class ThemingViewModel : DemoPageBase
     [ObservableProperty] private bool _isLightTheme;
     [ObservableProperty] private SukiBackgroundStyle _backgroundStyle ;
     [ObservableProperty] private bool _backgroundAnimations;
+    [ObservableProperty] private bool _backgroundTransitions;
 
     private string? _customShader = null;
     
@@ -36,7 +38,7 @@ public partial class ThemingViewModel : DemoPageBase
             IsLightTheme = variant == ThemeVariant.Light;
         _theme.OnColorThemeChanged += theme =>
         {
-            // TODO: Implement a way to make the correct, might need to wrap the thing in a VM, this isn't ideal.
+            // TODO: Implement a way to make this correct, might need to wrap the thing in a VM, this isn't ideal.
         };
     }
 
@@ -52,7 +54,10 @@ public partial class ThemingViewModel : DemoPageBase
 
     partial void OnBackgroundAnimationsChanged(bool value) => 
         BackgroundAnimationsChanged?.Invoke(value);
-    
+
+    partial void OnBackgroundTransitionsChanged(bool value) =>
+        BackgroundTransitionsChanged?.Invoke(value);
+
     [RelayCommand]
     private void TryCustomShader(string shaderType)
     {

--- a/SukiUI.Demo/SukiUIDemoView.axaml
+++ b/SukiUI.Demo/SukiUIDemoView.axaml
@@ -15,6 +15,7 @@
                  BackgroundAnimationEnabled="{Binding AnimationsEnabled}"
                  BackgroundShaderFile="{Binding CustomShaderFile}"
                  BackgroundStyle="{Binding BackgroundStyle}"
+                 BackgroundTransitionsEnabled="{Binding TransitionsEnabled}"
                  CanMinimize="{Binding !WindowLocked}"
                  CanMove="{Binding !WindowLocked}"
                  CanResize="{Binding !WindowLocked}"
@@ -82,6 +83,11 @@
             <MenuItem Command="{Binding ToggleAnimationsCommand}" Header="Animations">
                 <MenuItem.Icon>
                     <avalonia:MaterialIcon Kind="{Binding AnimationsEnabled, Converter={x:Static converters:BoolToIconConverters.Animation}}" />
+                </MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Command="{Binding ToggleTransitionsCommand}" Header="Transitions">
+                <MenuItem.Icon>
+                    <avalonia:MaterialIcon Kind="{Binding TransitionsEnabled, Converter={x:Static converters:BoolToIconConverters.Animation}}" />
                 </MenuItem.Icon>
             </MenuItem>
         </MenuItem>

--- a/SukiUI.Demo/SukiUIDemoViewModel.cs
+++ b/SukiUI.Demo/SukiUIDemoViewModel.cs
@@ -32,6 +32,8 @@ public partial class SukiUIDemoViewModel : ObservableObject
     [ObservableProperty] private SukiBackgroundStyle _backgroundStyle = SukiBackgroundStyle.Gradient;
     [ObservableProperty] private bool _animationsEnabled;
     [ObservableProperty] private string? _customShaderFile;
+    [ObservableProperty] private bool _transitionsEnabled;
+    [ObservableProperty] private double _transitionTime;
 
     private readonly SukiTheme _theme;
     private readonly ThemingViewModel _theming;
@@ -43,6 +45,7 @@ public partial class SukiUIDemoViewModel : ObservableObject
         _theming.BackgroundStyleChanged += style => BackgroundStyle = style;
         _theming.BackgroundAnimationsChanged += enabled => AnimationsEnabled = enabled;
         _theming.CustomBackgroundStyleChanged += shader => CustomShaderFile = shader;
+        _theming.BackgroundTransitionsChanged += enabled => TransitionsEnabled = enabled;
         
         BackgroundStyles = new AvaloniaList<SukiBackgroundStyle>(Enum.GetValues<SukiBackgroundStyle>());
         _theme = SukiTheme.GetInstance();
@@ -78,6 +81,17 @@ public partial class SukiUIDemoViewModel : ObservableObject
         var content = AnimationsEnabled
             ? "Background animations are now enabled."
             : "Background animations are now disabled.";
+        return SukiHost.ShowToast(title, content);
+    }
+
+    [RelayCommand]
+    private Task ToggleTransitions()
+    {
+        TransitionsEnabled = !TransitionsEnabled;
+        var title = TransitionsEnabled ? "Transitions Enabled" : "Transitions Disabled";
+        var content = TransitionsEnabled
+            ? "Background transitions are now enabled."
+            : "Background transitions are now disabled.";
         return SukiHost.ShowToast(title, content);
     }
 
@@ -118,4 +132,7 @@ public partial class SukiUIDemoViewModel : ObservableObject
 
     partial void OnAnimationsEnabledChanged(bool value) => 
         _theming.BackgroundAnimations = value;
+
+    partial void OnTransitionsEnabledChanged(bool value) =>
+        _theming.BackgroundTransitions = value;
 }

--- a/SukiUI/Content/Shaders/cells.sksl
+++ b/SukiUI/Content/Shaders/cells.sksl
@@ -40,5 +40,5 @@ vec4 main(vec2 fragCoord)
 
     vec3 col = mix(iPrimary, iAccent, clamp(vorv.x * 2.2 + vorv.y, -1., 1.) * 0.5 + 0.5);
     vec3 comp = blendOverlay(iBase, col);
-    return vec4(comp, 1.);
+    return vec4(comp, iAlpha);
 }

--- a/SukiUI/Content/Shaders/flat.sksl
+++ b/SukiUI/Content/Shaders/flat.sksl
@@ -1,3 +1,3 @@
 vec4 main(vec2 fragCoord) {
-    return vec4(iBase, 1.0);
+    return vec4(iBase, iAlpha);
 }

--- a/SukiUI/Content/Shaders/gradient.sksl
+++ b/SukiUI/Content/Shaders/gradient.sksl
@@ -84,5 +84,5 @@ vec4 main(vec2 fragCoord) {
         col = blendOverlayDark(iBase, finalComp);
     }
 
-    return vec4(col, 1.0);
+    return vec4(col, iAlpha);
 }

--- a/SukiUI/Content/Shaders/waves.sksl
+++ b/SukiUI/Content/Shaders/waves.sksl
@@ -51,5 +51,5 @@ vec4 main(vec2 fragCoord )
     vec3 col = mix(iPrimary, iAccent, uv.x);
     voronoi(uv * 4.0 - 1.0, col);
     vec3 finalCol = blendOverlay(iBase, col);
-    return vec4(finalCol,1.0);
+    return vec4(finalCol,iAlpha);
 }

--- a/SukiUI/Controls/SukiWindow.axaml
+++ b/SukiUI/Controls/SukiWindow.axaml
@@ -24,7 +24,9 @@
                                                          AnimationEnabled="{TemplateBinding BackgroundAnimationEnabled}"
                                                          ShaderCode="{TemplateBinding BackgroundShaderCode}"
                                                          ShaderFile="{TemplateBinding BackgroundShaderFile}"
-                                                         Style="{TemplateBinding BackgroundStyle}" />
+                                                         Style="{TemplateBinding BackgroundStyle}"
+                                                         TransitionTime="{TemplateBinding BackgroundTransitionTime}"
+                                                         TransitionsEnabled="{TemplateBinding BackgroundTransitionsEnabled}" />
                                     <DockPanel LastChildFill="True">
                                         <Panel DockPanel.Dock="Top">
                                             <Panel.Styles>

--- a/SukiUI/Controls/SukiWindow.axaml.cs
+++ b/SukiUI/Controls/SukiWindow.axaml.cs
@@ -116,9 +116,8 @@ public class SukiWindow : Window
         AvaloniaProperty.Register<SukiWindow, SukiBackgroundStyle>(nameof(BackgroundStyle),
             defaultValue: SukiBackgroundStyle.Gradient);
 
-    /// <summary>
-    /// Which of the default background styles to use.
-    /// </summary>
+    
+    /// <inheritdoc cref="SukiBackground.Style"/>
     public SukiBackgroundStyle BackgroundStyle
     {
         get => GetValue(BackgroundStyleProperty);
@@ -128,10 +127,7 @@ public class SukiWindow : Window
     public static readonly StyledProperty<string?> BackgroundShaderFileProperty =
         AvaloniaProperty.Register<SukiWindow, string?>(nameof(BackgroundShaderFile));
 
-    /// <summary>
-    /// Specify a filename of an EMBEDDED RESOURCE file of type `.SkSL` with or without extension and it will be loaded and displayed.
-    /// This takes priority over the <see cref="BackgroundShaderCode"/> property, which in turns takes priority over <see cref="BackgroundStyle"/>.
-    /// </summary>
+    /// <inheritdoc cref="SukiBackground.ShaderFile"/>
     public string? BackgroundShaderFile
     {
         get => GetValue(BackgroundShaderFileProperty);
@@ -141,14 +137,32 @@ public class SukiWindow : Window
     public static readonly StyledProperty<string?> BackgroundShaderCodeProperty =
         AvaloniaProperty.Register<SukiWindow, string?>(nameof(BackgroundShaderCode));
 
-    /// <summary>
-    /// Specify the shader code to use directly, simpler if you don't want to create an .SkSL file or want to generate the shader effect at runtime in some way.
-    /// This takes priority over the <see cref="BackgroundStyle"/> property, but is second in priority to <see cref="BackgroundShaderFile"/> if it is set.
-    /// </summary>
+    
+    /// <inheritdoc cref="SukiBackground.ShaderCode"/>
     public string? BackgroundShaderCode
     {
         get => GetValue(BackgroundShaderCodeProperty);
         set => SetValue(BackgroundShaderCodeProperty, value);
+    }
+    
+    public static readonly StyledProperty<bool> BackgroundTransitionsEnabledProperty =
+        AvaloniaProperty.Register<SukiBackground, bool>(nameof(BackgroundTransitionsEnabled), defaultValue: false);
+    
+    /// <inheritdoc cref="SukiBackground.TransitionsEnabled"/>
+    public bool BackgroundTransitionsEnabled
+    {
+        get => GetValue(BackgroundTransitionsEnabledProperty);
+        set => SetValue(BackgroundTransitionsEnabledProperty, value);
+    }
+
+    public static readonly StyledProperty<double> BackgroundTransitionTimeProperty =
+        AvaloniaProperty.Register<SukiBackground, double>(nameof(BackgroundTransitionTime), defaultValue: 1.0);
+    
+    /// <inheritdoc cref="SukiBackground.TransitionTime"/>
+    public double BackgroundTransitionTime
+    {
+        get => GetValue(BackgroundTransitionTimeProperty);
+        set => SetValue(BackgroundTransitionTimeProperty, value);
     }
 
     public SukiWindow()
@@ -157,7 +171,6 @@ public class SukiWindow : Window
     }
 
     private IDisposable? _subscriptionDisposables;
-    private SukiBackground _background;
 
     protected override void OnLoaded(RoutedEventArgs e)
     {

--- a/SukiUI/Utilities/Background/ShaderBackgroundDraw.cs
+++ b/SukiUI/Utilities/Background/ShaderBackgroundDraw.cs
@@ -56,6 +56,7 @@ namespace SukiUI.Utilities.Background
         {
             if (!TransitionsEnabled) return;
             if (oldValue is null || Equals(oldValue, newValue)) return;
+            _oldEffect?.Dispose();
             _oldEffect = oldValue;
             _transitionStartTime = TransitionTick.Elapsed.TotalSeconds;
             _transitionEndTime = _transitionStartTime + Math.Max(0, TransitionTime);
@@ -114,7 +115,7 @@ namespace SukiUI.Utilities.Background
                 canvas.DrawRect(rect, mainShaderPaint);
             }
 
-            if (TransitionsEnabled && _oldEffect is not null)
+            if (_oldEffect is not null)
             {
                 using var oldShaderPaint = new SKPaint();
                 // Blend modes effect the transition quite heavily, only these 3 seem to work in any reasonable way.

--- a/SukiUI/Utilities/Background/SukiBackgroundEffect.cs
+++ b/SukiUI/Utilities/Background/SukiBackgroundEffect.cs
@@ -14,7 +14,8 @@ namespace SukiUI.Utilities.Background
     public class SukiBackgroundEffect : IDisposable
     {
         private const string Uniforms = "uniform float iTime;        // Scaled shader playback time (s)\n" +
-                                        "uniform float iDark      ;   // DarkTheme\n" +
+                                        "uniform float iDark;        // DarkTheme\n" +
+                                        "uniform float iAlpha;       // Current alpha for this effect - used for blending\n" +
                                         "uniform vec3 iResolution;   // Viewport resolution (pixels)\n" +
                                         "uniform vec3 iPrimary;      // Currently active primary color\n" +
                                         "uniform vec3 iAccent;       // Currently active accent color\n" +
@@ -49,14 +50,15 @@ namespace SukiUI.Utilities.Background
                 resName = assembly.GetManifestResourceNames()
                     .FirstOrDefault(x => x.ToLowerInvariant().Contains(shaderName));
             }
+
             if (resName is null)
                 throw new FileNotFoundException(
                     $"Unable to find a file with the name \"{shaderName}\" anywhere in the assembly.");
             using var tr = new StreamReader(assembly.GetManifestResourceStream(resName)!);
             return FromString(tr.ReadToEnd());
         }
-        
-        
+
+
         public static SukiBackgroundEffect FromString(string shaderString)
         {
             var withUniforms = Uniforms + shaderString;
@@ -68,6 +70,12 @@ namespace SukiUI.Utilities.Background
         public void Dispose()
         {
             Effect.Dispose();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is not SukiBackgroundEffect effect) return false;
+            return effect._effectString == _effectString;
         }
 
         public class SKShaderCompileException : Exception


### PR DESCRIPTION
### Changes
- Implemented a simple fade transition between background effects.
- Included related properties on `SukiBackground` and associated ones on `SukiWindow`.
- Included a new `iAlpha` uniform for use in blending.
- Added controls to the demo app to test this feature.

### Outstanding issues
- This does involve - only for the duration of the fade however - rendering two full shader passes, as such it's disabled by default to avoid performance implications.
- Fade effect isn't perfect and can look a bit harsh depending on precisely what effects are blended together.
  - This is mostly a consequence of the weird blending modes, I couldn't find one that achieved what I was looking for despite trying them all. Playing around with different easing functions may also improve the situation.
- Can't fade between colours as of right now without expanding the shader API - would need to include a duplicate set of "old" colours so that shaders could blend between them which would further complicate shaders.
  - This is actually reasonably doable with a few minor tweaks, though it will contribute to the bloat. I can rework this PR and include that change if it's a desirable feature.
- Adding more and more uniforms that are heavily controlled from C# is likely to cause problems both in terms of performance and the ease of implementing a desirable background effect by devs, as the raw values are so heavily twisted by the time they reach the GPU that if you wanted to use the raw colours you'd have to essentially "revert" all the calculations on the GPU.