### PR TITLE
Support Win11 Snap Layout

### DIFF
--- a/SukiUI/Controls/SukiWindow.axaml.cs
+++ b/SukiUI/Controls/SukiWindow.axaml.cs
@@ -7,6 +7,7 @@ using Avalonia.Threading;
 using System;
 using System.Reactive;
 using System.Reactive.Linq;
+using System.Reflection;
 using Avalonia.Collections;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Interactivity;
@@ -208,6 +209,7 @@ public class SukiWindow : Window
                         : WindowState.Maximized;
                 };
                 bool pointerOnMaxButton = false;
+                var  setter             = typeof(Button).GetProperty("IsPointerOver");
 
                 var proc = (IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam, ref bool handled) =>
                 {
@@ -232,13 +234,14 @@ public class SukiWindow : Window
                                     maximize.DesiredSize.Height)
                                 .Contains(new Point(x, y)))
                             {
-                                Console.WriteLine(DateTime.Now);
-                                pointerOnMaxButton = true;
-                                handled  = true;
+                                setter?.SetValue(maximize, true);
+                                pointerOnMaxButton     = true;
+                                handled                = true;
                                 return (IntPtr)9;
                             }
 
                             pointerOnMaxButton = false;
+                            setter?.SetValue(maximize, false);
                             break;
                     }
 


### PR DESCRIPTION
I'v made  `SukiWindow` supported win11 snap layout just like this:

![image](https://github.com/kikipoulet/SukiUI/assets/82046714/9efe3792-2a99-4933-9c4f-6fc1e63f5b38)

~~I found little bugs that this panel will make control lose focus but this is responsible for Avalonia. I made it still can trigger event, but hover animation will hardly be triggered.~~

I'v recover the button's hover animation using `Reflection`.
