### PR TITLE
Minor button tweak and small attempt to improve performance.

### DIFF
--- a/SukiUI.Demo/Features/ControlsLibrary/ButtonsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/ButtonsView.axaml
@@ -16,6 +16,7 @@
             <Setter Property="Content" Value="Button" />
             <Setter Property="theme:ButtonExtensions.ShowProgress" Value="{Binding IsBusy}" />
             <Setter Property="Command" Value="{Binding ButtonClickedCommand}" />
+            <Setter Property="IsEnabled" Value="{Binding IsEnabled}" />
         </Style>
     </UserControl.Styles>
     <Grid RowDefinitions="Auto,*">
@@ -28,6 +29,16 @@
                     <TextBlock>
                         Clicking on any one of the buttons will make them all "Busy" for 3 seconds, and how this is achieved can be seen in the XAML for the Busy Button.
                     </TextBlock>
+                    <StackPanel Margin="0,25,0,0" Orientation="Horizontal">
+                        <TextBlock Margin="0,0,0,0"
+                                   VerticalAlignment="Center"
+                                   FontWeight="DemiBold"
+                                   Text="Buttons Enabled: " />
+                        <ToggleButton Margin="15,0,0,0"
+                                      Classes="Switch"
+                                      IsChecked="{Binding IsEnabled}" />
+
+                    </StackPanel>
                 </StackPanel>
             </controls:GroupBox>
         </controls:GlassCard>

--- a/SukiUI.Demo/Features/ControlsLibrary/ButtonsViewModel.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/ButtonsViewModel.cs
@@ -8,6 +8,7 @@ namespace SukiUI.Demo.Features.ControlsLibrary;
 public partial class ButtonsViewModel() : DemoPageBase("Buttons", MaterialIconKind.CursorDefaultClick)
 {
     [ObservableProperty] private bool _isBusy;
+    [ObservableProperty] private bool _isEnabled = true;
 
     [RelayCommand]
     private Task ButtonClicked()

--- a/SukiUI/Controls/SukiBackground.cs
+++ b/SukiUI/Controls/SukiBackground.cs
@@ -125,6 +125,7 @@ namespace SukiUI.Controls
         {
             _draw.Bounds = Bounds;
             context.Custom(_draw);
+            Dispatcher.UIThread.InvokeAsync(InvalidateVisual, DispatcherPriority.Background);
         }
 
         private void HandleBackgroundStyleChanges()

--- a/SukiUI/Controls/SukiWindow.axaml
+++ b/SukiUI/Controls/SukiWindow.axaml
@@ -16,95 +16,94 @@
                         CornerRadius="{OnPlatform '0',
                                                   Linux='10',
                                                   x:TypeArguments=CornerRadius}">
-                    <Panel IsHitTestVisible="True">
-                        <VisualLayerManager Name="PART_VisualLayerManager" IsHitTestVisible="True">
-                            <suki:SukiHost>
-                                <Panel x:Name="PART_Root">
-                                    <suki:SukiBackground Name="PART_Background"
-                                                         AnimationEnabled="{TemplateBinding BackgroundAnimationEnabled}"
-                                                         ShaderCode="{TemplateBinding BackgroundShaderCode}"
-                                                         ShaderFile="{TemplateBinding BackgroundShaderFile}"
-                                                         Style="{TemplateBinding BackgroundStyle}"
-                                                         TransitionTime="{TemplateBinding BackgroundTransitionTime}"
-                                                         TransitionsEnabled="{TemplateBinding BackgroundTransitionsEnabled}" />
-                                    <DockPanel LastChildFill="True">
-                                        <Panel DockPanel.Dock="Top">
-                                            <Panel.Styles>
-                                                <Style Selector="suki|SukiWindow[ShowBottomBorder=True] /template/ Border#PART_BottomBorder">
-                                                    <Setter Property="BorderThickness" Value="0,0,0,1" />
-                                                </Style>
-                                                <Style Selector="suki|SukiWindow[ShowBottomBorder=False] /template/ Border#PART_BottomBorder">
-                                                    <Setter Property="BorderThickness" Value="0,0,0,0" />
-                                                </Style>
-                                            </Panel.Styles>
-                                            <StackPanel>
-                                                <LayoutTransformControl Name="PART_LayoutTransform" RenderTransformOrigin="0%,0%">
-                                                    <Panel>
-                                                        <suki:GlassCard Name="PART_TitleBarBackground"
-                                                                        BorderThickness="0"
-                                                                        CornerRadius="0"
-                                                                        IsAnimated="False" />
-                                                        <DockPanel Margin="12,9" LastChildFill="True">
-                                                            <StackPanel VerticalAlignment="Center"
-                                                                        DockPanel.Dock="Right"
-                                                                        FlowDirection="RightToLeft"
-                                                                        Orientation="Horizontal"
-                                                                        Spacing="7">
-                                                                <StackPanel.Styles>
-                                                                    <Style Selector="PathIcon">
-                                                                        <Setter Property="Height" Value="10" />
-                                                                        <Setter Property="Width" Value="10" />
-                                                                    </Style>
-                                                                </StackPanel.Styles>
-                                                                <Button Name="PART_CloseButton" Classes="Basic Rounded WindowControlsButton Close">
-                                                                    <PathIcon Data="{x:Static icons:Icons.WindowClose}" />
-                                                                </Button>
-                                                                <Button Name="PART_MaximizeButton"
-                                                                        Classes="Basic Rounded WindowControlsButton"
-                                                                        IsVisible="{TemplateBinding CanResize}">
-                                                                    <PathIcon x:Name="MaximizeIcon" Data="{x:Static icons:Icons.WindowMaximize}" />
-                                                                </Button>
-                                                                <Button Name="PART_MinimizeButton"
-                                                                        VerticalContentAlignment="Bottom"
-                                                                        Classes="Basic Rounded WindowControlsButton"
-                                                                        IsVisible="{TemplateBinding CanMinimize}">
-                                                                    <PathIcon Margin="0,0,0,4"
-                                                                              VerticalAlignment="Bottom"
-                                                                              Data="{x:Static icons:Icons.WindowMinimize}" />
-                                                                </Button>
-                                                            </StackPanel>
-                                                            <StackPanel VerticalAlignment="Center"
-                                                                        IsHitTestVisible="False"
-                                                                        Orientation="Horizontal"
-                                                                        Spacing="10">
-                                                                <ContentPresenter HorizontalAlignment="Left"
-                                                                                  Content="{TemplateBinding LogoContent}"
-                                                                                  IsHitTestVisible="False" />
-                                                                <TextBlock VerticalAlignment="Center"
-                                                                           FontSize="{TemplateBinding TitleFontSize}"
-                                                                           FontWeight="{TemplateBinding TitleFontWeight}"
-                                                                           IsHitTestVisible="False"
-                                                                           Text="{TemplateBinding Title}" />
-                                                            </StackPanel>
-                                                        </DockPanel>
-                                                    </Panel>
-                                                </LayoutTransformControl>
-                                                <Menu IsEnabled="{TemplateBinding IsMenuVisible}" ItemsSource="{TemplateBinding MenuItems}" />
-                                                <Border Name="PART_BottomBorder" BorderBrush="{DynamicResource SukiBorderBrush}" />
-                                            </StackPanel>
-                                        </Panel>
-                                        <ContentPresenter x:Name="PART_ContentPresenter"
-                                                          HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                          Content="{TemplateBinding Content}"
-                                                          ContentTemplate="{TemplateBinding ContentTemplate}"
-                                                          CornerRadius="10"
-                                                          IsHitTestVisible="True" />
-                                    </DockPanel>
+                    <VisualLayerManager Name="PART_VisualLayerManager" IsHitTestVisible="True">
+                        <VisualLayerManager.ChromeOverlayLayer>
+                            <suki:SukiHost />
+                        </VisualLayerManager.ChromeOverlayLayer>
+                        <Panel x:Name="PART_Root">
+                            <suki:SukiBackground Name="PART_Background"
+                                                 AnimationEnabled="{TemplateBinding BackgroundAnimationEnabled}"
+                                                 ShaderCode="{TemplateBinding BackgroundShaderCode}"
+                                                 ShaderFile="{TemplateBinding BackgroundShaderFile}"
+                                                 Style="{TemplateBinding BackgroundStyle}"
+                                                 TransitionTime="{TemplateBinding BackgroundTransitionTime}"
+                                                 TransitionsEnabled="{TemplateBinding BackgroundTransitionsEnabled}" />
+                            <DockPanel LastChildFill="True">
+                                <Panel DockPanel.Dock="Top">
+                                    <Panel.Styles>
+                                        <Style Selector="suki|SukiWindow[ShowBottomBorder=True] /template/ Border#PART_BottomBorder">
+                                            <Setter Property="BorderThickness" Value="0,0,0,1" />
+                                        </Style>
+                                        <Style Selector="suki|SukiWindow[ShowBottomBorder=False] /template/ Border#PART_BottomBorder">
+                                            <Setter Property="BorderThickness" Value="0,0,0,0" />
+                                        </Style>
+                                    </Panel.Styles>
+                                    <StackPanel>
+                                        <LayoutTransformControl Name="PART_LayoutTransform" RenderTransformOrigin="0%,0%">
+                                            <Panel>
+                                                <suki:GlassCard Name="PART_TitleBarBackground"
+                                                                BorderThickness="0"
+                                                                CornerRadius="0"
+                                                                IsAnimated="False" />
+                                                <DockPanel Margin="12,9" LastChildFill="True">
+                                                    <StackPanel VerticalAlignment="Center"
+                                                                DockPanel.Dock="Right"
+                                                                FlowDirection="RightToLeft"
+                                                                Orientation="Horizontal"
+                                                                Spacing="7">
+                                                        <StackPanel.Styles>
+                                                            <Style Selector="PathIcon">
+                                                                <Setter Property="Height" Value="10" />
+                                                                <Setter Property="Width" Value="10" />
+                                                            </Style>
+                                                        </StackPanel.Styles>
+                                                        <Button Name="PART_CloseButton" Classes="Basic Rounded WindowControlsButton Close">
+                                                            <PathIcon Data="{x:Static icons:Icons.WindowClose}" />
+                                                        </Button>
+                                                        <Button Name="PART_MaximizeButton"
+                                                                Classes="Basic Rounded WindowControlsButton"
+                                                                IsVisible="{TemplateBinding CanResize}">
+                                                            <PathIcon x:Name="MaximizeIcon" Data="{x:Static icons:Icons.WindowMaximize}" />
+                                                        </Button>
+                                                        <Button Name="PART_MinimizeButton"
+                                                                VerticalContentAlignment="Bottom"
+                                                                Classes="Basic Rounded WindowControlsButton"
+                                                                IsVisible="{TemplateBinding CanMinimize}">
+                                                            <PathIcon Margin="0,0,0,4"
+                                                                      VerticalAlignment="Bottom"
+                                                                      Data="{x:Static icons:Icons.WindowMinimize}" />
+                                                        </Button>
+                                                    </StackPanel>
+                                                    <StackPanel VerticalAlignment="Center"
+                                                                IsHitTestVisible="False"
+                                                                Orientation="Horizontal"
+                                                                Spacing="10">
+                                                        <ContentPresenter HorizontalAlignment="Left"
+                                                                          Content="{TemplateBinding LogoContent}"
+                                                                          IsHitTestVisible="False" />
+                                                        <TextBlock VerticalAlignment="Center"
+                                                                   FontSize="{TemplateBinding TitleFontSize}"
+                                                                   FontWeight="{TemplateBinding TitleFontWeight}"
+                                                                   IsHitTestVisible="False"
+                                                                   Text="{TemplateBinding Title}" />
+                                                    </StackPanel>
+                                                </DockPanel>
+                                            </Panel>
+                                        </LayoutTransformControl>
+                                        <Menu IsEnabled="{TemplateBinding IsMenuVisible}" ItemsSource="{TemplateBinding MenuItems}" />
+                                        <Border Name="PART_BottomBorder" BorderBrush="{DynamicResource SukiBorderBrush}" />
+                                    </StackPanel>
                                 </Panel>
-                            </suki:SukiHost>
-                        </VisualLayerManager>
-                    </Panel>
+                                <ContentPresenter x:Name="PART_ContentPresenter"
+                                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                  Content="{TemplateBinding Content}"
+                                                  ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                  CornerRadius="10"
+                                                  IsHitTestVisible="True" />
+                            </DockPanel>
+                        </Panel>
+                    </VisualLayerManager>
                 </Border>
             </ControlTemplate>
         </Setter>

--- a/SukiUI/Theme/Button.axaml
+++ b/SukiUI/Theme/Button.axaml
@@ -9,7 +9,7 @@
         <Setter Property="Background" Value="{DynamicResource SukiBackground}" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
-        
+
         <Setter Property="FontSize" Value="15" />
         <Setter Property="Padding" Value="20,8" />
         <Setter Property="Template">
@@ -47,6 +47,7 @@
         <Setter Property="Transitions">
             <Transitions>
                 <BrushTransition Property="Background" Duration="0:0:0.35" />
+                <DoubleTransition Property="Opacity" Duration="0:0:0.35" />
             </Transitions>
         </Setter>
 
@@ -61,7 +62,7 @@
             </Setter>
         </Style>
         <Style Selector="^ /template/ controls|Loading">
-          <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
+            <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
         </Style>
 
 
@@ -112,26 +113,30 @@
                 <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
             </Style>
         </Style>
-        
+        <Style Selector="^:disabled">
+            <Setter Property="Opacity" Value="0.5" />
+        </Style>
+
+        <!--  Classes  -->
         <Style Selector="^.NoPressedAnimation">
-        <Style Selector="^:pressed">
-            <Style Selector="^ /template/ TextBlock">
-                <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
-            </Style>
-            <Style Selector="^ /template/ Border">
-                <Setter Property="Background" Value="{DynamicResource SukiCardBackground}" />
-                <Setter Property="BorderBrush" Value="{DynamicResource SukiPrimaryColor}" />
-                <Setter Property="RenderTransform">
-                    <Setter.Value>
-                        <ScaleTransform ScaleX="1" ScaleY="1" />
-                    </Setter.Value>
-                </Setter>
-            </Style>
-            <Style Selector="^ /template/ ContentPresenter">
-                <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
+            <Style Selector="^:pressed">
+                <Style Selector="^ /template/ TextBlock">
+                    <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
+                </Style>
+                <Style Selector="^ /template/ Border">
+                    <Setter Property="Background" Value="{DynamicResource SukiCardBackground}" />
+                    <Setter Property="BorderBrush" Value="{DynamicResource SukiPrimaryColor}" />
+                    <Setter Property="RenderTransform">
+                        <Setter.Value>
+                            <ScaleTransform ScaleX="1" ScaleY="1" />
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+                <Style Selector="^ /template/ ContentPresenter">
+                    <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
+                </Style>
             </Style>
         </Style>
-            </Style>
 
         <!--  Classes  -->
         <Style Selector="^.Accent">
@@ -262,7 +267,7 @@
             <Style Selector="^ /template/ TextBlock">
                 <Setter Property="Foreground" Value="White" />
             </Style>
-            
+
             <Style Selector="^ /template/ controls|Loading">
                 <Setter Property="Foreground" Value="White" />
             </Style>
@@ -310,7 +315,7 @@
                     </Transitions>
                 </Setter>
             </Style>
-            
+
             <Style Selector="^ /template/ controls|Loading">
                 <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
             </Style>


### PR DESCRIPTION
### Changes
- Add 0.5 opacity to buttons when disabled, as there was no visual feedback for disabled buttons.
- Remove `SukiHost` as the root and apply it in the `VisualLayoutManager.ChromeOverlayLayer` instead.
- Remove seemingly needless outer `Panel` to further flatten visual tree.

### Outstanding issues
- `SukiBackground` needs to now call `InvalidateVisual` to ensure it is correctly rendered when animations are enabled.
- This doesn't seem to have made a huge impact on performance (that I can tell) but it's eliminating a potential source at least.