### PR TITLE
Include simple right window buttons implementation and demo.

### DIFF
--- a/SukiUI.Demo/SukiUIDemoView.axaml
+++ b/SukiUI.Demo/SukiUIDemoView.axaml
@@ -38,30 +38,29 @@
     </suki:SukiWindow.LogoContent>
     <suki:SukiWindow.RightWindowTitleBarControls>
         <Button Classes="Basic Rounded WindowControlsButton">
-            <avalonia:MaterialIcon Kind="Cog" Foreground="{DynamicResource SukiText}"/>
+            <avalonia:MaterialIcon Kind="Cog" Foreground="{DynamicResource SukiText}" />
             <Button.Flyout>
                 <Flyout>
-                    <Border CornerRadius="15" 
-                            ClipToBounds="True" 
+                    <Border CornerRadius="15"
+                            ClipToBounds="True"
                             Background="{DynamicResource SukiCardBackground}"
                             BorderBrush="{DynamicResource SukiLightBorderBrush}"
-                            BorderThickness="1"
-                            FlowDirection="LeftToRight">
-                        <Border Background="{DynamicResource PopupGradientBrush}" 
+                            BorderThickness="1">
+                        <Border Background="{DynamicResource PopupGradientBrush}"
                                 Padding="15">
                             <suki:GroupBox Header="Settings Demo">
                                 <StackPanel Spacing="5">
                                     <DockPanel>
-                                        <TextBlock Text="Volume:" 
+                                        <TextBlock Text="Volume:"
                                                    DockPanel.Dock="Left"
-                                                   VerticalAlignment="Center"/>
-                                        <Slider Value="50" MinWidth="100"/>
+                                                   VerticalAlignment="Center" />
+                                        <Slider Value="50" MinWidth="100" />
                                     </DockPanel>
                                     <DockPanel>
-                                        <TextBlock Text="Mute:" 
+                                        <TextBlock Text="Mute:"
                                                    DockPanel.Dock="Left"
-                                                   VerticalAlignment="Center"/>
-                                        <ToggleSwitch/>
+                                                   VerticalAlignment="Center" />
+                                        <ToggleSwitch />
                                     </DockPanel>
                                 </StackPanel>
                             </suki:GroupBox>
@@ -69,6 +68,12 @@
                     </Border>
                 </Flyout>
             </Button.Flyout>
+        </Button>
+        <Button Classes="Basic Rounded WindowControlsButton">
+            <avalonia:MaterialIcon Kind="Cog" Foreground="{DynamicResource SukiText}" />
+        </Button>
+        <Button Classes="Basic Rounded WindowControlsButton">
+            <avalonia:MaterialIcon Kind="Cog" Foreground="{DynamicResource SukiText}" />
         </Button>
     </suki:SukiWindow.RightWindowTitleBarControls>
 

--- a/SukiUI.Demo/SukiUIDemoView.axaml
+++ b/SukiUI.Demo/SukiUIDemoView.axaml
@@ -69,12 +69,6 @@
                 </Flyout>
             </Button.Flyout>
         </Button>
-        <Button Classes="Basic Rounded WindowControlsButton">
-            <avalonia:MaterialIcon Kind="Cog" Foreground="{DynamicResource SukiText}" />
-        </Button>
-        <Button Classes="Basic Rounded WindowControlsButton">
-            <avalonia:MaterialIcon Kind="Cog" Foreground="{DynamicResource SukiText}" />
-        </Button>
     </suki:SukiWindow.RightWindowTitleBarControls>
 
     <suki:SukiWindow.MenuItems>

--- a/SukiUI.Demo/SukiUIDemoView.axaml
+++ b/SukiUI.Demo/SukiUIDemoView.axaml
@@ -36,6 +36,41 @@
             </avalonia:MaterialIcon.Transitions>
         </avalonia:MaterialIcon>
     </suki:SukiWindow.LogoContent>
+    <suki:SukiWindow.RightWindowTitleBarControls>
+        <Button Classes="Basic Rounded WindowControlsButton">
+            <avalonia:MaterialIcon Kind="Cog" Foreground="{DynamicResource SukiText}"/>
+            <Button.Flyout>
+                <Flyout>
+                    <Border CornerRadius="15" 
+                            ClipToBounds="True" 
+                            Background="{DynamicResource SukiCardBackground}"
+                            BorderBrush="{DynamicResource SukiLightBorderBrush}"
+                            BorderThickness="1"
+                            FlowDirection="LeftToRight">
+                        <Border Background="{DynamicResource PopupGradientBrush}" 
+                                Padding="15">
+                            <suki:GroupBox Header="Settings Demo">
+                                <StackPanel Spacing="5">
+                                    <DockPanel>
+                                        <TextBlock Text="Volume:" 
+                                                   DockPanel.Dock="Left"
+                                                   VerticalAlignment="Center"/>
+                                        <Slider Value="50" MinWidth="100"/>
+                                    </DockPanel>
+                                    <DockPanel>
+                                        <TextBlock Text="Mute:" 
+                                                   DockPanel.Dock="Left"
+                                                   VerticalAlignment="Center"/>
+                                        <ToggleSwitch/>
+                                    </DockPanel>
+                                </StackPanel>
+                            </suki:GroupBox>
+                        </Border>
+                    </Border>
+                </Flyout>
+            </Button.Flyout>
+        </Button>
+    </suki:SukiWindow.RightWindowTitleBarControls>
 
     <suki:SukiWindow.MenuItems>
         <MenuItem Header="Toggles">
@@ -48,14 +83,16 @@
                       Header="Window Lock"
                       ToolTip.Tip="Toggles minimizing and resizing.">
                 <MenuItem.Icon>
-                    <avalonia:MaterialIcon Kind="{Binding WindowLocked, Converter={x:Static converters:BoolToIconConverters.WindowLock}}" />
+                    <avalonia:MaterialIcon
+                        Kind="{Binding WindowLocked, Converter={x:Static converters:BoolToIconConverters.WindowLock}}" />
                 </MenuItem.Icon>
             </MenuItem>
             <MenuItem Command="{Binding ToggleTitleBarCommand}"
                       Header="Title Bar"
                       ToolTip.Tip="Toggles the title bar.">
                 <MenuItem.Icon>
-                    <avalonia:MaterialIcon Kind="{Binding TitleBarVisible, Converter={x:Static converters:BoolToIconConverters.Visibility}}" />
+                    <avalonia:MaterialIcon
+                        Kind="{Binding TitleBarVisible, Converter={x:Static converters:BoolToIconConverters.Visibility}}" />
                 </MenuItem.Icon>
             </MenuItem>
             <MenuItem Header="Fullscreen"
@@ -82,12 +119,14 @@
             <MenuItem Header="-" />
             <MenuItem Command="{Binding ToggleAnimationsCommand}" Header="Animations">
                 <MenuItem.Icon>
-                    <avalonia:MaterialIcon Kind="{Binding AnimationsEnabled, Converter={x:Static converters:BoolToIconConverters.Animation}}" />
+                    <avalonia:MaterialIcon
+                        Kind="{Binding AnimationsEnabled, Converter={x:Static converters:BoolToIconConverters.Animation}}" />
                 </MenuItem.Icon>
             </MenuItem>
             <MenuItem Command="{Binding ToggleTransitionsCommand}" Header="Transitions">
                 <MenuItem.Icon>
-                    <avalonia:MaterialIcon Kind="{Binding TransitionsEnabled, Converter={x:Static converters:BoolToIconConverters.Animation}}" />
+                    <avalonia:MaterialIcon
+                        Kind="{Binding TransitionsEnabled, Converter={x:Static converters:BoolToIconConverters.Animation}}" />
                 </MenuItem.Icon>
             </MenuItem>
         </MenuItem>

--- a/SukiUI/Controls/SukiWindow.axaml
+++ b/SukiUI/Controls/SukiWindow.axaml
@@ -75,6 +75,13 @@
                                                                       VerticalAlignment="Bottom"
                                                                       Data="{x:Static icons:Icons.WindowMinimize}" />
                                                         </Button>
+                                                        <ItemsControl ItemsSource="{TemplateBinding RightWindowTitleBarControls}">
+                                                            <ItemsControl.ItemsPanel>
+                                                                <ItemsPanelTemplate>
+                                                                    <StackPanel Orientation="Horizontal" FlowDirection="RightToLeft"/>
+                                                                </ItemsPanelTemplate>
+                                                            </ItemsControl.ItemsPanel>
+                                                        </ItemsControl>
                                                     </StackPanel>
                                                     <StackPanel VerticalAlignment="Center"
                                                                 IsHitTestVisible="False"

--- a/SukiUI/Controls/SukiWindow.axaml.cs
+++ b/SukiUI/Controls/SukiWindow.axaml.cs
@@ -166,6 +166,17 @@ public class SukiWindow : Window
         set => SetValue(BackgroundTransitionTimeProperty, value);
     }
 
+    public static readonly StyledProperty<Avalonia.Controls.Controls> RightWindowTitleBarControlsProperty = AvaloniaProperty.Register<SukiWindow, Avalonia.Controls.Controls>(nameof(RightWindowTitleBarControls), defaultValue: new Avalonia.Controls.Controls());
+
+    /// <summary>
+    /// Controls that are displayed on the right side of the title bar, to the left of the normal window control buttons. (Displays provided controls right-to-left)
+    /// </summary>
+    public Avalonia.Controls.Controls RightWindowTitleBarControls
+    {
+        get => GetValue(RightWindowTitleBarControlsProperty);
+        set => SetValue(RightWindowTitleBarControlsProperty, value);
+    }
+
     public SukiWindow()
     {
         MenuItems = new AvaloniaList<MenuItem>();

--- a/SukiUI/Enums/SukiBackgroundStyle.cs
+++ b/SukiUI/Enums/SukiBackgroundStyle.cs
@@ -5,6 +5,8 @@ namespace SukiUI.Enums
         Gradient,
         Flat,
         Bubble,
-        BubbleStrong
+        BubbleStrong,
+        Waves,
+        Cells
     }
 }

--- a/SukiUI/Theme/Button.axaml
+++ b/SukiUI/Theme/Button.axaml
@@ -460,6 +460,11 @@
             <Setter Property="Cursor" Value="Hand" />
             <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor0}" />
             <Setter Property="Padding" Value="0" />
+            <Setter Property="Transitions">
+                <Transitions>
+                    <BrushTransition Property="Background" Duration="0.01"/>
+                </Transitions>
+            </Setter>
             <Style Selector="^:pointerover">
                 <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor25}" />
             </Style>

--- a/SukiUI/Theme/FlyoutPresenter.axaml
+++ b/SukiUI/Theme/FlyoutPresenter.axaml
@@ -10,6 +10,7 @@
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
         <Setter Property="TextElement.Foreground" Value="{DynamicResource SukiText}"/>
         <Setter Property="Cursor" Value="Arrow"/>
+        <Setter Property="FlowDirection" Value="{TemplateBinding FlowDirection}"/>
         <Setter Property="Template">
             <ControlTemplate>
                 <Border Name="LayoutRoot"

--- a/SukiUI/Theme/FlyoutPresenter.axaml
+++ b/SukiUI/Theme/FlyoutPresenter.axaml
@@ -8,6 +8,8 @@
         <Setter Property="Padding" Value="4" />
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+        <Setter Property="TextElement.Foreground" Value="{DynamicResource SukiText}"/>
+        <Setter Property="Cursor" Value="Arrow"/>
         <Setter Property="Template">
             <ControlTemplate>
                 <Border Name="LayoutRoot"


### PR DESCRIPTION
### Changes
- Add a `RightWindowTitleBarControls` property to `SukiWindow` so now you can display arbitrary content in the title bar if needed.
  - Included a demo of a possible use case for this.
- Re-added the waves/cells background styles to the enum so they can be used.
  - Mainly to give people some "different" options out of the box. 
  - Would be nice to maybe investigate some better out-of-the-box options, I really like Waves but I'm not that hot on Cells (I think Cells would look better with just tweaking colours and scale values.

### Outstanding issues
- The `Flyout` control is clearly not properly styled out of the box as can be seen in the demo, I have to do a lot of manual stuff to get a normal `Flyout` to look right.
- The need to include specific button styles to have the buttons in the title bar look right is a bit awkward, but without a horribly bloated mess of a custom viewmodel wrapper for title bar buttons I don't see a solution.
- There's some kind of bug with the `ToggleSwitch` that is now visible in the flyout too.