### PR TITLE
[Perf] Optimize some visual effects

### DIFF
--- a/SukiUI/Theme/RadioButtonStyles.xaml
+++ b/SukiUI/Theme/RadioButtonStyles.xaml
@@ -227,7 +227,7 @@
                              UseLayoutRounding="False">
                         <Ellipse.Transitions>
                             <Transitions>
-                                <BrushTransition Property="Fill" Duration="0:0:0.4" />
+                                <BrushTransition Property="Fill" Duration="0:0:0.1" />
                                 <DoubleTransition Property="Width" Duration="0:0:0.3" />
                                 <DoubleTransition Property="Height" Duration="0:0:0.3" />
                             </Transitions>

--- a/SukiUI/Theme/SliderStyles.xaml
+++ b/SukiUI/Theme/SliderStyles.xaml
@@ -76,7 +76,7 @@
                         <Track.DecreaseButton>
                             <RepeatButton Name="PART_DecreaseButton"
                                           Height="22"
-                                          Margin="8,0,-27,0"
+                                          Margin="8,0,-30,0"
                                           HorizontalAlignment="Stretch"
                                           Background="{DynamicResource SukiPrimaryColor}"
                                           BorderThickness="0"
@@ -85,13 +85,13 @@
                         <Track.IncreaseButton>
                             <RepeatButton Name="PART_IncreaseButton" Classes="repeattrack" />
                         </Track.IncreaseButton>
-                        <Thumb Name="thumb">
+                        <Thumb Name="thumb" Margin="3,0,0,0">
                             <Thumb.Template>
                                 <ControlTemplate>
                                     <Grid Width="32" Height="32">
                                         <Border Width="16"
                                                 Height="16"
-                                                Margin="0,0,0,0"
+                                                Margin="0"
                                                 Background="White"
                                                 BorderThickness="0"
                                                 Classes="ThumbBorder ThumbB"

--- a/SukiUI/Theme/TabItem.axaml
+++ b/SukiUI/Theme/TabItem.axaml
@@ -35,7 +35,6 @@
                         BorderThickness="{TemplateBinding BorderThickness}"
                         CornerRadius="{TemplateBinding CornerRadius}">
                     <StackPanel>
-
                         <ContentPresenter Name="PART_HeaderPresenter"
                                           Padding="0,5"
                                           HorizontalAlignment="Center"
@@ -45,7 +44,13 @@
                                           ContentTemplate="{TemplateBinding HeaderTemplate}"
                                           TextBlock.FontFamily="{TemplateBinding FontFamily}"
                                           TextBlock.FontSize="{TemplateBinding FontSize}"
-                                          TextBlock.FontWeight="{TemplateBinding FontWeight}" />
+                                          TextBlock.FontWeight="{TemplateBinding FontWeight}">
+                            <ContentPresenter.Transitions>
+                                <Transitions>
+                                    <BrushTransition Property="Foreground" Duration="0:0:0.1" />
+                                </Transitions>
+                            </ContentPresenter.Transitions>
+                        </ContentPresenter>
                         <Border Name="PART_Underline"
                                 Height="3"
                                 Margin="10,0,10,0"
@@ -74,7 +79,7 @@
         <Style Selector="^:pointerover">
             <Setter Property="Background" Value="Transparent" />
             <Style Selector="^ /template/ ContentPresenter#PART_HeaderPresenter">
-                <Setter Property="TextBlock.Foreground" Value="{DynamicResource SukiPrimaryColor50}" />
+                <Setter Property="TextBlock.Foreground" Value="{DynamicResource SukiPrimaryColor75}" />
             </Style>
         </Style>
 


### PR DESCRIPTION
- Tabitem contentpresenter brush transition
- Radiobutton white eclipse fill lasting shorter time while selecting
- Slider thumb margin:

before:
![image](https://github.com/user-attachments/assets/699c1ede-e287-4bb8-9053-d7978b920b4a)

now:
![image](https://github.com/user-attachments/assets/5d7fd813-466a-465b-9b07-ed889888835b)
