### PR TITLE
Migrate to Avalonia 11.1

### DIFF
--- a/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsView.axaml
@@ -19,9 +19,8 @@
                     <TextBlock>
                         As the API for this resides entirely in C#, the source for the examples can be viewed on GitHub at the URL below.
                     </TextBlock>
-                    <Button Classes="Hyperlink"
-                            Command="{Binding OpenSourceUrlCommand}"
-                            Content="Source Here." />
+                    <HyperlinkButton NavigateUri="https://github.com/kikipoulet/SukiUI/blob/main/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsViewModel.cs"
+                                     Content="Source Here." />
                     <TextBlock>
                         Click any of the following buttons to open up a dialog.
                     </TextBlock>

--- a/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsViewModel.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsViewModel.cs
@@ -21,10 +21,5 @@ public partial class DialogsViewModel() : DemoPageBase("Dialogs", MaterialIconKi
 
     [RelayCommand]
     private static void OpenDialogWindowDemo() => new DialogWindowDemo().Show();
-
-    [RelayCommand]
-    private void OpenSourceUrl() =>
-        UrlUtilities.OpenUrl(
-            $"https://github.com/kikipoulet/SukiUI/blob/main/SukiUI.Demo/Features/ControlsLibrary/Dialogs/{nameof(DialogsViewModel)}.cs");
         
 }

--- a/SukiUI.Demo/Features/ControlsLibrary/Dialogs/VmDialogView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/Dialogs/VmDialogView.axaml
@@ -17,9 +17,8 @@
             <TextBlock>
                 Internally the dialog system then uses the ViewLocator registered in your Application resources to build an appropriate view.
             </TextBlock>
-            <Button Classes="Hyperlink"
-                    Command="{Binding OpenViewLocatorSourceCommand}"
-                    Content="The source for our implementation of a ViewLocator that makes this possible can be found here." />
+            <HyperlinkButton NavigateUri="https://github.com/kikipoulet/SukiUI/blob/main/SukiUI.Demo/Common/ViewLocator.cs"
+                             Content="The source for our implementation of a ViewLocator that makes this possible can be found here."/>
             <Button HorizontalContentAlignment="Center"
                     Command="{Binding CloseDialogCommand}"
                     Content="Close" />

--- a/SukiUI.Demo/Features/ControlsLibrary/Dialogs/VmDialogViewModel.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/Dialogs/VmDialogViewModel.cs
@@ -8,9 +8,5 @@ namespace SukiUI.Demo.Features.ControlsLibrary.Dialogs;
 public partial class VmDialogViewModel : ObservableObject
 {
     [RelayCommand]
-    private static void OpenViewLocatorSource() =>
-        UrlUtilities.OpenUrl("https://github.com/kikipoulet/SukiUI/blob/main/SukiUI.Demo/Common/ViewLocator.cs");
-
-    [RelayCommand]
     private static void CloseDialog() => SukiHost.CloseDialog();
 }

--- a/SukiUI.Demo/Features/ControlsLibrary/TextView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/TextView.axaml
@@ -34,9 +34,7 @@
                             </TextBlock>
                         </StackPanel>
                         <showMeTheXaml:XamlDisplay UniqueId="TextHyperlink">
-                            <TextBlock xml:space="preserve">Text With A <Button Classes="Hyperlink"
-                                        Command="{Binding HyperlinkClickedCommand}"
-                                        Content="Hyperlink" /> Inside.</TextBlock>
+                            <TextBlock xml:space="preserve">Text With A <HyperlinkButton Command="{Binding HyperlinkClickedCommand}" IsVisited="{Binding HyperlinkVisited}" Content="Hyperlink" /> Inside.</TextBlock>
                         </showMeTheXaml:XamlDisplay>
                         <showMeTheXaml:XamlDisplay UniqueId="TextBlock1">
                             <TextBlock Classes="h1" />

--- a/SukiUI.Demo/Features/ControlsLibrary/TextViewModel.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/TextViewModel.cs
@@ -12,10 +12,12 @@ public partial class TextViewModel() : DemoPageBase("Text", MaterialIconKind.Tex
 
     [ObservableProperty] private string _textBoxValue = DefaultText;
     [ObservableProperty] private string _textBlockValue = DefaultText;
+    [ObservableProperty] private bool _hyperlinkVisited;
 
     [RelayCommand]
-    private static Task HyperlinkClicked()
+    private Task HyperlinkClicked()
     {
+        HyperlinkVisited = true;
         return SukiHost.ShowToast("Clicked a hyperlink", "You clicked the hyperlink on the Text page.");
     }
 }

--- a/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastsView.axaml
@@ -28,9 +28,9 @@
                     <TextBlock>
                         As the API for this resides entirely in C#, the source for the examples can be viewed on GitHub at the URL below.
                     </TextBlock>
-                    <Button Classes="Hyperlink"
-                            Command="{Binding OpenSourceUrlCommand}"
-                            Content="Source Here." />
+                    <HyperlinkButton
+                        NavigateUri="https://github.com/kikipoulet/SukiUI/blob/main/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastsViewModel.cs"
+                        Content="Source Here." />
                 </StackPanel>
             </controls:GroupBox>
         </controls:GlassCard>

--- a/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastsViewModel.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastsViewModel.cs
@@ -13,11 +13,6 @@ namespace SukiUI.Demo.Features.ControlsLibrary.Toasts;
 public partial class ToastsViewModel() : DemoPageBase("Toasts", MaterialIconKind.BellRing)
 {
     [RelayCommand]
-    private static void OpenSourceUrl() =>
-        UrlUtilities.OpenUrl(
-            $"https://github.com/kikipoulet/SukiUI/blob/main/SukiUI.Demo/Features/ControlsLibrary/Toasts/{nameof(ToastsViewModel)}.cs");
-
-    [RelayCommand]
     private static Task ShowSingleStandardToast() =>
         SukiHost.ShowToast("A Simple Toast", "This is the content of a toast.");
         

--- a/SukiUI.Demo/Features/Splash/SplashView.axaml
+++ b/SukiUI.Demo/Features/Splash/SplashView.axaml
@@ -22,9 +22,9 @@
                 <TextBlock Name="TextBlockWithInline">
                     In this app you'll find a sample page
                     (
-                    <Button Classes="Hyperlink"
-                            Command="{Binding OpenDashboardCommand}"
-                            Content="Dashboard" />
+                    <HyperlinkButton Command="{Binding OpenDashboardCommand}"
+                                     IsVisited="{Binding DashBoardVisited}"
+                                     Content="Dashboard" />
                     )
                     with a variety of controls used together, as well as a control library for testing and demonstration purposes.
                 </TextBlock>

--- a/SukiUI.Demo/Features/Splash/SplashViewModel.cs
+++ b/SukiUI.Demo/Features/Splash/SplashViewModel.cs
@@ -1,3 +1,4 @@
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Material.Icons;
 using SukiUI.Demo.Features.Dashboard;
@@ -7,9 +8,12 @@ namespace SukiUI.Demo.Features.Splash;
 
 public partial class SplashViewModel(PageNavigationService nav) : DemoPageBase("Welcome", MaterialIconKind.Hand, int.MinValue)
 {
+    [ObservableProperty] private bool _dashBoardVisited;
+    
     [RelayCommand]
     private void OpenDashboard()
     {
+        DashBoardVisited = true;
         nav.RequestNavigation<DashboardViewModel>();
     }
 }

--- a/SukiUI.Demo/SukiUI.Demo.csproj
+++ b/SukiUI.Demo/SukiUI.Demo.csproj
@@ -9,13 +9,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="11.1.0-rc2" />
+		<PackageReference Include="Avalonia" Version="11.1.0" />
 		<PackageReference Include="Avalonia.AvaloniaEdit" Version="11.0.6" />
-		<PackageReference Include="Avalonia.Desktop" Version="11.1.0-rc2" />
-		<PackageReference Include="Avalonia.Fonts.Inter" Version="11.1.0-rc2" />
+		<PackageReference Include="Avalonia.Desktop" Version="11.1.0" />
+		<PackageReference Include="Avalonia.Fonts.Inter" Version="11.1.0" />
 		<!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.0-rc2" />
-		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.0-rc2" />
+		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.0" />
+		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.0" />
 		<PackageReference Include="AvaloniaEdit.TextMate" Version="11.0.6" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
 		<PackageReference Include="Dock.Avalonia" Version="11.1.0-rc1" />

--- a/SukiUI/SukiUI.csproj
+++ b/SukiUI/SukiUI.csproj
@@ -28,11 +28,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="11.1.0-rc2" />
-		<PackageReference Include="Avalonia.Skia" Version="11.1.0-rc2" />
+		<PackageReference Include="Avalonia" Version="11.1.0" />
+		<PackageReference Include="Avalonia.Skia" Version="11.1.0" />
 		<PackageReference Include="SkiaSharp" Version="2.88.8" />
-		<PackageReference Include="Avalonia.Controls.DataGrid" Version="11.1.0-rc2" />
-		<PackageReference Include="Avalonia.Themes.Simple" Version="11.1.0-rc2" />
+		<PackageReference Include="Avalonia.Controls.DataGrid" Version="11.1.0" />
+		<PackageReference Include="Avalonia.Themes.Simple" Version="11.1.0" />
 		<PackageReference Include="ReactiveUI" Version="20.1.1" />
 	</ItemGroup>
 

--- a/SukiUI/Theme/Button.axaml
+++ b/SukiUI/Theme/Button.axaml
@@ -475,34 +475,6 @@
                 </Style>
             </Style>
         </Style>
-
-        <!-- <Style Selector="^.Hyperlink"> -->
-        <!--     <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" /> -->
-        <!--     <Setter Property="Padding" Value="0" /> -->
-        <!--     <Setter Property="Cursor" Value="Hand" /> -->
-        <!--     <Setter Property="VerticalAlignment" Value="Bottom" /> -->
-        <!--     <Setter Property="BorderThickness" Value="0" /> -->
-        <!--     <Setter Property="Background" Value="Transparent" /> -->
-        <!--     <Setter Property="Template"> -->
-        <!--         <ControlTemplate> -->
-        <!--             <ContentPresenter Content="{TemplateBinding Content}"> -->
-        <!--                 <ContentPresenter.Styles> -->
-        <!--                     <Style Selector="TextBlock"> -->
-        <!--                         <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" /> -->
-        <!--                         <Setter Property="FontSize" Value="{TemplateBinding FontSize}" /> -->
-        <!--                         <Setter Property="TextDecorations" Value="Underline" /> -->
-        <!--                         <Setter Property="Transitions"> -->
-        <!--                             <Transitions> -->
-        <!--                                 <BrushTransition Property="Foreground" Duration="{DynamicResource ShortAnimationDuration}" /> -->
-        <!--                             </Transitions> -->
-        <!--                         </Setter> -->
-        <!--                     </Style> -->
-        <!--                 </ContentPresenter.Styles> -->
-        <!--             </ContentPresenter> -->
-        <!--         </ControlTemplate> -->
-        <!--     </Setter> -->
-        <!-- </Style> -->
-
         <Style Selector="^.Large">
             <Setter Property="FontSize" Value="18" />
             <Setter Property="Padding" Value="30,12" />

--- a/SukiUI/Theme/Button.axaml
+++ b/SukiUI/Theme/Button.axaml
@@ -476,32 +476,32 @@
             </Style>
         </Style>
 
-        <Style Selector="^.Hyperlink">
-            <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
-            <Setter Property="Padding" Value="0" />
-            <Setter Property="Cursor" Value="Hand" />
-            <Setter Property="VerticalAlignment" Value="Bottom" />
-            <Setter Property="BorderThickness" Value="0" />
-            <Setter Property="Background" Value="Transparent" />
-            <Setter Property="Template">
-                <ControlTemplate>
-                    <ContentPresenter Content="{TemplateBinding Content}">
-                        <ContentPresenter.Styles>
-                            <Style Selector="TextBlock">
-                                <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
-                                <Setter Property="FontSize" Value="{TemplateBinding FontSize}" />
-                                <Setter Property="TextDecorations" Value="Underline" />
-                                <Setter Property="Transitions">
-                                    <Transitions>
-                                        <BrushTransition Property="Foreground" Duration="{DynamicResource ShortAnimationDuration}" />
-                                    </Transitions>
-                                </Setter>
-                            </Style>
-                        </ContentPresenter.Styles>
-                    </ContentPresenter>
-                </ControlTemplate>
-            </Setter>
-        </Style>
+        <!-- <Style Selector="^.Hyperlink"> -->
+        <!--     <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" /> -->
+        <!--     <Setter Property="Padding" Value="0" /> -->
+        <!--     <Setter Property="Cursor" Value="Hand" /> -->
+        <!--     <Setter Property="VerticalAlignment" Value="Bottom" /> -->
+        <!--     <Setter Property="BorderThickness" Value="0" /> -->
+        <!--     <Setter Property="Background" Value="Transparent" /> -->
+        <!--     <Setter Property="Template"> -->
+        <!--         <ControlTemplate> -->
+        <!--             <ContentPresenter Content="{TemplateBinding Content}"> -->
+        <!--                 <ContentPresenter.Styles> -->
+        <!--                     <Style Selector="TextBlock"> -->
+        <!--                         <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" /> -->
+        <!--                         <Setter Property="FontSize" Value="{TemplateBinding FontSize}" /> -->
+        <!--                         <Setter Property="TextDecorations" Value="Underline" /> -->
+        <!--                         <Setter Property="Transitions"> -->
+        <!--                             <Transitions> -->
+        <!--                                 <BrushTransition Property="Foreground" Duration="{DynamicResource ShortAnimationDuration}" /> -->
+        <!--                             </Transitions> -->
+        <!--                         </Setter> -->
+        <!--                     </Style> -->
+        <!--                 </ContentPresenter.Styles> -->
+        <!--             </ContentPresenter> -->
+        <!--         </ControlTemplate> -->
+        <!--     </Setter> -->
+        <!-- </Style> -->
 
         <Style Selector="^.Large">
             <Setter Property="FontSize" Value="18" />

--- a/SukiUI/Theme/HyperlinkButton.axaml
+++ b/SukiUI/Theme/HyperlinkButton.axaml
@@ -1,0 +1,70 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <ControlTheme x:Key="SukiHyperlinkButtonStyle" TargetType="HyperlinkButton">
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BackgroundSizing" Value="OuterBorderEdge" />
+        <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="CornerRadius" Value="0" />
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="HorizontalAlignment" Value="Left" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="RenderTransform" Value="none" />
+        <Setter Property="TextBlock.TextDecorations" Value="Underline" />
+        <Setter Property="Transitions">
+            <Transitions>
+                <TransformOperationsTransition Property="RenderTransform" Duration="0:0:.075" />
+                <BrushTransition Property="Foreground" Duration="0:0:.9"/>
+            </Transitions>
+        </Setter>
+        <Setter Property="Template">
+            <ControlTemplate>
+                <ContentPresenter x:Name="PART_ContentPresenter"
+                                  Background="{TemplateBinding Background}"
+                                  BackgroundSizing="{TemplateBinding BackgroundSizing}"
+                                  BorderBrush="{TemplateBinding BorderBrush}"
+                                  BorderThickness="{TemplateBinding BorderThickness}"
+                                  CornerRadius="{TemplateBinding CornerRadius}"
+                                  Content="{TemplateBinding Content}"
+                                  ContentTemplate="{TemplateBinding ContentTemplate}"
+                                  Padding="{TemplateBinding Padding}"
+                                  RecognizesAccessKey="True"
+                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryDarkColor}" />
+        </Style>
+
+        <Style Selector="^:pressed">
+            <Setter Property="RenderTransform" Value="scale(0.95)" />
+        </Style>
+
+        <Style Selector="^:pressed /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor75}" />
+        </Style>
+
+        <Style Selector="^:disabled /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Foreground" Value="{DynamicResource SukiDisabledText}" />
+        </Style>
+
+        <Style Selector="^:visited">
+            <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+                <Setter Property="Foreground" Value="{DynamicResource SukiAccentColor}" />
+            </Style>
+            <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+                <Setter Property="Foreground" Value="{DynamicResource SukiAccentDarkColor}" />
+            </Style>
+            <Style Selector="^:pressed /template/ ContentPresenter#PART_ContentPresenter">
+                <Setter Property="Foreground" Value="{DynamicResource SukiAccentColor75}" />
+            </Style>
+        </Style>
+    </ControlTheme>
+    <ControlTheme x:Key="{x:Type HyperlinkButton}"
+                  BasedOn="{StaticResource SukiHyperlinkButtonStyle}"
+                  TargetType="HyperlinkButton" />
+</ResourceDictionary>

--- a/SukiUI/Theme/HyperlinkButton.axaml
+++ b/SukiUI/Theme/HyperlinkButton.axaml
@@ -16,7 +16,6 @@
         <Setter Property="Transitions">
             <Transitions>
                 <TransformOperationsTransition Property="RenderTransform" Duration="0:0:.075" />
-                <BrushTransition Property="Foreground" Duration="0:0:.9"/>
             </Transitions>
         </Setter>
         <Setter Property="Template">
@@ -35,7 +34,15 @@
                                   VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
             </ControlTemplate>
         </Setter>
-
+        
+        <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Transitions">
+                <Transitions>
+                    <BrushTransition Property="Foreground" Duration="{StaticResource ShortAnimationDuration}"/>
+                </Transitions>
+            </Setter>
+        </Style>
+        
         <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
             <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryDarkColor}" />
         </Style>

--- a/SukiUI/Theme/Index.axaml
+++ b/SukiUI/Theme/Index.axaml
@@ -54,6 +54,7 @@
                 <ResourceInclude Source="avares://SukiUI/Theme/DatePicker.axaml" />
                 <ResourceInclude Source="avares://sukiUI/Theme/ToolTipStyle.axaml" />
                 <ResourceInclude Source="avares://sukiUI/Theme/Button.axaml" />
+                <ResourceInclude Source="avares://sukiUI/Theme/HyperlinkButton.axaml"/>
                 <ResourceInclude Source="avares://sukiUI/Theme/PathIcon.axaml" />
                 <ResourceInclude Source="avares://sukiUI/Theme/Expander.axaml" />
                 <ResourceInclude Source="avares://sukiUI/Theme/CalendarDatePickerStyle.axaml" />

--- a/SukiUI/Theme/TextBoxStyles.xaml
+++ b/SukiUI/Theme/TextBoxStyles.xaml
@@ -373,7 +373,7 @@
                         <Border Name="borderbottom"
                                 Margin="1,-1,1,-1"
                                 BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
                                 ClipToBounds="True"
                                 CornerRadius="1">
                             <Border.Transitions>


### PR DESCRIPTION
### Changes
- Migrate to Avalonia 11.1.0 (Release)
- Fix a binding error in TextBox styles (I only managed to catch this when I was implementing logging in my own project, I might add some Avalonia logging to the demo app so we can see what's going on internally a bit more easily)
- Switch every inline button in the demo app to `HyperlinkButton`
  - Also removed the `Hyperlink` button style as it's redundant now.
- Create a basic style for `HyperlinkButton`

### Outstanding issues
- ~~HyperlinkButton brush transition not really working, though that might be preferable.~~
- The annoying text run not updating the text color bug is still present in Avalonia requiring the annoying workaround still...
- The tooltip bug still remains, I have to assume it isn't a bug in Avalonia but a feature and we have to adjust our implementation somehow?
- The `ToggleSwitch` style is still broken in the settings flyout, weird state bug that causes it to flicker whenever the flyout is opened