### PR TITLE
Fixed DataGrid row mouse click selection

### DIFF
--- a/SukiUI/Theme/DataGridStyle.axaml
+++ b/SukiUI/Theme/DataGridStyle.axaml
@@ -20,8 +20,7 @@
     </Design.PreviewWith>
     <Style Selector="DataGridCell">
         <Setter Property="Background" Value="Transparent" />
-        <Setter Property="HorizontalContentAlignment" Value="Left" />
-        <Setter Property="HorizontalAlignment" Value="Left" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Stretch" />
         <Setter Property="FontSize" Value="25" />
         <Setter Property="Template">

--- a/SukiUI/Theme/DataGridStyle.axaml
+++ b/SukiUI/Theme/DataGridStyle.axaml
@@ -27,10 +27,8 @@
             <ControlTemplate>
                 <Grid Background="{TemplateBinding Background}" ColumnDefinitions="*,Auto">
                     <ContentPresenter Margin="{TemplateBinding Padding}"
-                                      HorizontalAlignment="Center"
+                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                       VerticalAlignment="Center"
-                                      HorizontalContentAlignment="Center"
-                                      VerticalContentAlignment="Center"
                                       Content="{TemplateBinding Content}"
                                       ContentTemplate="{TemplateBinding ContentTemplate}"
                                       TextBlock.Foreground="{TemplateBinding Foreground}" />


### PR DESCRIPTION
Since Avalonia 11.1.0 DataGrid row selection has only worked when clicking directly on cell content. Clicking anywhere on the row should select it. The behavior is easily seen on the "Invoices" DataGrid in the "Dashboard" page of the demo app.