### PR TITLE
[Fix] `TransitioningContentControl` crushes when a view attaches visual tree many times

### DIFF
--- a/SukiUI/Controls/SukiTransitioningContentControl.axaml.cs
+++ b/SukiUI/Controls/SukiTransitioningContentControl.axaml.cs
@@ -155,6 +155,9 @@ namespace SukiUI.Controls
             _animCancellationToken.Cancel();
             _animCancellationToken.Dispose();
             _animCancellationToken = new CancellationTokenSource();
+
+            FirstBuffer = null;
+            SecondBuffer = null;
             
             if (_isFirstBufferActive) SecondBuffer = content;
             else FirstBuffer = content;


### PR DESCRIPTION
Related Issue: #258 

What Happened:

When adding some items after emptying the `SukiSideMenu`, it can cause `TransitioningContentControl` to crash if those added items ever appear.

Possible Causes:

The `Views` that were found to be causing the problem had their `VisualParent` in the `TransitioningContentControl`'s `PushContent()` function not empty, but either `FirstBuffer` or `SecondBuffer`. because the `VisualParent` was reassigned to another `Buffer` when it was not empty, this would cause a crash.

```
Unhandled exception. System.InvalidOperationException: 
The control UotanToolbox.Features.Home.HomeView (Content = WrapPanel) 
already has a visual parent ContentPresenter (Name = PART_FirstBufferControl) 
while trying to add it as a child of ContentPresenter (Name = PART_SecondBufferControl).
```

I don't know if there will be any side effects from this pr, but this solves the problem