### PR TITLE
Fixed a few bugs in toasts.

### DIFF
--- a/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastsView.axaml
@@ -28,6 +28,7 @@
                     <HyperlinkButton
                         NavigateUri="https://github.com/kikipoulet/SukiUI/blob/main/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastsViewModel.cs"
                         Content="Source Here." />
+                    <Button Command="{Binding DismissAllToastsCommand}" Content="Click To Dismiss All Active Toasts" HorizontalAlignment="Left" Classes="Flat"/>
                 </StackPanel>
             </suki:GroupBox>
         </suki:GlassCard>

--- a/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastsViewModel.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastsViewModel.cs
@@ -107,4 +107,7 @@ public partial class ToastsViewModel(ISukiToastManager toastManager) : DemoPageB
 
     [RelayCommand]
     private void ShowToastWindow() => new ToastWindowDemo(toastManager).Show();
+
+    [RelayCommand]
+    private void DismissAllToasts() => toastManager.DismissAll();
 }

--- a/SukiUI/Controls/Hosts/SukiToastHost.cs
+++ b/SukiUI/Controls/Hosts/SukiToastHost.cs
@@ -106,8 +106,11 @@ namespace SukiUI.Controls
         private void ManagerOnToastDismissed(object sender, SukiToastManagerEventArgs args) => 
             ClearToast(args.Toast);
 
-        private void ManagerOnAllToastsDismissed(object sender, EventArgs e) => 
-            Items.Clear();
+        private void ManagerOnAllToastsDismissed(object sender, EventArgs e)
+        {
+            foreach(var toast in Items)
+                ClearToast((ISukiToast)toast!);
+        }
 
         private void ManagerOnToastQueued(object sender, SukiToastManagerEventArgs args)
         {
@@ -120,7 +123,7 @@ namespace SukiUI.Controls
         
         private void ClearToast(ISukiToast toast)
         {
-            if (!Items.Contains(toast)) return;
+            if (Manager.IsDismissed(toast)) return;
             toast.AnimateDismiss();
             Task.Delay(300).ContinueWith(_ =>
             {

--- a/SukiUI/Controls/SukiToast.axaml.cs
+++ b/SukiUI/Controls/SukiToast.axaml.cs
@@ -59,6 +59,8 @@ public class SukiToast : ContentControl, ISukiToast
         get => GetValue(ActionButtonsProperty);
         set => SetValue(ActionButtonsProperty, value);
     }
+    
+    public Action<ISukiToast>? DelayDismissAction { get; set; }
 
     public SukiToast()
     {
@@ -102,6 +104,7 @@ public class SukiToast : ContentControl, ISukiToast
         ActionButtons.Clear();
         OnDismissed = null;
         OnClicked = null;
+        DelayDismissAction = null;
         DockPanel.SetDock(this, Dock.Bottom);
         return this;
     }

--- a/SukiUI/Toasts/ISukiToast.cs
+++ b/SukiUI/Toasts/ISukiToast.cs
@@ -19,5 +19,10 @@ namespace SukiUI.Toasts
         void AnimateShow();
         void AnimateDismiss();
         ISukiToast ResetToDefault();
+        /// <summary>
+        /// This is what's called when a delay based dismiss is used.
+        /// This is tracked so that it can be disposed of when the toast is dismissed by other means.
+        /// </summary>
+        Action<ISukiToast>? DelayDismissAction { get; set; }
     }
 }

--- a/SukiUI/Toasts/ISukiToastManager.cs
+++ b/SukiUI/Toasts/ISukiToastManager.cs
@@ -45,5 +45,10 @@ namespace SukiUI.Toasts
         /// Dismisses all toasts from the stack immediately.
         /// </summary>
         void DismissAll();
+        
+        /// <summary>
+        /// Checks to see if a <see cref="ISukiToast"/> has already been dismissed from the stack.
+        /// </summary>
+        bool IsDismissed(ISukiToast toast);
     }
 }

--- a/SukiUI/Toasts/SukiToastBuilder.cs
+++ b/SukiUI/Toasts/SukiToastBuilder.cs
@@ -54,8 +54,16 @@ namespace SukiUI.Toasts
         }
         
         
-        public void Delay(TimeSpan delay, Action<ISukiToast> action) => 
-            Task.Delay(delay).ContinueWith(_ => action(Toast), TaskScheduler.FromCurrentSynchronizationContext());
+        public void Delay(TimeSpan delay, Action<ISukiToast> action)
+        {
+            Toast.DelayDismissAction = action;
+            Task.Delay(delay).ContinueWith(_ =>
+                {
+                    if (Toast.DelayDismissAction != action) return;
+                    Toast.DelayDismissAction.Invoke(Toast);
+                }, 
+                TaskScheduler.FromCurrentSynchronizationContext());
+        }
 
         public void SetOnDismiss(Action<ISukiToast> action) => Toast.OnDismissed = action;
 

--- a/SukiUI/Toasts/SukiToastManager.cs
+++ b/SukiUI/Toasts/SukiToastManager.cs
@@ -4,12 +4,13 @@ using System.Linq;
 
 namespace SukiUI.Toasts
 {
+    // It's important that events are raised BEFORE removing them from the manager so that the animation only plays once.
     public class SukiToastManager : ISukiToastManager
     {
         public event SukiToastManagerEventHandler? OnToastQueued;
         public event SukiToastManagerEventHandler? OnToastDismissed;
         public event EventHandler? OnAllToastsDismissed;
-        
+
         private readonly List<ISukiToast> _toasts = new();
 
         public void Queue(ISukiToast toast)
@@ -20,25 +21,25 @@ namespace SukiUI.Toasts
 
         public void Dismiss(ISukiToast toast)
         {
-            if(!_toasts.Remove(toast)) return;
+            if (!_toasts.Contains(toast)) return;
             OnToastDismissed?.Invoke(this, new SukiToastManagerEventArgs(toast));
+            _toasts.Remove(toast);
         }
 
         public void Dismiss(int count)
         {
             if (!_toasts.Any()) return;
-            if(count > _toasts.Count) count = _toasts.Count;
+            if (count > _toasts.Count) count = _toasts.Count;
             for (var i = 0; i < count; i++)
             {
                 var removed = _toasts[i];
-                _toasts.RemoveAt(i);
                 OnToastDismissed?.Invoke(this, new SukiToastManagerEventArgs(removed));
+                _toasts.RemoveAt(i);
             }
         }
 
         public void EnsureMaximum(int maxAllowed)
         {
-            Console.WriteLine($"{maxAllowed} - {_toasts.Count}");
             if (_toasts.Count <= maxAllowed) return;
             Dismiss(_toasts.Count - maxAllowed);
         }
@@ -46,8 +47,10 @@ namespace SukiUI.Toasts
         public void DismissAll()
         {
             if (!_toasts.Any()) return;
-            _toasts.Clear();
             OnAllToastsDismissed?.Invoke(this, EventArgs.Empty);
+            _toasts.Clear();
         }
+
+        public bool IsDismissed(ISukiToast toast) => !_toasts.Contains(toast);
     }
 }


### PR DESCRIPTION
### Additions
- Added a button in the toasts page of the demo app to dismiss all active toasts for testing purposes.
### Fixes
- Rare case of causing a toast to be dismissed twice by clicking during the animation fixed.
  - API slightly expanded for `ISukiToastManager` to allow for checking if a toast has or hasn't been dismissed.
- Fix potential source of memory leaks and an issue whereby toasts that were recycled via the toast pool could have their delay-based dismiss action called early or multiple times.
  - This involved expanding the API for `ISukiToast` to include a property which tracks the currently active delay action, and checking that it's the most recent one so that older delays aren't used early.
- Removed an errant `Console.WriteLine` that I had stupidly left in whilst I was testing something.

This addresses the issue laid out in #272 along with a few others I discovered along the way.