### PR TITLE
Add dedicated separator style. Demo TrayIcon.

### DIFF
--- a/SukiUI.Demo/App.axaml
+++ b/SukiUI.Demo/App.axaml
@@ -8,6 +8,27 @@
     <Application.DataTemplates>
         <common:ViewLocator />
     </Application.DataTemplates>
+    
+    <TrayIcon.Icons>
+        <TrayIcons>
+            <TrayIcon Icon="/Assets/OIG.N5o-removebg-preview.png" 
+                      ToolTipText="SukiUI Native Menu Demo">
+                <TrayIcon.Menu>
+                    <NativeMenu>
+                        <NativeMenuItem Header="Native Menu Demo">
+                            <NativeMenu>
+                                <NativeMenuItem Header="Option 1"   />
+                                <NativeMenuItem Header="Option 2"   />
+                                <NativeMenuItemSeparator/>
+                                <NativeMenuItem Header="Option 3"  />
+                            </NativeMenu>
+                        </NativeMenuItem>
+                    </NativeMenu>
+                </TrayIcon.Menu>
+            </TrayIcon>
+        </TrayIcons>
+    </TrayIcon.Icons>
+    
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/SukiUI.Demo/Features/ControlsLibrary/ContextMenusView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/ContextMenusView.axaml
@@ -37,10 +37,11 @@
                     </MenuItem.Icon>
                 </MenuItem>
                 <MenuItem Header="Separator Next" />
-                <MenuItem Header="-" />
+                <Separator/>
                 <MenuItem Header="Submenu">
                     <MenuItem Header="Sub-Submenu">
                         <MenuItem Command="{Binding NestedOptionClickedCommand}" Header="Nested Option" />
+                        <MenuItem Header="-" />
                         <MenuItem Header="Disabled Nested Option" IsEnabled="False" />
                     </MenuItem>
                 </MenuItem>

--- a/SukiUI/Theme/Index.axaml
+++ b/SukiUI/Theme/Index.axaml
@@ -61,6 +61,7 @@
                 <ResourceInclude Source="avares://sukiUI/Theme/CalendarDatePickerStyle.axaml" />
                 <ResourceInclude Source="avares://sukiUI/Theme/TabControl.axaml" />
                 <ResourceInclude Source="avares://sukiUI/Theme/TabItem.axaml" />
+                <ResourceInclude Source="avares://sukiUI/Theme/Separator.axaml" />
                 <ResourceInclude Source="avares://sukiUI/Theme/DropDownButton.axaml" />
                 <ResourceInclude Source="avares://sukiUI/Theme/Menu.axaml" />
                 <ResourceInclude Source="avares://sukiUI/Theme/ContextMenu.axaml" />

--- a/SukiUI/Theme/MenuFlyoutPresenter.axaml
+++ b/SukiUI/Theme/MenuFlyoutPresenter.axaml
@@ -16,11 +16,13 @@
                             BorderThickness="{TemplateBinding BorderThickness}"
                             ClipToBounds="True"
                             CornerRadius="{TemplateBinding CornerRadius}">
-                        <ItemsPresenter Name="PART_ItemsPresenter"
-                                        HorizontalAlignment="Left"
-                                        VerticalAlignment="Center"
-                                        ItemsPanel="{TemplateBinding ItemsPanel}"
-                                        KeyboardNavigation.TabNavigation="Continue" />
+                        <Panel Background="{DynamicResource PopupGradientBrush}">
+                            <ItemsPresenter Name="PART_ItemsPresenter"
+                                            HorizontalAlignment="Left"
+                                            VerticalAlignment="Center"
+                                            ItemsPanel="{TemplateBinding ItemsPanel}"
+                                            KeyboardNavigation.TabNavigation="Continue" />
+                        </Panel>
                     </Border>
                 </Panel>
             </ControlTemplate>

--- a/SukiUI/Theme/MenuItem.axaml
+++ b/SukiUI/Theme/MenuItem.axaml
@@ -100,16 +100,6 @@
             <Setter Property="Background" Value="{DynamicResource SukiLightBorderBrush}" />
         </Style>
 
-        <Style Selector="^:separator">
-            <Setter Property="Template">
-                <ControlTemplate>
-                    <Separator Height="1"
-                               Margin="20,1,0,1"
-                               Background="{DynamicResource ThemeControlMidBrush}" />
-                </ControlTemplate>
-            </Setter>
-        </Style>
-
         <Style Selector="^:open /template/ LayoutTransformControl#PART_LayoutTransform">
             <Style.Animations>
                 <Animation Easing="{StaticResource MenuEasing}"
@@ -152,12 +142,9 @@
         </Style>
 
         <Style Selector="^:separator">
-            <Setter Property="Height" Value="NaN" />
             <Setter Property="Template">
                 <ControlTemplate>
-                    <Separator Height="1"
-                               Margin="0,0"
-                               Background="{DynamicResource SukiLightBorderBrush}" />
+                    <Separator Margin="0"/>
                 </ControlTemplate>
             </Setter>
         </Style>

--- a/SukiUI/Theme/Separator.axaml
+++ b/SukiUI/Theme/Separator.axaml
@@ -1,0 +1,36 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <ControlTheme x:Key="SukiSeparatorStyle" TargetType="Separator">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="CornerRadius" Value="0" />
+        <Setter Property="Foreground" Value="{DynamicResource SukiLightBorderBrush}" />
+        <Setter Property="MinHeight" Value="1" />
+        <Setter Property="Height" Value="1" />
+        <Setter Property="Margin" Value="0" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Border Name="PART_RootBorder"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderThickness}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        CornerRadius="{TemplateBinding CornerRadius}">
+                    <Rectangle Name="PART_Content" Fill="{TemplateBinding Foreground}" />
+                </Border>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^ /template/ Border#PART_RootBorder">
+            <Setter Property="ClipToBounds" Value="True" />
+        </Style>
+
+        <Style Selector="^ /template/ Rectangle#PART_Content">
+            <Setter Property="Height" Value="1" />
+            <Setter Property="HorizontalAlignment" Value="Stretch" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
+    </ControlTheme>
+    <ControlTheme x:Key="{x:Type Separator}" TargetType="Separator"
+                  BasedOn="{StaticResource SukiSeparatorStyle}" />
+</ResourceDictionary>


### PR DESCRIPTION
### Changes
- Added a dedicated `Separator` style, we only use it in menus, but if people want to use `Separator` elsewhere it should now work nicely out of the box.
- Added a demo of `TrayIcon` and `NativeMenu` 
- Fixed `MenuFlyoutPresenter` so that it uses the gradient background, this means `NativeMenu` looks right on Windows.
- Tested Chinese text in `NativeMenu` and - on WIndows at least - it doesn't seem to be blurry. This _should_ close #159 

### Outstanding Issues
- I've only been able to test NativeMenu and the TrayIcon on Windows 11, I assume it'd be equally fine on Windows 10 but Linux/MacOS I have no idea. My assumption is that the _root_ menu would possibly be rendered differently if the OS is asked to render it in those cases.