### PR TITLE
Implement software rendering fallback.

### DIFF
--- a/SukiUI.Demo/Controls/LoadingTest.cs
+++ b/SukiUI.Demo/Controls/LoadingTest.cs
@@ -63,6 +63,11 @@ namespace SukiUI.Demo.Controls
                 }
                 canvas.Restore();
             }
+
+            protected override void RenderSoftware(SKCanvas canvas, SKRect rect)
+            {
+                throw new System.NotImplementedException();
+            }
         }
     }
 

--- a/SukiUI.Demo/Features/Effects/ShaderToyRenderer.cs
+++ b/SukiUI.Demo/Features/Effects/ShaderToyRenderer.cs
@@ -50,6 +50,11 @@ namespace SukiUI.Demo.Features.Effects
                 }
                 canvas.Restore();
             }
+
+            protected override void RenderSoftware(SKCanvas canvas, SKRect rect)
+            {
+                throw new System.NotImplementedException();
+            }
         }
     }
 }

--- a/SukiUI.Demo/SukiUIDemoViewModel.cs
+++ b/SukiUI.Demo/SukiUIDemoViewModel.cs
@@ -133,6 +133,7 @@ public partial class SukiUIDemoViewModel : ObservableObject
     [RelayCommand]
     private void ToggleTitleBar()
     {
+        TitleBarVisible = !TitleBarVisible;
         ToastManager.CreateSimpleInfoToast()
             .WithTitle($"Title Bar {(TitleBarVisible ? "Visible" : "Hidden")}")
             .WithContent($"Window title bar has been {(TitleBarVisible ? "shown" : "hidden")}.")

--- a/SukiUI/Controls/SukiBackground.cs
+++ b/SukiUI/Controls/SukiBackground.cs
@@ -88,6 +88,14 @@ namespace SukiUI.Controls
             get => GetValue(TransitionTimeProperty);
             set => SetValue(TransitionTimeProperty, value);
         }
+
+        public static readonly StyledProperty<bool> ForceSoftwareRenderingProperty = AvaloniaProperty.Register<SukiBackground, bool>(nameof(ForceSoftwareRendering));
+
+        public bool ForceSoftwareRendering
+        {
+            get => GetValue(ForceSoftwareRenderingProperty);
+            set => SetValue(ForceSoftwareRenderingProperty, value);
+        }
         
         private readonly EffectBackgroundDraw _draw;
         private readonly IDisposable _observables;
@@ -96,9 +104,13 @@ namespace SukiUI.Controls
         {
             IsHitTestVisible = false;
             _draw = new EffectBackgroundDraw(new Rect(0, 0, Bounds.Width, Bounds.Height));
+            var forceSwRenderingObs = this.GetObservable(ForceSoftwareRenderingProperty)
+                .Do(enabled => _draw.ForceSoftwareRendering = enabled)
+                .Select(_ => Unit.Default);
             var transEnabledObs = this.GetObservable(TransitionsEnabledProperty)
                 .Do(enabled => _draw.TransitionsEnabled = enabled)
-                .Select(_ => Unit.Default);
+                .Select(_ => Unit.Default)
+                .Merge(forceSwRenderingObs);
             var transTime = this.GetObservable(TransitionTimeProperty)
                 .Do(time => _draw.TransitionTime = time)
                 .Select(_ => Unit.Default)

--- a/SukiUI/Controls/SukiWindow.axaml
+++ b/SukiUI/Controls/SukiWindow.axaml
@@ -37,7 +37,7 @@
                                                  Style="{TemplateBinding BackgroundStyle}"
                                                  TransitionTime="{TemplateBinding BackgroundTransitionTime}"
                                                  TransitionsEnabled="{TemplateBinding BackgroundTransitionsEnabled}" 
-                                                 ForceSoftwareRendering="True"/>
+                                                 ForceSoftwareRendering="{TemplateBinding BackgroundForceSoftwareRendering}"/>
                             <Panel Background="White"
                                    IsVisible="{DynamicResource IsLight}"
                                    Opacity="0.1" />

--- a/SukiUI/Controls/SukiWindow.axaml
+++ b/SukiUI/Controls/SukiWindow.axaml
@@ -36,7 +36,8 @@
                                                  ShaderFile="{TemplateBinding BackgroundShaderFile}"
                                                  Style="{TemplateBinding BackgroundStyle}"
                                                  TransitionTime="{TemplateBinding BackgroundTransitionTime}"
-                                                 TransitionsEnabled="{TemplateBinding BackgroundTransitionsEnabled}" />
+                                                 TransitionsEnabled="{TemplateBinding BackgroundTransitionsEnabled}" 
+                                                 ForceSoftwareRendering="True"/>
                             <Panel Background="White"
                                    IsVisible="{DynamicResource IsLight}"
                                    Opacity="0.1" />

--- a/SukiUI/Controls/SukiWindow.axaml.cs
+++ b/SukiUI/Controls/SukiWindow.axaml.cs
@@ -175,6 +175,18 @@ public class SukiWindow : Window
         AvaloniaProperty.Register<SukiWindow, Avalonia.Controls.Controls>(nameof(RightWindowTitleBarControls), 
             defaultValue: new Avalonia.Controls.Controls());
 
+    public static readonly StyledProperty<bool> BackgroundForceSoftwareRenderingProperty = AvaloniaProperty.Register<SukiWindow, bool>(nameof(BackgroundForceSoftwareRendering));
+    
+    /// <summary>
+    /// Forces the background of the window to utilise software rendering.
+    /// This prevents use of any advanced effects or animations and provides only a flat background colour that changes with the theme.
+    /// </summary>
+    public bool BackgroundForceSoftwareRendering
+    {
+        get => GetValue(BackgroundForceSoftwareRenderingProperty);
+        set => SetValue(BackgroundForceSoftwareRenderingProperty, value);
+    }
+
     /// <summary>
     /// Controls that are displayed on the right side of the title bar,
     /// to the left of the normal window control buttons. (Displays provided controls right-to-left)

--- a/SukiUI/Utilities/Effects/EffectBackgroundDraw.cs
+++ b/SukiUI/Utilities/Effects/EffectBackgroundDraw.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Diagnostics;
 using Avalonia;
+using Avalonia.Skia;
+using Avalonia.Styling;
 using SkiaSharp;
 
 namespace SukiUI.Utilities.Effects
@@ -59,6 +61,14 @@ namespace SukiUI.Utilities.Effects
                 else
                     _oldEffect = null;
             }
+        }
+
+        protected override void RenderSoftware(SKCanvas canvas, SKRect rect)
+        {
+            if (ActiveVariant == ThemeVariant.Dark)
+                canvas.Clear(ActiveTheme.Background.ToSKColor());
+            else
+                canvas.Clear(new SKColorF(0.95f, 0.95f, 0.95f, 1f));
         }
 
         private static double InverseLerp(double start, double end, double value) =>

--- a/SukiUI/Utilities/Effects/EffectDrawBase.cs
+++ b/SukiUI/Utilities/Effects/EffectDrawBase.cs
@@ -7,6 +7,7 @@ using Avalonia.Rendering.SceneGraph;
 using Avalonia.Skia;
 using Avalonia.Styling;
 using SkiaSharp;
+using SukiUI.Models;
 
 namespace SukiUI.Utilities.Effects
 {
@@ -39,10 +40,14 @@ namespace SukiUI.Utilities.Effects
                 _animationEnabled = value;
             }
         }
+        
+        public bool ForceSoftwareRendering { get; set; }
 
         protected float AnimationSpeedScale { get; set; } = 0.1f;
         
         protected ThemeVariant ActiveVariant { get; private set; }
+        
+        protected SukiColorTheme ActiveTheme { get; private set; }
         
         protected float AnimationSeconds => (float)_animationTick.Elapsed.TotalSeconds;
         
@@ -53,7 +58,10 @@ namespace SukiUI.Utilities.Effects
             Bounds = bounds;
             var sTheme = SukiTheme.GetInstance();
             sTheme.OnBaseThemeChanged += v => ActiveVariant = v;
-            ActiveVariant = SukiTheme.GetInstance().ActiveBaseTheme;
+            ActiveVariant = sTheme.ActiveBaseTheme;
+            sTheme.OnColorThemeChanged += t => ActiveTheme = t;
+            ActiveTheme = sTheme.ActiveColorTheme!;
+            
         }
 
         public void Render(ImmediateDrawingContext context)
@@ -61,10 +69,22 @@ namespace SukiUI.Utilities.Effects
             var leaseFeature = context.TryGetFeature<ISkiaSharpApiLeaseFeature>();
             if (leaseFeature is null) throw new InvalidOperationException("Unable to lease Skia API");
             using var lease = leaseFeature.Lease();
-            Render(lease.SkCanvas, SKRect.Create((float)Bounds.Width, (float)Bounds.Height));
+            var rect = SKRect.Create((float)Bounds.Width, (float)Bounds.Height);
+            if(lease.GrContext is null || ForceSoftwareRendering) // GrContext is null whenever
+                RenderSoftware(lease.SkCanvas, rect);
+            else
+                Render(lease.SkCanvas, rect);
         }
 
+        /// <summary>
+        /// Called every frame to render content.
+        /// </summary>
         protected abstract void Render(SKCanvas canvas, SKRect rect);
+        
+        /// <summary>
+        /// Called every frame whenever the app falls back to software rendering (or <see cref="ForceSoftwareRendering"/> is enabled)
+        /// </summary>
+        protected abstract void RenderSoftware(SKCanvas canvas, SKRect rect);
 
         protected SKShader? EffectWithUniforms(float alpha = 1f) => 
             EffectWithUniforms(Effect, alpha);


### PR DESCRIPTION
### Changes
- Implemented a software rendering fallback for the background renderer.
  - Simply uses the "flat" background style colouring as it's nice and performant.
  - Should allow `SukiWindow` to not only be previewable in an IDE but should also let us run on Avalonia web in the future if that's desirable and things like VMs which don't have any hardware acceleration enabled.
  - Fixes: #288 
- Fixed a minor bug in the demo which prevented the title bar from toggling properly.

I've created an API for `SukiBackground` which allows you to force software rendering manually, however I've not exposed this through `SukiWindow` yet, if you think it's a good idea and might be useful I'm happy to add that before merging.