### PR TITLE
Remove dependency on ReactiveUI

### DIFF
--- a/SukiUI/Controls/Hosts/SukiToastHost.cs
+++ b/SukiUI/Controls/Hosts/SukiToastHost.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Linq;
-using System.Reactive;
-using System.Reactive.Linq;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
@@ -41,20 +38,22 @@ namespace SukiUI.Controls
             set => SetValue(PositionProperty, value);
         }
 
-        private IDisposable? _subscriptions;
-        
         protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
         {
             base.OnApplyTemplate(e);
-            _subscriptions = this.GetObservable(PositionProperty)
-                .Do(OnPositionChanged)
-                .Select(_ => Unit.Default).ObserveOn(new AvaloniaSynchronizationContext())
-                .Subscribe();
+            OnPositionChanged(Position);
         }
 
-        private void OnPositionChanged(ToastLocation obj)
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
         {
-            HorizontalAlignment = Position switch
+            base.OnPropertyChanged(change);
+            if (change.Property == PositionProperty && change.NewValue is ToastLocation loc) 
+                OnPositionChanged(loc);
+        }
+
+        private void OnPositionChanged(ToastLocation newLoc)
+        {
+            HorizontalAlignment = newLoc switch
             {
                 ToastLocation.BottomRight => HorizontalAlignment.Right,
                 ToastLocation.BottomLeft => HorizontalAlignment.Left,
@@ -62,7 +61,7 @@ namespace SukiUI.Controls
                 ToastLocation.TopLeft => HorizontalAlignment.Left,
                 _ => throw new ArgumentOutOfRangeException()
             };
-            VerticalAlignment = Position switch
+            VerticalAlignment = newLoc switch
             {
                 ToastLocation.BottomRight => VerticalAlignment.Bottom,
                 ToastLocation.BottomLeft => VerticalAlignment.Bottom,
@@ -70,12 +69,6 @@ namespace SukiUI.Controls
                 ToastLocation.TopLeft => VerticalAlignment.Top,
                 _ => throw new ArgumentOutOfRangeException()
             };
-        }
-
-        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
-        {
-            base.OnDetachedFromVisualTree(e);
-            _subscriptions?.Dispose();
         }
         
         private static void OnManagerPropertyChanged(AvaloniaObject sender,

--- a/SukiUI/Controls/PropertyGrid/PropertyGrid.axaml.cs
+++ b/SukiUI/Controls/PropertyGrid/PropertyGrid.axaml.cs
@@ -2,17 +2,16 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
-using System;
 using System.ComponentModel;
-using System.Reactive.Linq;
 
+// ReSharper disable once CheckNamespace
 namespace SukiUI.Controls
 {
     public partial class PropertyGrid : UserControl
     {
         static PropertyGrid()
         {
-            ItemProperty.Changed.Subscribe(OnItemChanged);
+            ItemProperty.Changed.AddClassHandler<PropertyGrid>((_, args) => OnItemChanged(args));
         }
 
         public PropertyGrid()
@@ -40,8 +39,8 @@ namespace SukiUI.Controls
             get { return GetValue(InstanceProperty); }
             set { SetValue(InstanceProperty, value); }
         }
-
-        private static void OnItemChanged(AvaloniaPropertyChangedEventArgs e)
+        
+        private static void OnItemChanged( AvaloniaPropertyChangedEventArgs e)
         {
             if (e.Sender is PropertyGrid propertyGrid)
             {

--- a/SukiUI/Controls/SettingsLayout.axaml.cs
+++ b/SukiUI/Controls/SettingsLayout.axaml.cs
@@ -8,14 +8,12 @@ using Avalonia.Data;
 using Avalonia.LogicalTree;
 using Avalonia.Markup.Xaml;
 using Avalonia.Styling;
-using DynamicData;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Avalonia.Layout;
 
 namespace SukiUI.Controls;
 
@@ -30,11 +28,6 @@ public partial class SettingsLayout : UserControl
     public SettingsLayout()
     {
         InitializeComponent();
-    }
-
-    protected override void OnAttachedToLogicalTree(LogicalTreeAttachmentEventArgs e)
-    {
-        base.OnAttachedToLogicalTree(e);
     }
 
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
@@ -55,11 +48,10 @@ public partial class SettingsLayout : UserControl
     private ObservableCollection<SettingsLayoutItem> _items;
 
     public static readonly DirectProperty<SettingsLayout, ObservableCollection<SettingsLayoutItem>> StepsProperty =
-        AvaloniaProperty.RegisterDirect<SettingsLayout, ObservableCollection<SettingsLayoutItem>>(nameof(Items), l => l.Items,
-            (numpicker, v) =>
-            {
-                numpicker.Items = v;
-            }, defaultBindingMode: BindingMode.TwoWay, enableDataValidation: true);
+        AvaloniaProperty.RegisterDirect<SettingsLayout, ObservableCollection<SettingsLayoutItem>>(nameof(Items),
+            l => l.Items,
+            (numpicker, v) => { numpicker.Items = v; }, defaultBindingMode: BindingMode.TwoWay,
+            enableDataValidation: true);
 
     public ObservableCollection<SettingsLayoutItem> Items
     {
@@ -110,7 +102,7 @@ public partial class SettingsLayout : UserControl
             var summaryButton = new RadioButton()
             {
                 Content = new TextBlock() { Text = settingsLayoutItem.Header, FontSize = 17 },
-                Classes = { new string[] { "MenuChip" } }
+                Classes = {  "MenuChip" }
             };
             summaryButton.Click += async (sender, args) =>
             {
@@ -119,7 +111,7 @@ public partial class SettingsLayout : UserControl
                 var x = border.TranslatePoint(new Point(), stackItems);
 
                 if (x.HasValue)
-                    await AnimateScroll(x.Value.Y);  // myScroll.Offset = new Vector(0, x.Value.Y);
+                    await AnimateScroll(x.Value.Y); // myScroll.Offset = new Vector(0, x.Value.Y);
             };
             radios.Add(summaryButton);
             stackSummary.Children.Add(summaryButton);
@@ -139,34 +131,27 @@ public partial class SettingsLayout : UserControl
         };
     }
 
-    private  Mutex mut = new Mutex();
+    private Mutex mut = new Mutex();
 
     private double LastDesiredSize = -1;
-    
+
     private async void DockPanel_SizeChanged(object sender, SizeChangedEventArgs e)
     {
-        
         var stack = this.GetTemplateChildren().First(n => n.Name == "StackSummary");
         var desiredSize = e.NewSize.Width > 1100 ? 400 : 0;
-        
-        if(LastDesiredSize == desiredSize)
+
+        if (LastDesiredSize == desiredSize)
             return;
 
         LastDesiredSize = desiredSize;
 
-        if (stack.Width != desiredSize && (stack.Width == 0 || stack.Width == 400)) 
+        if (stack.Width != desiredSize && (stack.Width == 0 || stack.Width == 400))
             stack.Animate<double>(WidthProperty, stack.Width, desiredSize, TimeSpan.FromMilliseconds(800));
-        
-       
     }
 
     private bool isAnimatingWidth = false;
     private bool isAnimatingMargin = false;
     private bool isAnimatingScroll = false;
-
-
-
-   
 
     private async Task AnimateScroll(double desiredScroll)
     {
@@ -189,7 +174,14 @@ public partial class SettingsLayout : UserControl
                 },
                 new KeyFrame()
                 {
-                    Setters = { new Setter { Property = ScrollViewer.OffsetProperty, Value = new Vector(myscroll.Offset.X, desiredScroll -30) } },
+                    Setters =
+                    {
+                        new Setter
+                        {
+                            Property = ScrollViewer.OffsetProperty,
+                            Value = new Vector(myscroll.Offset.X, desiredScroll - 30)
+                        }
+                    },
                     KeyTime = TimeSpan.FromMilliseconds(800)
                 }
             }
@@ -203,6 +195,4 @@ public partial class SettingsLayout : UserControl
 
         await Task.WhenAll(animationTask, abortTask);
     }
-
-   
 }

--- a/SukiUI/Controls/Stepper.axaml.cs
+++ b/SukiUI/Controls/Stepper.axaml.cs
@@ -3,8 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
-using System.Reactive;
-using System.Reactive.Linq;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
@@ -48,7 +46,6 @@ namespace SukiUI.Controls
         }
 
         private Grid? _grid;
-        private IDisposable? _subscriptionDisposables;
 
         protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
         {
@@ -59,19 +56,14 @@ namespace SukiUI.Controls
             }
 
             _grid = grid;
+            StepsChangedHandler(Steps);
         }
 
-        protected override void OnLoaded(RoutedEventArgs e)
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
         {
-            var indexObs = this.GetObservable(IndexProperty)
-                .Do(_ => StepsChangedHandler(Steps))
-                .Select(_ => Unit.Default);
-            _subscriptionDisposables = this.GetObservable(StepsProperty)
-                .Do(_ => StepsChangedHandler(Steps))
-                .Select(_ => Unit.Default)
-                .Merge(indexObs)
-                .ObserveOn(new AvaloniaSynchronizationContext())
-                .Subscribe();
+            base.OnPropertyChanged(change);
+            if (change.Property == IndexProperty || change.Property == StepsProperty) 
+                StepsChangedHandler(Steps);
         }
 
         private void StepsChangedHandler(IEnumerable? newSteps)
@@ -215,12 +207,6 @@ namespace SukiUI.Controls
             Grid.SetColumn(griditem, index);
 
             grid.Children.Add(griditem);
-        }
-
-        protected override void OnUnloaded(RoutedEventArgs e)
-        {
-            base.OnUnloaded(e);
-            _subscriptionDisposables?.Dispose();
         }
 
         #endregion

--- a/SukiUI/Controls/SukiSideMenuSearchService.cs
+++ b/SukiUI/Controls/SukiSideMenuSearchService.cs
@@ -2,16 +2,12 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
-using Avalonia.Data;
 using Avalonia.Data.Converters;
-using ReactiveUI;
-
-
-
 
 namespace SukiUI.Controls
 {
     // sirdoombox will kill me because of this
+    // this is quite disgusting but if it works it works... -Doom
     internal class SukiSideMenuService : INotifyPropertyChanged
     {
         

--- a/SukiUI/Controls/SukiTransitioningContentControl.axaml.cs
+++ b/SukiUI/Controls/SukiTransitioningContentControl.axaml.cs
@@ -1,13 +1,10 @@
 using System;
-using System.Reactive.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Animation;
 using Avalonia.Controls;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
-using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Styling;
 using Avalonia.Threading;
@@ -49,8 +46,6 @@ namespace SukiUI.Controls
 
         private ContentPresenter _firstBuffer = null!;
         private ContentPresenter _secondBuffer = null!;
-
-        private IDisposable? _disposable;
 
         private static readonly Animation FadeIn;
         private static readonly Animation FadeOut;
@@ -129,14 +124,11 @@ namespace SukiUI.Controls
 
         private CancellationTokenSource _animCancellationToken = new();
 
-        private IDisposable? _contentDisposable;
-
-        protected override void OnLoaded(RoutedEventArgs e)
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
         {
-            base.OnLoaded(e);
-            _contentDisposable = this.GetObservable(ContentProperty)
-                .ObserveOn(new AvaloniaSynchronizationContext())
-                .Subscribe(PushContent);
+            base.OnPropertyChanged(change);
+            if(change.Property == ContentProperty)
+                PushContent(change.NewValue);
         }
 
         protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
@@ -179,8 +171,6 @@ namespace SukiUI.Controls
         protected override void OnUnloaded(RoutedEventArgs e)
         {
             base.OnUnloaded(e);
-            _disposable?.Dispose();
-            _contentDisposable?.Dispose();
             _animCancellationToken.Dispose();
         }
     }

--- a/SukiUI/SukiUI.csproj
+++ b/SukiUI/SukiUI.csproj
@@ -33,7 +33,6 @@
 		<PackageReference Include="SkiaSharp" Version="2.88.8" />
 		<PackageReference Include="Avalonia.Controls.DataGrid" Version="11.2.0-beta1" />
 		<PackageReference Include="Avalonia.Themes.Simple" Version="11.2.0-beta1" />
-		<PackageReference Include="ReactiveUI" Version="20.1.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/SukiUI/Theme/Index.axaml.cs
+++ b/SukiUI/Theme/Index.axaml.cs
@@ -4,8 +4,6 @@ using Avalonia.Data;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media;
 using Avalonia.Styling;
-using DynamicData;
-using SukiUI.Controls;
 using SukiUI.Enums;
 using SukiUI.Extensions;
 using SukiUI.Models;
@@ -97,7 +95,13 @@ public partial class SukiTheme : Styles
     /// </summary>
     public void SwitchColorTheme()
     {
-        var index = ColorThemes.IndexOf(ActiveColorTheme);
+        var index = -1;
+        for (var i = 0; i < ColorThemes.Count; i++)
+        {
+            if (ColorThemes[i] != ActiveColorTheme) continue;
+            index = i;
+            break;
+        }
         if (index == -1) return;
         var newIndex = (index + 1) % ColorThemes.Count;
         var newColorTheme = ColorThemes[newIndex];
@@ -203,7 +207,6 @@ public partial class SukiTheme : Styles
             new DefaultSukiColorTheme(SukiColor.Red, Color.Parse("#D03A2F"), Color.Parse("#2FC5D0")),
             new DefaultSukiColorTheme(SukiColor.Green, Color.Parse("#537834"), Color.Parse("#B24DB0")),
             new DefaultSukiColorTheme(SukiColor.Blue, Color.Parse("#0A59F7"), Color.Parse("#F7A80A")),
- 
         };
         DefaultColorThemes = defaultThemes.ToDictionary(x => x.ThemeColor, y => (SukiColorTheme)y);
     }

--- a/docs/docs/documentation/getting-started/launch.md
+++ b/docs/docs/documentation/getting-started/launch.md
@@ -15,6 +15,10 @@ Include SukiUI styles in your `App.axaml`
 </Application>
 ```
 
+::: warning
+If a default `ThemeColor` is not set and you do not set the theme by any other means, your window and many controls will be completely transparent.
+:::
+
 ## Use SukiWindow as MainWindow
 
 Change MainWindow from Window class to SukiWindow class.

--- a/docs/docs/documentation/hosts/dialog.md
+++ b/docs/docs/documentation/hosts/dialog.md
@@ -3,3 +3,113 @@
 SukiUI provides a [host](./hosts) which can display dialogs easily at any level of your application. As standard we recommend simply using it in `SukiWindow.Hosts` as this provides the best experience, however dialogs can be localised within whatever context you require.
 
 The host is designed in such a way as to be MVVM friendly and as long as you have access to the `ISukiDialogManager` instance used for a given `SukiDialogHost` you can display dialogs in it.
+
+Here is a simple example setup using MVVM:
+
+### View
+```xml
+<!-- XMLNS definitions omitted for brevity -->
+<suki:SukiWindow>
+	<suki:SukiWindow.Hosts>
+		<suki:SukiDialogHost Manager="{Binding DialogManager}"/>
+	</suki:SukiWindow.Hosts>
+<suki:SukiWindow>
+```
+
+### ViewModel
+```cs
+public class ExampleViewModel
+{
+	public ISukiDialogManager DialogManager { get; } = new SukiDialogManager();
+}
+```
+---
+
+If you do not wish to use MVVM, or would rather a simpler solution that "just works", then you can choose to implement it like this:
+
+### AXAML
+```xml
+<!-- XMLNS definitions omitted for brevity -->
+<suki:SukiWindow>
+	<suki:SukiWindow.Hosts>
+		<suki:SukiDialogHost Name="DialogHost"/>
+	</suki:SukiWindow.Hosts>
+<suki:SukiWindow>
+```
+### Code-Behind
+```cs
+public class MainWindow : SukiWindow
+{
+	public static ISukiDialogManager DialogManager = new SukiDialogManager();
+
+	public MainWindow()
+	{
+		InitializeComponent();
+		DialogHost.Manager = DialogManager;
+	}
+}
+```
+
+### Usage
+
+```cs
+MainWindow.DialogManager.CreateDialog()
+	.TryShow();
+```
+
+## Displaying Dialogs
+
+In order to construct and therefore display dialogs, a fluent style builder is provided that makes constructing dialogs simple. To begin constructing a dialog, it's recommended to call the extension method `.CreateDialog()` on the `ISukiDialogManager` instance you want it to be displayed in.
+
+From here method calls can be chained to construct the dialog as desired, most of these are self explanatory and have associated XMLDocs for convenience.
+
+Finally to display a dialog the `.TryShow()` method can be called to attempt to show the dialog if none is currently shown.
+
+Here is a simple example, expanding on the `ViewModel` above:
+
+```cs
+public void DisplayDialog()
+{
+	DialogManager.CreateDialog()
+		.WithTitle("Example Dialog")
+		.WithContent("The content of an example dialog can be seen here.")
+		.TryShow();
+}
+```
+
+## Dismissing Dialogs
+
+By default, dialogs have no mechanism to be dismissed. In order to add dismissal mechanisms to a dialog it's necessary to use the `.Dismiss()` method, at which point you can provide a method by which the dialogs can be dismissed. Currently the only standalone dismissal is `.ByClickingBackground()` which will dismiss the dialog when the user clicks outside of it.
+
+Here is an example of an empty dialog which will be dismissed when the background is clicked.
+
+```cs
+public void DisplayDialog()
+{
+	DialogManager.CreateDialog()
+            .Dismiss().ByClickingBackground()
+            .TryShow();
+}
+```
+
+The other method of dismissing dialogs involves the use of action buttons, discussed in the next section.
+
+## Interactions
+
+Dialogs can be interacted with simply by including a call to `.WithActionButton()`, this can be supplied with some content for the button, an on-clicked callback and optionally the `dismissOnClick` parameter can be set to `true` if you want the dialog to close immediately on clicking that specific button. Any number of `.WithActionButton()` calls can be included in the chain to add any number of buttons.
+
+Here is an example of a dialog with two buttons, one of which will dismiss the dialog.
+
+```cs
+public void DisplayDialog()
+{
+    dialogManager.CreateDialog()
+        .WithActionButton("Don't Close", _ => { })
+        .WithActionButton("Close ", _ => { }, true) // last parameter optional
+        .TryShow();
+}
+```
+
+## MessageBox Style
+
+It is possible to use the `.OfType()` method to cause the dialog to use an included MessageBox style, the styles included are: Information, Success, Warning and Error. 


### PR DESCRIPTION
### Changes
- Removed dependency on ReactiveUI
  - A lot of our styled property changes relied on this library, but it is no longer the default in every Avalonia app and would require developers to install the correct version of ReactiveUI manually to prevent runtime errors when referencing the library directly. Of course the dependency would be included if installed via nuget but I still think dropping a mostly useless dependency is worthwhile.
  - This is actually a fairly major change internally in terms of behaviour, I did my best to thoroughly test every control I touched and everything seems solid but I think a second pair of eyes quickly checking is necessary to make sure I didn't miss something obvious.

### Docs
- Updated DIalogs documentation page to include all the basics.
- Added a warning to the launch page regarding not setting a `ThemeColor` as this can cause no default colours to be set which results in a transparent window and transparent controls. 
  - This is technically speaking a bug, it should be possible for the default colour to be used. However there is no clean mechanism for just falling back to a default colour without possibly setting it twice and causing a complete repaint of the visual tree. I think it's better to just inform people that they have to set the theme by some mechanism.