### PR TITLE
Fix #302 (At least partially)

### DIFF
--- a/SukiUI.Demo/Features/ControlsLibrary/CardsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/CardsView.axaml
@@ -36,12 +36,10 @@
                     <DockPanel Margin="0,12,0,0">
                         <TextBlock DockPanel.Dock="Left" FontWeight="DemiBold" VerticalAlignment="Center" Text="Is Opaque :" />
                         <ToggleSwitch Margin="8,0,0,0"  IsChecked="{Binding IsOpaque}" />
-                       
                     </DockPanel>
                     <DockPanel>
                         <TextBlock DockPanel.Dock="Left" FontWeight="DemiBold" VerticalAlignment="Center" Text="Is Interactive :" />
                         <ToggleSwitch Margin="8,0,0,0" IsChecked="{Binding IsInteractive}" />
-                     
                     </DockPanel>
                 </StackPanel>
             </suki:GroupBox>
@@ -66,23 +64,19 @@
                 </suki:GlassCard>
                 <suki:GlassCard>
                     <suki:GlassCard.Resources>
-                        <system:Double x:Key="GlassOpacity">0.2</system:Double>
+                        <system:Double x:Key="GlassOpacity">0.5</system:Double>
                     </suki:GlassCard.Resources>
                     <suki:GroupBox Header="Overriden Opacity">
-                        <TextBlock Classes="h4">This card's resources sets the double resource of "GlassOpacity" to 0.2</TextBlock>
+                        <TextBlock Classes="h4">This card's resources sets the double resource of "GlassOpacity" to 0.5</TextBlock>
                     </suki:GroupBox>
                 </suki:GlassCard>
-               
             </WrapPanel>
-                
                 <Border Background="{DynamicResource SukiControlBorderBrush}" Height="1" Margin="30,30"></Border>
                 <TextBlock TextWrapping="Wrap" HorizontalAlignment="Left" Margin="30,0,30,30" FontWeight="DemiBold" Text="GlassCard are animated with CompositionAnimations by the property IsAnimated set to 'True' by default. Opacity changes and Size changes of the GlassCard are automatically animated. See below the differences by adding an item."></TextBlock>
-                
                 <StackPanel Spacing="12" Margin="30,10" Orientation="Horizontal">
                     <Button Classes="Flat" Content="Add Item" Command="{Binding AddItemCommand}"></Button>
                     <Button  Content="Remove Item" Command="{Binding RemoveItemCommand}"></Button>
                 </StackPanel>
-                
                 <Grid ColumnDefinitions="*,*" Margin="15">
                     <suki:GlassCard HorizontalAlignment="Left" IsAnimated="False" Margin="15">
                         <StackPanel Spacing="35">
@@ -103,7 +97,6 @@
                             </ItemsControl>
                         </StackPanel>
                     </suki:GlassCard>
-                    
                     <suki:GlassCard Grid.Column="1" HorizontalAlignment="Left"  Margin="15">
                         <StackPanel Spacing="35">
                             <TextBlock FontWeight="DemiBold" FontSize="17" Text="Animated"></TextBlock>

--- a/SukiUI/Controls/GlassMorphism/GlassCard.axaml
+++ b/SukiUI/Controls/GlassMorphism/GlassCard.axaml
@@ -7,7 +7,6 @@
         <Setter Property="Padding" Value="20" />
         <Setter Property="Template">
             <ControlTemplate>
-            
                 <Panel Name="RootPanel" Opacity="0">
                     <Border Name="PART_BorderCard" RenderTransformOrigin="50%,50%"
                             Background="{TemplateBinding Background}"
@@ -16,28 +15,24 @@
                             ClipToBounds="{TemplateBinding ClipToBounds}"
                             CornerRadius="{TemplateBinding CornerRadius}"
                             Opacity="{DynamicResource GlassOpacity}">
-                        
                         <Border.Transitions>
                             <Transitions>
                                 <DoubleTransition Property="Width"
-                                                             Duration="0:0:0.5"
-                                                             Easing="QuadraticEaseOut"/>
+                                                  Duration="0:0:0.5"
+                                                  Easing="QuadraticEaseOut" />
                                 <DoubleTransition Property="Height"
-                                                             Duration="0:0:0.5"
-                                                             Easing="QuadraticEaseOut"/>
+                                                  Duration="0:0:0.5"
+                                                  Easing="QuadraticEaseOut" />
                             </Transitions>
                         </Border.Transitions>
-                        
                         <Border.Transitions>
                             <Transitions>
-                                <BrushTransition Property="Background" Duration="0:0:0.15" />
+                                <!-- <BrushTransition Property="Background" Duration="0:0:0.15" /> -->
                                 <BrushTransition Property="BorderBrush" Duration="0:0:0.15" />
                                 <DoubleTransition Property="Opacity" Duration="0:0:0.15" />
                             </Transitions>
                         </Border.Transitions>
                     </Border>
-               
-         
                     <Border Name="PART_ClipBorder"
                             Background="{DynamicResource SukiPrimaryColor0}"
                             BorderBrush="{DynamicResource SukiPrimaryColor0}"
@@ -49,18 +44,16 @@
                                 <BrushTransition Property="BorderBrush" Duration="0:0:0.15" />
                             </Transitions>
                         </Border.Transitions>
-                        <ContentPresenter Name="PART_CP" Margin="{TemplateBinding Padding}" Content="{TemplateBinding Content}" />
+                        <ContentPresenter Name="PART_CP" Margin="{TemplateBinding Padding}"
+                                          Content="{TemplateBinding Content}" />
                     </Border>
                 </Panel>
             </ControlTemplate>
         </Setter>
-        
-        
         <Style Selector="^.Control">
             <Setter Property="IsAnimated" Value="False"></Setter>
             <Setter Property="Padding" Value="0"></Setter>
         </Style>
-        
         <Style Selector="^.Discrete">
             <Setter Property="BorderBrush" Value="{DynamicResource SukiControlBorderBrush}" />
             <Setter Property="Padding" Value="0"></Setter>
@@ -69,14 +62,10 @@
             <Setter Property="Background" Value="{DynamicResource ControlSukiGlassCardBackground}" />
             <Setter Property="Opacity" Value="{DynamicResource ControlGlassOpacity}" />
         </Style>
-        
         <Style Selector="^.Discrete /template/ Border#PART_BorderCard">
             <Setter Property="Background" Value="{DynamicResource SukiGlassCardBackground}" />
             <Setter Property="Opacity" Value="{DynamicResource DiscreteControlGlassOpacity}" />
-            
-
         </Style>
-        
         <Style Selector="^.Primary /template/ Border#PART_ClipBorder">
             <Setter Property="BorderBrush" Value="{DynamicResource SukiAccentColor0}" />
         </Style>
@@ -102,12 +91,10 @@
         <Style Selector="^.Primary /template/ Border#PART_BorderCard">
             <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor25}" />
         </Style>
-        
         <Style Selector="^.PrimaryOpaque /template/ Border#PART_BorderCard">
-            <Setter Property="Opacity" Value="1"/>
+            <Setter Property="Opacity" Value="1" />
             <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor}" />
         </Style>
-        
         <Style Selector="^[IsVisible=True] /template/ Panel#RootPanel">
             <Setter Property="Opacity" Value="1" />
         </Style>


### PR DESCRIPTION
### Changes
- Disables the background brush transition on glass cards which isn't necessary as the effect is driven by opacity anyway. This at least partially fixes #302, though I think there is still a small amount of white flashing when going back from opaque to transparent, but it's significantly less noticeable.