### PR TITLE
Rewrite internals of `EffectDrawBase`

### DIFF
--- a/SukiUI.Demo/Features/Effects/ShaderToyRenderer.cs
+++ b/SukiUI.Demo/Features/Effects/ShaderToyRenderer.cs
@@ -10,6 +10,7 @@ namespace SukiUI.Demo.Features.Effects
     public class ShaderToyRenderer : Control
     {
         private CompositionCustomVisual? _customVisual;
+        private SukiEffect? _sukiEffect;
 
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
         {
@@ -20,6 +21,7 @@ namespace SukiUI.Demo.Features.Effects
             _customVisual = comp.CreateCustomVisual(visualHandler);
             ElementComposition.SetElementChildVisual(this, _customVisual);
             _customVisual.SendHandlerMessage(EffectDrawBase.StartAnimations);
+            if(_sukiEffect != null) _customVisual.SendHandlerMessage(_sukiEffect);
             Update();
         }
         
@@ -31,6 +33,7 @@ namespace SukiUI.Demo.Features.Effects
 
         public void SetEffect(SukiEffect effect)
         {
+            _sukiEffect = effect;
             _customVisual?.SendHandlerMessage(effect);
         }
 

--- a/SukiUI/Controls/SukiBackground.cs
+++ b/SukiUI/Controls/SukiBackground.cs
@@ -106,6 +106,7 @@ namespace SukiUI.Controls
             var visualHandler = new EffectBackgroundDraw();
             _customVisual = comp.CreateCustomVisual(visualHandler);
             ElementComposition.SetElementChildVisual(this, _customVisual);
+            _customVisual.SendHandlerMessage(TransitionTime);
             HandleBackgroundStyleChanges();
             Update();
         }

--- a/SukiUI/Controls/SukiTransitioningContentControl.axaml.cs
+++ b/SukiUI/Controls/SukiTransitioningContentControl.axaml.cs
@@ -176,11 +176,7 @@ namespace SukiUI.Controls
                     });
                 });
                 FadeIn.RunAsync(To, _animCancellationToken.Token).ContinueWith(_ => 
-                    Dispatcher.UIThread.Invoke(() =>
-                    {
-                        Console.WriteLine(To.Name);
-                        return To.IsHitTestVisible = true;
-                    }));
+                    Dispatcher.UIThread.Invoke(() => To.IsHitTestVisible = true));
             }
             catch
             {

--- a/SukiUI/Controls/SukiTransitioningContentControl.axaml.cs
+++ b/SukiUI/Controls/SukiTransitioningContentControl.axaml.cs
@@ -6,6 +6,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
+using Avalonia.Media;
 using Avalonia.Styling;
 using Avalonia.Threading;
 
@@ -44,14 +45,16 @@ namespace SukiUI.Controls
 
         private bool _isFirstBufferActive;
 
-        private ContentPresenter _firstBuffer = null!;
-        private ContentPresenter _secondBuffer = null!;
+        private ContentPresenter? _firstBuffer = null;
+        private ContentPresenter? _secondBuffer = null;
 
         private static readonly Animation FadeIn;
         private static readonly Animation FadeOut;
         
-        private ContentPresenter To => _isFirstBufferActive ? _secondBuffer : _firstBuffer;
-        private ContentPresenter From => _isFirstBufferActive ? _firstBuffer : _secondBuffer;
+        private ContentPresenter? To => _isFirstBufferActive ? _firstBuffer : _secondBuffer;
+        private ContentPresenter? From => _isFirstBufferActive ? _secondBuffer : _firstBuffer;
+
+        private object? _contentBeforeApplied;
 
         static SukiTransitioningContentControl()
         {
@@ -123,6 +126,7 @@ namespace SukiUI.Controls
         }
 
         private CancellationTokenSource _animCancellationToken = new();
+        
 
         protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
         {
@@ -138,34 +142,50 @@ namespace SukiUI.Controls
                 _firstBuffer = fBuff;
             if (e.NameScope.Get<ContentPresenter>("PART_SecondBufferControl") is { } sBuff)
                 _secondBuffer = sBuff;
+            if (_contentBeforeApplied != null)
+            {
+                PushContent(_contentBeforeApplied);
+                _contentBeforeApplied = null;
+            }
         }
 
-        public void PushContent(object? content)
+        private void PushContent(object? content)
         {
-            if (content is null) return;
+            if (To is null || From is null)
+            {
+                _contentBeforeApplied = content;
+                return;
+            }
             
             _animCancellationToken.Cancel();
             _animCancellationToken.Dispose();
             _animCancellationToken = new CancellationTokenSource();
-
-            FirstBuffer = null;
-            SecondBuffer = null;
             
             if (_isFirstBufferActive) SecondBuffer = content;
             else FirstBuffer = content;
+            _isFirstBufferActive = !_isFirstBufferActive;
             try
             {
-                FadeOut.RunAsync(From, _animCancellationToken.Token);
-                FadeIn.RunAsync(To, _animCancellationToken.Token);
+                FadeOut.RunAsync(From, _animCancellationToken.Token).ContinueWith(_ =>
+                {
+                    Dispatcher.UIThread.Invoke(() =>
+                    {
+                        From.IsHitTestVisible = false;
+                        if (_isFirstBufferActive) SecondBuffer = null;
+                        else FirstBuffer = null;
+                    });
+                });
+                FadeIn.RunAsync(To, _animCancellationToken.Token).ContinueWith(_ => 
+                    Dispatcher.UIThread.Invoke(() =>
+                    {
+                        Console.WriteLine(To.Name);
+                        return To.IsHitTestVisible = true;
+                    }));
             }
             catch
             {
                 // ignored
             }
-
-            To.IsHitTestVisible = true;
-            From.IsHitTestVisible = false;
-            _isFirstBufferActive = !_isFirstBufferActive;
         }
 
         protected override void OnUnloaded(RoutedEventArgs e)

--- a/SukiUI/Controls/SukiWindow.axaml.cs
+++ b/SukiUI/Controls/SukiWindow.axaml.cs
@@ -109,6 +109,7 @@ public class SukiWindow : Window
     public static readonly StyledProperty<bool> BackgroundAnimationEnabledProperty =
         AvaloniaProperty.Register<SukiWindow, bool>(nameof(BackgroundAnimationEnabled), defaultValue: false);
 
+    /// <inheritdoc cref="SukiBackground.AnimationEnabled"/>
     public bool BackgroundAnimationEnabled
     {
         get => GetValue(BackgroundAnimationEnabledProperty);

--- a/SukiUI/Utilities/Effects/EffectBackgroundDraw.cs
+++ b/SukiUI/Utilities/Effects/EffectBackgroundDraw.cs
@@ -14,14 +14,17 @@ namespace SukiUI.Utilities.Effects
         internal bool TransitionsEnabled { get; set; }
         internal double TransitionTime { get; set; }
 
-        private static readonly Stopwatch TransitionTick = Stopwatch.StartNew();
-
-        private static float TransitionSeconds => (float)TransitionTick.Elapsed.TotalSeconds;
+        private float TransitionSeconds => (float)CompositionNow.TotalSeconds;
 
         private SukiEffect? _oldEffect;
         private float _transitionStartTime;
         private float _transitionEndTime;
 
+        public EffectBackgroundDraw() : base(true)
+        {
+            
+        }
+        
         protected override void EffectChanged(SukiEffect? oldValue, SukiEffect? newValue)
         {
             if (!TransitionsEnabled) return;

--- a/SukiUI/Utilities/Effects/EffectBackgroundDraw.cs
+++ b/SukiUI/Utilities/Effects/EffectBackgroundDraw.cs
@@ -20,7 +20,7 @@ namespace SukiUI.Utilities.Effects
         private float _transitionStartTime;
         private float _transitionEndTime;
 
-        public EffectBackgroundDraw() : base(true)
+        public EffectBackgroundDraw() : base(false)
         {
             
         }

--- a/SukiUI/Utilities/Effects/EffectBackgroundDraw.cs
+++ b/SukiUI/Utilities/Effects/EffectBackgroundDraw.cs
@@ -9,6 +9,8 @@ namespace SukiUI.Utilities.Effects
 {
     internal class EffectBackgroundDraw : EffectDrawBase
     {
+        public static readonly object EnableTransitions = new(), DisableTransitions = new();
+        
         internal bool TransitionsEnabled { get; set; }
         internal double TransitionTime { get; set; }
 
@@ -20,10 +22,6 @@ namespace SukiUI.Utilities.Effects
         private float _transitionStartTime;
         private float _transitionEndTime;
 
-        public EffectBackgroundDraw(Rect bounds) : base(bounds)
-        {
-        }
-
         protected override void EffectChanged(SukiEffect? oldValue, SukiEffect? newValue)
         {
             if (!TransitionsEnabled) return;
@@ -33,10 +31,15 @@ namespace SukiUI.Utilities.Effects
             _transitionEndTime = TransitionSeconds + (float)Math.Max(0, TransitionTime);
         }
 
+        public override void OnMessage(object message)
+        {
+            base.OnMessage(message);
+            if (message is float time) 
+                TransitionTime = time;
+        }
+
         protected override void Render(SKCanvas canvas, SKRect rect)
         {
-            canvas.Clear(SKColors.Transparent);
-
             if (Effect is not null)
             {
                 using var paint = new SKPaint();
@@ -46,7 +49,6 @@ namespace SukiUI.Utilities.Effects
             }
             if (_oldEffect is not null)
             {
-                
                 using var paint = new SKPaint();
                 // TODO: Investigate how to blend the shaders better - currently the only problem with this system.
                 // Blend modes effect the transition quite heavily, only these 3 seem to work in any reasonable way.

--- a/SukiUI/Utilities/Effects/EffectBackgroundDraw.cs
+++ b/SukiUI/Utilities/Effects/EffectBackgroundDraw.cs
@@ -34,8 +34,9 @@ namespace SukiUI.Utilities.Effects
         public override void OnMessage(object message)
         {
             base.OnMessage(message);
-            if (message is float time) 
-                TransitionTime = time;
+            if (message == EnableTransitions) TransitionsEnabled = true;
+            else if (message == DisableTransitions) TransitionsEnabled = false;
+            if (message is double time) TransitionTime = time;
         }
 
         protected override void Render(SKCanvas canvas, SKRect rect)
@@ -59,7 +60,10 @@ namespace SukiUI.Utilities.Effects
                 using var shader = EffectWithUniforms(_oldEffect, (float)(1 - lerped));
                 paint.Shader = shader;
                 if (lerped < 1)
+                {
                     canvas.DrawRect(rect, paint);
+                    if(!AnimationEnabled) Invalidate();
+                }
                 else
                     _oldEffect = null;
             }

--- a/SukiUI/Utilities/Effects/EffectDrawBase.cs
+++ b/SukiUI/Utilities/Effects/EffectDrawBase.cs
@@ -54,9 +54,11 @@ namespace SukiUI.Utilities.Effects
         protected float AnimationSeconds => (float)_animationTick.Elapsed.TotalSeconds;
         
         private readonly Stopwatch _animationTick = new();
+        private readonly bool _invalidateRect;
 
-        protected EffectDrawBase()
+        protected EffectDrawBase(bool invalidateRect = false)
         {
+            _invalidateRect = invalidateRect;
             var sTheme = SukiTheme.GetInstance();
             sTheme.OnBaseThemeChanged += v => ActiveVariant = v;
             ActiveVariant = sTheme.ActiveBaseTheme;
@@ -96,7 +98,10 @@ namespace SukiUI.Utilities.Effects
         public override void OnAnimationFrameUpdate()
         {
             if (!AnimationEnabled) return;
-            Invalidate(GetRenderBounds());
+            if(_invalidateRect)
+                Invalidate(GetRenderBounds());
+            else
+                Invalidate();
             RegisterForNextAnimationFrameUpdate();
         }
 

--- a/SukiUI/Utilities/Effects/EffectDrawBase.cs
+++ b/SukiUI/Utilities/Effects/EffectDrawBase.cs
@@ -56,7 +56,7 @@ namespace SukiUI.Utilities.Effects
         private readonly Stopwatch _animationTick = new();
         private readonly bool _invalidateRect;
 
-        protected EffectDrawBase(bool invalidateRect = false)
+        protected EffectDrawBase(bool invalidateRect = true)
         {
             _invalidateRect = invalidateRect;
             var sTheme = SukiTheme.GetInstance();

--- a/SukiUI/Utilities/Effects/EffectDrawBase.cs
+++ b/SukiUI/Utilities/Effects/EffectDrawBase.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using Avalonia;
 using Avalonia.Media;
 using Avalonia.Platform;
+using Avalonia.Rendering.Composition;
 using Avalonia.Rendering.SceneGraph;
 using Avalonia.Skia;
 using Avalonia.Styling;
@@ -11,10 +12,11 @@ using SukiUI.Models;
 
 namespace SukiUI.Utilities.Effects
 {
-    public abstract class EffectDrawBase : ICustomDrawOperation
+    public abstract class EffectDrawBase : CompositionCustomVisualHandler
     {
-        public Rect Bounds { get; set; }
-
+        public static readonly object StartAnimations = new(), StopAnimations = new(), 
+            EnableForceSoftwareRendering = new(), DisableForceSoftwareRendering = new();
+        
         private SukiEffect? _effect;
 
         public SukiEffect? Effect
@@ -29,7 +31,7 @@ namespace SukiUI.Utilities.Effects
             }
         }
 
-        private bool _animationEnabled = true;
+        private bool _animationEnabled;
         public bool AnimationEnabled
         {
             get => _animationEnabled;
@@ -51,30 +53,54 @@ namespace SukiUI.Utilities.Effects
         
         protected float AnimationSeconds => (float)_animationTick.Elapsed.TotalSeconds;
         
-        private readonly Stopwatch _animationTick = Stopwatch.StartNew();
+        private readonly Stopwatch _animationTick = new();
 
-        protected EffectDrawBase(Rect bounds)
+        protected EffectDrawBase()
         {
-            Bounds = bounds;
             var sTheme = SukiTheme.GetInstance();
             sTheme.OnBaseThemeChanged += v => ActiveVariant = v;
             ActiveVariant = sTheme.ActiveBaseTheme;
             sTheme.OnColorThemeChanged += t => ActiveTheme = t;
             ActiveTheme = sTheme.ActiveColorTheme!;
-            
         }
 
-        public void Render(ImmediateDrawingContext context)
+        public override void OnRender(ImmediateDrawingContext context)
         {
             var leaseFeature = context.TryGetFeature<ISkiaSharpApiLeaseFeature>();
             if (leaseFeature is null) throw new InvalidOperationException("Unable to lease Skia API");
             using var lease = leaseFeature.Lease();
-            var rect = SKRect.Create((float)Bounds.Width, (float)Bounds.Height);
-            if(lease.GrContext is null || ForceSoftwareRendering) // GrContext is null whenever
+            var rect = SKRect.Create((float)EffectiveSize.X, (float)EffectiveSize.Y);
+            if(lease.GrContext is null || ForceSoftwareRendering) // GrContext is null whenever there is no hardware acceleration available
                 RenderSoftware(lease.SkCanvas, rect);
             else
                 Render(lease.SkCanvas, rect);
         }
+        
+        public override void OnMessage(object message)
+        {
+            if (message == StartAnimations)
+            {
+                AnimationEnabled = true;
+                RegisterForNextAnimationFrameUpdate();
+            }
+            else if (message == StopAnimations)
+            {
+                AnimationEnabled = false;
+            }
+            else if (message is SukiEffect effect)
+            {
+                Effect = effect;
+            }
+        }
+
+        public override void OnAnimationFrameUpdate()
+        {
+            if (!AnimationEnabled) return;
+            Invalidate(GetRenderBounds());
+            RegisterForNextAnimationFrameUpdate();
+        }
+
+        //protected abstract void InvalidateInternal();
 
         /// <summary>
         /// Called every frame to render content.
@@ -90,13 +116,13 @@ namespace SukiUI.Utilities.Effects
             EffectWithUniforms(Effect, alpha);
 
         protected SKShader? EffectWithUniforms(SukiEffect? effect, float alpha = 1f) => 
-            effect?.ToShaderWithUniforms(AnimationSeconds, ActiveVariant, Bounds, AnimationSpeedScale, alpha);
+            effect?.ToShaderWithUniforms(AnimationSeconds, ActiveVariant, GetRenderBounds(), AnimationSpeedScale, alpha);
 
         protected SKShader? EffectWithCustomUniforms(Func<SKRuntimeEffect,SKRuntimeEffectUniforms> uniformFactory, float alpha = 1f) =>
             EffectWithCustomUniforms(Effect, uniformFactory, alpha);
         
         protected SKShader? EffectWithCustomUniforms(SukiEffect? effect, Func<SKRuntimeEffect,SKRuntimeEffectUniforms> uniformFactory, float alpha = 1f) =>
-            effect?.ToShaderWithCustomUniforms(uniformFactory, AnimationSeconds, Bounds, AnimationSpeedScale, alpha);
+            effect?.ToShaderWithCustomUniforms(uniformFactory, AnimationSeconds, GetRenderBounds(), AnimationSpeedScale, alpha);
 
         protected virtual void EffectChanged(SukiEffect? oldValue, SukiEffect? newValue)
         {


### PR DESCRIPTION
### Changes
- Internally, `EffectDrawBase` now uses `CompositionCustomVisualHandler`.
  - Whenever animations are disabled, GPU & CPU usage are significantly lower (near 0%) - Related Issue: #167 
- Fix `SukiTransitioningContentControl`.
  - Transition animations now play correctly.
  - Backbuffer is cleared out when it's done playing it's animation and assigning `null` to the content is now valid which should make detaching content from the visual tree work as intended.

### Outstanding Issues
- The `Loading` control - even when invalidating only the rect for it - still has very high GPU utilisation and I'm not quite sure why.
- The `ShaderToyRenderer` in the demo also suffers from this same issue - though it seems to use less GPU for reasons beyond my understanding.
- We don't really have a docs page covering `SukiWindow` at the moment.

I wanted to ideally have at least one or two other people test this to make sure the GPU/CPU issues are in fact under control and everything renders correctly, before this gets merged as it's a pretty major internal change.