### PR TITLE
Add styled buttons to dialogs, bump dependencies.

### DIFF
--- a/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsViewModel.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsViewModel.cs
@@ -63,7 +63,7 @@ public partial class DialogsViewModel(ISukiDialogManager dialogManager, ISukiToa
             .OfType(SelectedType)
             .WithTitle("MessageBox style dialog.")
             .WithContent("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.")
-            .WithActionButton("Close " + SelectedType.ToString(), _ => { }, true)
+            .WithActionButton("Close " + SelectedType.ToString(), _ => { }, true, "Flat", "Accent")
             .Dismiss().ByClickingBackground()
             .TryShow();
     }

--- a/SukiUI.Demo/SukiUI.Demo.csproj
+++ b/SukiUI.Demo/SukiUI.Demo.csproj
@@ -9,21 +9,21 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="11.2.0-beta1" />
+		<PackageReference Include="Avalonia" Version="11.2.1" />
 		<PackageReference Include="Avalonia.AvaloniaEdit" Version="11.1.0" />
-		<PackageReference Include="Avalonia.Controls.ColorPicker" Version="11.2.0-beta1" />
-		<PackageReference Include="Avalonia.Desktop" Version="11.2.0-beta1" />
-		<PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.0-beta1" />
+		<PackageReference Include="Avalonia.Controls.ColorPicker" Version="11.2.1" />
+		<PackageReference Include="Avalonia.Desktop" Version="11.2.1" />
+		<PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.1" />
 		<!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.0-beta1" />
-		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.0-beta1" />
+		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.1" />
+		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.1" />
 		<PackageReference Include="AvaloniaEdit.TextMate" Version="11.1.0" />
-		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
-		<PackageReference Include="Dock.Avalonia" Version="11.1.0.1" />
-		<PackageReference Include="Dock.Model" Version="11.1.0.1" />
-		<PackageReference Include="Dock.Model.Avalonia" Version="11.1.0.1" />
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
+		<PackageReference Include="Dock.Avalonia" Version="11.2.0" />
+		<PackageReference Include="Dock.Model" Version="11.2.0" />
+		<PackageReference Include="Dock.Model.Avalonia" Version="11.2.0" />
 		<PackageReference Include="Material.Icons.Avalonia" Version="2.1.10" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0-preview.3.24172.9" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
 		<PackageReference Include="ShowMeTheXaml.Avalonia" Version="1.5.1" />
 		<PackageReference Include="ShowMeTheXaml.Avalonia.Generator" Version="1.5.1" />
 	</ItemGroup>

--- a/SukiUI.Dock/SukiUI.Dock.csproj
+++ b/SukiUI.Dock/SukiUI.Dock.csproj
@@ -14,8 +14,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Dock.Avalonia" Version="11.1.0.1" />
-      <PackageReference Include="Dock.Model.Avalonia" Version="11.1.0.1" />
+      <PackageReference Include="Dock.Avalonia" Version="11.2.0" />
+      <PackageReference Include="Dock.Model.Avalonia" Version="11.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/SukiUI/Dialogs/FluentSukiDialogBuilder.cs
+++ b/SukiUI/Dialogs/FluentSukiDialogBuilder.cs
@@ -85,9 +85,9 @@ namespace SukiUI.Dialogs
         /// Any number of buttons can be added to the dialog.
         /// </summary>
         public static SukiDialogBuilder WithActionButton(this SukiDialogBuilder builder, object? content, Action<ISukiDialog> onClicked,
-            bool dismissOnClick = false)
+            bool dismissOnClick = false, params string[] classes)
         {
-            builder.AddActionButton(content, onClicked, dismissOnClick);
+            builder.AddActionButton(content, onClicked, dismissOnClick, classes);
             return builder;
         }
 

--- a/SukiUI/Dialogs/SukiDialogBuilder.cs
+++ b/SukiUI/Dialogs/SukiDialogBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Controls.Notifications;
 using SukiUI.ColorTheme;
@@ -57,13 +58,15 @@ namespace SukiUI.Dialogs
         
         public void SetOnDismissed(Action<ISukiDialog> onDismissed) => Dialog.OnDismissed = onDismissed;
         
-        public void AddActionButton(object? buttonContent, Action<ISukiDialog> onClicked, bool dismissOnClick)
+        public void AddActionButton(object? buttonContent, Action<ISukiDialog> onClicked, bool dismissOnClick, string[] classes)
         {
-            var btn = new Button()
-            {
-                Content = buttonContent,
-                Classes = { "Flat" }
-            };
+            if(classes.Length == 0)
+                classes = new[] { "Flat" };
+            
+            var btn = new Button { Content = buttonContent };
+            foreach(var @class in classes)
+                btn.Classes.Add(@class);
+            
             btn.Click += (_,_) =>
             {
                 onClicked(Dialog);

--- a/SukiUI/SukiUI.csproj
+++ b/SukiUI/SukiUI.csproj
@@ -28,11 +28,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="11.2.0-beta1" />
-		<PackageReference Include="Avalonia.Skia" Version="11.2.0-beta1" />
+		<PackageReference Include="Avalonia" Version="11.2.1" />
+		<PackageReference Include="Avalonia.Skia" Version="11.2.1" />
 		<PackageReference Include="SkiaSharp" Version="2.88.8" />
-		<PackageReference Include="Avalonia.Controls.DataGrid" Version="11.2.0-beta1" />
-		<PackageReference Include="Avalonia.Themes.Simple" Version="11.2.0-beta1" />
+		<PackageReference Include="Avalonia.Controls.DataGrid" Version="11.2.1" />
+		<PackageReference Include="Avalonia.Themes.Simple" Version="11.2.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/docs/docs/documentation/hosts/dialog.md
+++ b/docs/docs/documentation/hosts/dialog.md
@@ -117,6 +117,19 @@ public void DisplayDialog()
 }
 ```
 
+Buttons can also have their class or classes specified as the last optional parameter, by default the `Flat` style is used, however any one of the standard [button styles](./controls/inputs/button) 
+
+In the following example, the dialog will have the flat style button, with the accent color:
+
+```cs
+public void DisplayDialog()
+{
+    dialogManager.CreateDialog()
+        .WithActionButton("Styled Button ", _ => { }, true, "Flat", "Accent")
+        .TryShow();
+}
+```
+
 ![dialogclose](https://github.com/user-attachments/assets/3d07344f-c302-400a-b2cf-88865e7713ba)
 
 ## MessageBox Style

--- a/docs/docs/documentation/hosts/dialog.md
+++ b/docs/docs/documentation/hosts/dialog.md
@@ -117,7 +117,7 @@ public void DisplayDialog()
 }
 ```
 
-Buttons can also have their class or classes specified as the last optional parameter, by default the `Flat` style is used, however any one of the standard [button styles](./controls/inputs/button) 
+Buttons can also have their class or classes specified as the last optional parameter, by default the `Flat` style is used, however any one of the standard [button styles](/documentation/controls/inputs/button) 
 
 In the following example, the dialog will have the flat style button, with the accent color:
 


### PR DESCRIPTION
### Changes
- Added the ability to set the class for buttons in dialogs 
  - Fixes: #334
  - Non-breaking change via optional parameter
  - Amended docs to cover the new feature.
- Bumped the versions for every dependency we have to the most recent stable versions across the board in preparation for a stable 6.0.0 release
  - Notably Avalonia and related packages are at 11.2.1 and Avalonia.Dock is up to 11.2.0
  - Fixes: #332 

As this involves a package version bump I just want to double check that this builds and runs fine on other dev environments before this PR is merged.