### PR TITLE
[Housekeeping] for project files and package generation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,9 +1,15 @@
 root = true
 
+[*]
 tab_width = 4
 indent_size = 4
 end_of_line = crlf
 indent_style = space
+
+[*.{csproj,props}]
+indent_style = space
+tab_width = 2
+indent_size = 2
 
 [*.{cs,vb}]
 #### Naming styles ####

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>13.0</LangVersion>
+  </PropertyGroup>
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,4 +5,13 @@
     <Nullable>enable</Nullable>
     <LangVersion>13.0</LangVersion>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <Authors></Authors>
+    <Copyright></Copyright>
+    <Owners></Owners>
+    <Description>https://github.com/kikipoulet/SukiUI</Description>
+    <RepositoryUrl>https://github.com/kikipoulet/SukiUI</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+  </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,28 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Avalonia.AvaloniaEdit" Version="11.1.0" />
+    <PackageVersion Include="Avalonia.Controls.ColorPicker" Version="11.2.1" />
+    <PackageVersion Include="Avalonia.Desktop" Version="11.2.1" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.2.1" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.2.1" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.2.1" />
+    <PackageVersion Include="AvaloniaEdit.TextMate" Version="11.1.0" />
+    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.3.2" />
+    <PackageVersion Include="Dock.Model" Version="11.2.0" />
+    <PackageVersion Include="Material.Icons.Avalonia" Version="2.1.10" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageVersion Include="ShowMeTheXaml.Avalonia" Version="1.5.1" />
+    <PackageVersion Include="ShowMeTheXaml.Avalonia.Generator" Version="1.5.1" />
+    <PackageVersion Include="Avalonia" Version="11.2.1" />
+    <PackageVersion Include="Avalonia.Skia" Version="11.2.1" />
+    <PackageVersion Include="SkiaSharp" Version="2.88.8" />
+    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.2.1" />
+    <PackageVersion Include="Avalonia.Themes.Simple" Version="11.2.1" />
+    <PackageVersion Include="Dock.Avalonia" Version="11.2.0" />
+    <PackageVersion Include="Dock.Model.Avalonia" Version="11.2.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+  </ItemGroup>
+</Project>

--- a/Suki.sln
+++ b/Suki.sln
@@ -10,6 +10,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{28455569-AF0F-473B-912D-AE515F68FE15}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		Directory.Build.props = Directory.Build.props
+		Directory.Packages.props = Directory.Packages.props
 		LICENSE = LICENSE
 		nuget.config = nuget.config
 		Settings.XamlStyler = Settings.XamlStyler

--- a/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastsViewModel.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastsViewModel.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Reactive.Concurrency;
-using System.Timers;
 using Avalonia.Controls;
 using Avalonia.Controls.Notifications;
 using Avalonia.Threading;
@@ -40,7 +37,7 @@ public partial class ToastsViewModel(ISukiToastManager toastManager) : DemoPageB
             .WithTitle("Updating...")
             .WithContent(progress)
             .Queue();
-        var timer = new Timer(20);
+        var timer = new System.Timers.Timer(20);
         timer.Elapsed += (_, _) =>
         {
             Dispatcher.UIThread.Invoke(() =>
@@ -75,6 +72,7 @@ public partial class ToastsViewModel(ISukiToastManager toastManager) : DemoPageB
             .Dismiss().ByClicking()
             .Queue();
     }
+
     private void ShowTypeDemoToast(NotificationType toastType)
     {
         toastManager.CreateToast()

--- a/SukiUI.Demo/SukiUI.Demo.csproj
+++ b/SukiUI.Demo/SukiUI.Demo.csproj
@@ -1,60 +1,60 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<OutputType>WinExe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
-		<Nullable>enable</Nullable>
-		<BuiltInComInteropSupport>true</BuiltInComInteropSupport>
-		<ApplicationManifest>app.manifest</ApplicationManifest>
-		<AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+  </PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)' != 'Debug'">
-		<PublishAot>true</PublishAot>
-		<InvariantGlobalization>true</InvariantGlobalization>
-	</PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="11.2.1" />
-		<PackageReference Include="Avalonia.AvaloniaEdit" Version="11.1.0" />
-		<PackageReference Include="Avalonia.Controls.ColorPicker" Version="11.2.1" />
-		<PackageReference Include="Avalonia.Desktop" Version="11.2.1" />
-		<PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.1" />
-		<!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.1" />
-		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.1" />
-		<PackageReference Include="AvaloniaEdit.TextMate" Version="11.1.0" />
-		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
-		<PackageReference Include="Dock.Avalonia" Version="11.2.0" />
-		<PackageReference Include="Dock.Model" Version="11.2.0" />
-		<PackageReference Include="Dock.Model.Avalonia" Version="11.2.0" />
-		<PackageReference Include="Material.Icons.Avalonia" Version="2.1.10" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-		<PackageReference Include="ShowMeTheXaml.Avalonia" Version="1.5.1" />
-		<PackageReference Include="ShowMeTheXaml.Avalonia.Generator" Version="1.5.1" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Avalonia" />
+    <PackageReference Include="Avalonia.AvaloniaEdit" />
+    <PackageReference Include="Avalonia.Controls.ColorPicker" />
+    <PackageReference Include="Avalonia.Desktop" />
+    <PackageReference Include="Avalonia.Fonts.Inter" />
+    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
+    <PackageReference Include="Avalonia.Themes.Fluent" />
+    <PackageReference Include="AvaloniaEdit.TextMate" />
+    <PackageReference Include="CommunityToolkit.Mvvm" />
+    <PackageReference Include="Dock.Avalonia" />
+    <PackageReference Include="Dock.Model" />
+    <PackageReference Include="Dock.Model.Avalonia" />
+    <PackageReference Include="Material.Icons.Avalonia" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="ShowMeTheXaml.Avalonia" />
+    <PackageReference Include="ShowMeTheXaml.Avalonia.Generator" />
+    <PackageReference Include="System.Text.Json" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\SukiUI.Dock\SukiUI.Dock.csproj" />
-		<ProjectReference Include="..\SukiUI\SukiUI.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SukiUI.Dock\SukiUI.Dock.csproj" />
+    <ProjectReference Include="..\SukiUI\SukiUI.csproj" />
+  </ItemGroup>
 
-	<ItemGroup>
-	  <None Remove="Assets\OIG.N5o-removebg-preview.png" />
-	  <AvaloniaResource Include="Assets\OIG.N5o-removebg-preview.png" />
-	</ItemGroup>
+  <ItemGroup>
+    <None Remove="Assets\OIG.N5o-removebg-preview.png" />
+    <AvaloniaResource Include="Assets\OIG.N5o-removebg-preview.png" />
+  </ItemGroup>
 
-	<ItemGroup>
-	  <EmbeddedResource Include="Assets\space.sksl" />
-	  <EmbeddedResource Include="Assets\clouds.sksl" />
-	  <EmbeddedResource Include="Assets\weird.sksl" />
-	</ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Assets\space.sksl" />
+    <EmbeddedResource Include="Assets\clouds.sksl" />
+    <EmbeddedResource Include="Assets\weird.sksl" />
+  </ItemGroup>
 
-	<ItemGroup>
-	  <UpToDateCheckInput Remove="Features\ControlsLibrary\Effects\EffectsView.axaml" />
-	</ItemGroup>
+  <ItemGroup>
+    <UpToDateCheckInput Remove="Features\ControlsLibrary\Effects\EffectsView.axaml" />
+  </ItemGroup>
 
-	<ItemGroup>
-	  <EmbeddedResource Include="Features\Effects\shaderart.sksl" />
-	</ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Features\Effects\shaderart.sksl" />
+  </ItemGroup>
 
 </Project>

--- a/SukiUI.Dock/SukiUI.Dock.csproj
+++ b/SukiUI.Dock/SukiUI.Dock.csproj
@@ -1,28 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>6.0.0-beta7</Version>
-        <PackageIcon>OIG.N5o-removebg-preview.png</PackageIcon>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Version>6.0.0-beta7</Version>
+    <PackageIcon>OIG.N5o-removebg-preview.png</PackageIcon>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\SukiUI\SukiUI.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SukiUI\SukiUI.csproj" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <PackageReference Include="Dock.Avalonia" Version="11.2.0" />
-      <PackageReference Include="Dock.Model.Avalonia" Version="11.2.0" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Dock.Avalonia" />
+    <PackageReference Include="Dock.Model.Avalonia" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <None Update="OIG.N5o-removebg-preview.png">
-        <Pack>True</Pack>
-        <PackagePath></PackagePath>
-      </None>
-    </ItemGroup>
+  <ItemGroup>
+    <None Update="OIG.N5o-removebg-preview.png">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/SukiUI.Dock/SukiUI.Dock.csproj
+++ b/SukiUI.Dock/SukiUI.Dock.csproj
@@ -1,12 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Version>6.0.0-beta7</Version>
-    <PackageIcon>OIG.N5o-removebg-preview.png</PackageIcon>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <IsPackable>true</IsPackable>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageVersion>6.0.0-beta7</PackageVersion>
+    <PackageDescription></PackageDescription>
+    <PackageTags>avalonia;avaloniaui;ui;theme;dock;docking;sukiui</PackageTags>
+    <PackageProjectUrl>https://github.com/kikipoulet/SukiUI</PackageProjectUrl>
+    <PackageIcon>OIG.N5o-removebg-preview.png</PackageIcon>
+  </PropertyGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\SukiUI\SukiUI.csproj" />
   </ItemGroup>

--- a/SukiUI/SukiUI.csproj
+++ b/SukiUI/SukiUI.csproj
@@ -1,114 +1,117 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
-		<IsPackable>true</IsPackable>
-		<Authors></Authors>
-		<Copyright></Copyright>
-		<PackageProjectUrl>https://github.com/kikipoulet/SukiUI</PackageProjectUrl>
-		<PackageDescription></PackageDescription>
-		<Owners></Owners>
-		<PackageTags>avalonia;avaloniaui;ui;theme</PackageTags>
-		<RepositoryUrl>https://github.com/kikipoulet/SukiUI</RepositoryUrl>
-		<RepositoryType>git</RepositoryType>
-		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<IsPackable>true</IsPackable>
-		<RootNamespace>SukiUI</RootNamespace>
-		<Version>5.0.4</Version>
-		<FileVersion>2.0.0</FileVersion>
-		<AssemblyVersion>2.0.0</AssemblyVersion>
-		<LangVersion>10</LangVersion>
-		<UserSecretsId>712f85e4-12d3-41b0-a417-5714a113666f</UserSecretsId>
-		<Description>https://github.com/kikipoulet/SukiUI</Description>
-		<PackageVersion>6.0.0-beta8</PackageVersion>
-		<Nullable>enable</Nullable>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-		<PackageIcon>OIG.N5o-removebg-preview.png</PackageIcon>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <RootNamespace>SukiUI</RootNamespace>
+    <Version>5.0.4</Version>
+    <FileVersion>2.0.0</FileVersion>
+    <AssemblyVersion>2.0.0</AssemblyVersion>
+    <UserSecretsId>712f85e4-12d3-41b0-a417-5714a113666f</UserSecretsId>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="11.2.1" />
-		<PackageReference Include="Avalonia.Skia" Version="11.2.1" />
-		<PackageReference Include="SkiaSharp" Version="2.88.8" />
-		<PackageReference Include="Avalonia.Controls.DataGrid" Version="11.2.1" />
-		<PackageReference Include="Avalonia.Themes.Simple" Version="11.2.1" />
-	</ItemGroup>
+  <PropertyGroup>
+    <Authors></Authors>
+    <Copyright></Copyright>
+    <Owners></Owners>
+    <Description>https://github.com/kikipoulet/SukiUI</Description>
+    <RepositoryUrl>https://github.com/kikipoulet/SukiUI</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<AvaloniaResource Include="**\*.xaml" />
-		<AvaloniaResource Include="Content\Images\icons8-file-explorer-new-48.png" />
-		<None Remove="CustomFont\MiSans\MiSansLatin-Bold.ttf" />
-	
-		<None Remove="CustomFont\MiSans\MiSansLatin-Demibold.ttf" />
-		<None Remove="CustomFont\MiSans\MiSansLatin-ExtraLight.ttf" />
-		<None Remove="CustomFont\MiSans\MiSansLatin-Heavy.ttf" />
-		<None Remove="CustomFont\MiSans\MiSansLatin-Light.ttf" />
-		<None Remove="CustomFont\MiSans\MiSansLatin-Medium.ttf" />
-		<None Remove="CustomFont\MiSans\MiSansLatin-Normal.ttf" />
-		<None Remove="CustomFont\MiSans\MiSansLatin-Regular.ttf" />
-		<None Remove="CustomFont\MiSans\MiSansLatin-Semibold.ttf" />
-		<None Remove="CustomFont\MiSans\MiSansLatin-Thin.ttf" />
-	</ItemGroup>
+  <PropertyGroup>
+    <IsPackable>true</IsPackable>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageVersion>6.0.0-beta8</PackageVersion>
+    <PackageDescription></PackageDescription>
+    <PackageTags>avalonia;avaloniaui;ui;theme</PackageTags>
+    <PackageProjectUrl>https://github.com/kikipoulet/SukiUI</PackageProjectUrl>
+    <PackageIcon>OIG.N5o-removebg-preview.png</PackageIcon>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<AvaloniaResource Include="Roboto-Regular.ttf" />
-		<AvaloniaResource Include="Roboto-Medium.ttf" />
-		<AvaloniaResource Include="CustomFont\Quicksand-Bold.ttf" />
-		<AvaloniaResource Include="CustomFont\Quicksand-Light.ttf" />
-		<AvaloniaResource Include="CustomFont\Quicksand-Medium.ttf" />
-		<AvaloniaResource Include="CustomFont\Quicksand-Regular.ttf" />
-		<AvaloniaResource Include="CustomFont\Quicksand-SemiBold.ttf" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Avalonia" />
+    <PackageReference Include="Avalonia.Skia" />
+    <PackageReference Include="SkiaSharp" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" />
+    <PackageReference Include="Avalonia.Themes.Simple" />
+  </ItemGroup>
 
-	<ItemGroup>
-	  <None Update="OIG.N5o-removebg-preview.png">
-	    <Pack>True</Pack>
-	    <PackagePath />
-	  </None>
-	</ItemGroup>
+  <ItemGroup>
+    <AvaloniaResource Include="**\*.xaml" />
+    <AvaloniaResource Include="Content\Images\icons8-file-explorer-new-48.png" />
+    <None Remove="CustomFont\MiSans\MiSansLatin-Bold.ttf" />
 
-	<ItemGroup>
-	  <UpToDateCheckInput Remove="Controls\TouchInput\TouchKeyboard\TouchKeyboard.axaml" />
-	  <UpToDateCheckInput Remove="Controls\TouchInput\TouchKeyboard\TouchKeyboardPopUp.axaml" />
-	  <UpToDateCheckInput Remove="Controls\TouchInput\TouchNumericPad\NumericPadPopUp.axaml" />
-	  <UpToDateCheckInput Remove="Controls\TouchInput\TouchNumericPad\TouchNumericPad.axaml" />
-	</ItemGroup>
+    <None Remove="CustomFont\MiSans\MiSansLatin-Demibold.ttf" />
+    <None Remove="CustomFont\MiSans\MiSansLatin-ExtraLight.ttf" />
+    <None Remove="CustomFont\MiSans\MiSansLatin-Heavy.ttf" />
+    <None Remove="CustomFont\MiSans\MiSansLatin-Light.ttf" />
+    <None Remove="CustomFont\MiSans\MiSansLatin-Medium.ttf" />
+    <None Remove="CustomFont\MiSans\MiSansLatin-Normal.ttf" />
+    <None Remove="CustomFont\MiSans\MiSansLatin-Regular.ttf" />
+    <None Remove="CustomFont\MiSans\MiSansLatin-Semibold.ttf" />
+    <None Remove="CustomFont\MiSans\MiSansLatin-Thin.ttf" />
+  </ItemGroup>
 
-	<ItemGroup>
-	  <Compile Update="Controls\WaveProgress.axaml.cs">
-	    <DependentUpon>WaveProgress.axaml</DependentUpon>
-	    <SubType>Code</SubType>
-	  </Compile>
-	  <Compile Update="Controls\Hosts\SukiToastHost.cs">
-	    <DependentUpon>SukiToastHost.axaml</DependentUpon>
-	  </Compile>
-	  <Compile Update="Controls\Hosts\SukiDialogHost.cs">
-	    <DependentUpon>SukiDialogHost.axaml</DependentUpon>
-	  </Compile>
-	  <Compile Update="Controls\SukiDialog.cs">
-	    <DependentUpon>SukiDialog.axaml</DependentUpon>
-	  </Compile>
-	</ItemGroup>
+  <ItemGroup>
+    <AvaloniaResource Include="Roboto-Regular.ttf" />
+    <AvaloniaResource Include="Roboto-Medium.ttf" />
+    <AvaloniaResource Include="CustomFont\Quicksand-Bold.ttf" />
+    <AvaloniaResource Include="CustomFont\Quicksand-Light.ttf" />
+    <AvaloniaResource Include="CustomFont\Quicksand-Medium.ttf" />
+    <AvaloniaResource Include="CustomFont\Quicksand-Regular.ttf" />
+    <AvaloniaResource Include="CustomFont\Quicksand-SemiBold.ttf" />
+  </ItemGroup>
 
-	<ItemGroup>
-	  <EmbeddedResource Include="Content\Shaders\Background\bubblestrong.sksl" />
-	  <EmbeddedResource Include="Content\Shaders\Background\cells.sksl" />
-	  <EmbeddedResource Include="Content\Shaders\Background\flat.sksl" />
-	  <EmbeddedResource Include="Content\Shaders\Background\bubble.sksl" />
-	  <EmbeddedResource Include="Content\Shaders\Background\waves.sksl" />
-	  <EmbeddedResource Include="Content\Shaders\Loading\glow.sksl" />
-	  <EmbeddedResource Include="Content\Shaders\Loading\pellets.sksl" />
-	  <None Remove="Content\Shaders\Background\gradient.sksl" />
-	  <EmbeddedResource Include="Content\Shaders\Background\gradient.sksl" />
-	  <None Remove="Content\Shaders\Loading\simple.sksl" />
-	  <EmbeddedResource Include="Content\Shaders\Loading\simple.sksl" />
-	  <None Remove="Content\Shaders\Background\gradientsoft.sksl" />
-	  <EmbeddedResource Include="Content\Shaders\Background\gradientsoft.sksl" />
-	  <None Remove="Content\Shaders\Background\gradientdarker.sksl" />
-	  <EmbeddedResource Include="Content\Shaders\Background\gradientdarker.sksl" />
-	  <None Remove="Content\Shaders\Background\backgroundshadcn.sksl" />
-	  <EmbeddedResource Include="Content\Shaders\Background\backgroundshadcn.sksl" />
-	</ItemGroup>
+  <ItemGroup>
+    <None Update="OIG.N5o-removebg-preview.png">
+      <Pack>True</Pack>
+      <PackagePath />
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <UpToDateCheckInput Remove="Controls\TouchInput\TouchKeyboard\TouchKeyboard.axaml" />
+    <UpToDateCheckInput Remove="Controls\TouchInput\TouchKeyboard\TouchKeyboardPopUp.axaml" />
+    <UpToDateCheckInput Remove="Controls\TouchInput\TouchNumericPad\NumericPadPopUp.axaml" />
+    <UpToDateCheckInput Remove="Controls\TouchInput\TouchNumericPad\TouchNumericPad.axaml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="Controls\WaveProgress.axaml.cs">
+      <DependentUpon>WaveProgress.axaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Update="Controls\Hosts\SukiToastHost.cs">
+      <DependentUpon>SukiToastHost.axaml</DependentUpon>
+    </Compile>
+    <Compile Update="Controls\Hosts\SukiDialogHost.cs">
+      <DependentUpon>SukiDialogHost.axaml</DependentUpon>
+    </Compile>
+    <Compile Update="Controls\SukiDialog.cs">
+      <DependentUpon>SukiDialog.axaml</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Content\Shaders\Background\bubblestrong.sksl" />
+    <EmbeddedResource Include="Content\Shaders\Background\cells.sksl" />
+    <EmbeddedResource Include="Content\Shaders\Background\flat.sksl" />
+    <EmbeddedResource Include="Content\Shaders\Background\bubble.sksl" />
+    <EmbeddedResource Include="Content\Shaders\Background\waves.sksl" />
+    <EmbeddedResource Include="Content\Shaders\Loading\glow.sksl" />
+    <EmbeddedResource Include="Content\Shaders\Loading\pellets.sksl" />
+    <None Remove="Content\Shaders\Background\gradient.sksl" />
+    <EmbeddedResource Include="Content\Shaders\Background\gradient.sksl" />
+    <None Remove="Content\Shaders\Loading\simple.sksl" />
+    <EmbeddedResource Include="Content\Shaders\Loading\simple.sksl" />
+    <None Remove="Content\Shaders\Background\gradientsoft.sksl" />
+    <EmbeddedResource Include="Content\Shaders\Background\gradientsoft.sksl" />
+    <None Remove="Content\Shaders\Background\gradientdarker.sksl" />
+    <EmbeddedResource Include="Content\Shaders\Background\gradientdarker.sksl" />
+    <None Remove="Content\Shaders\Background\backgroundshadcn.sksl" />
+    <EmbeddedResource Include="Content\Shaders\Background\backgroundshadcn.sksl" />
+  </ItemGroup>
 
 </Project>

--- a/SukiUI/SukiUI.csproj
+++ b/SukiUI/SukiUI.csproj
@@ -12,20 +12,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Authors></Authors>
-    <Copyright></Copyright>
-    <Owners></Owners>
-    <Description>https://github.com/kikipoulet/SukiUI</Description>
-    <RepositoryUrl>https://github.com/kikipoulet/SukiUI</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageVersion>6.0.0-beta8</PackageVersion>
     <PackageDescription></PackageDescription>
-    <PackageTags>avalonia;avaloniaui;ui;theme</PackageTags>
+    <PackageTags>avalonia;avaloniaui;ui;theme;sukiui</PackageTags>
     <PackageProjectUrl>https://github.com/kikipoulet/SukiUI</PackageProjectUrl>
     <PackageIcon>OIG.N5o-removebg-preview.png</PackageIcon>
   </PropertyGroup>


### PR DESCRIPTION
### Relevant changes
- added Directory.Build.props, Directory.Packages.props to centrally manage nuget package versions and global project settings (speeds up managing nuget packages via IDE dramatically)
- added [*.{csproj,props}] to editorconfig, to enforce uniform formatting for props and csproj files
- auto formatted csproj and props files according to new editorconfig settings

### Breaking Changes
- use netstandard2.0 for SukiUI.Dock
- added tags to SukiUI.Dock

### Misc
- fixed ambiguous reference in ToastsViewModel
- added most recent .NET 8 version of System.Text.Json to Demo app, to fix a transitive package vulnerability