### PR TITLE
Fixed DataGrid scrolling (#344)

### DIFF
--- a/SukiUI/Theme/DataGridStyle.axaml
+++ b/SukiUI/Theme/DataGridStyle.axaml
@@ -312,40 +312,61 @@
         <Setter Property="Template">
             <ControlTemplate>
                 <Border Background="Transparent" BorderThickness="0">
-                    <ScrollViewer Name="PART_ScrollViewer"
-                                  HorizontalScrollBarVisibility="{TemplateBinding HorizontalScrollBarVisibility}"
-                                  VerticalScrollBarVisibility="{TemplateBinding VerticalScrollBarVisibility}">
-                        <Grid ColumnDefinitions="Auto,*,Auto" RowDefinitions="Auto,*,Auto,Auto">
+                    <Grid ColumnDefinitions="Auto,*,Auto" RowDefinitions="Auto,*,Auto,Auto">
+                        <Grid.Styles>
+                            <Style Selector="DataGrid /template/ Border > Grid:pointerover ScrollBar#PART_VerticalScrollbar">
+                                <Setter Property="AllowAutoHide" Value="True"></Setter>
+                            </Style>
+                            <Style Selector="DataGrid /template/ Border > Grid:pointerover ScrollBar#PART_HorizontalScrollbar">
+                                <Setter Property="AllowAutoHide" Value="True"></Setter>
+                            </Style>
+                        </Grid.Styles>
+                        
+                        <DataGridColumnHeader Name="PART_TopLeftCornerHeader"
+                                              Grid.Row="0"
+                                              Grid.Column="0"
+                                              Width="22" />
+                        <DataGridColumnHeadersPresenter Name="PART_ColumnHeadersPresenter"
+                                                        Grid.Row="0"
+                                                        Grid.Column="1" />
+                        <DataGridColumnHeader Name="PART_TopRightCornerHeader"
+                                              Grid.Row="0"
+                                              Grid.Column="2" />
+                        <Rectangle Name="PART_ColumnHeadersAndRowsSeparator"
+                                   Grid.Row="0"
+                                   Grid.Column="0"
+                                   Grid.ColumnSpan="3"
+                                   Height="1"
+                                   VerticalAlignment="Bottom"
+                                   Fill="Transparent"
+                                   StrokeThickness="1" />
 
-                            <DataGridColumnHeader Name="PART_TopLeftCornerHeader"
-                                                  Grid.Row="0"
-                                                  Grid.Column="0"
-                                                  Width="22" />
-                            <DataGridColumnHeadersPresenter Name="PART_ColumnHeadersPresenter"
-                                                            Grid.Row="0"
-                                                            Grid.Column="1" />
-                            <DataGridColumnHeader Name="PART_TopRightCornerHeader"
-                                                  Grid.Row="0"
-                                                  Grid.Column="2" />
-                            <Rectangle Name="PART_ColumnHeadersAndRowsSeparator"
-                                       Grid.Row="0"
-                                       Grid.Column="0"
-                                       Grid.ColumnSpan="3"
-                                       Height="1"
-                                       VerticalAlignment="Bottom"
-                                       Fill="Transparent"
-                                       StrokeThickness="1" />
+                        <DataGridRowsPresenter Name="PART_RowsPresenter"
+                                    ClipToBounds="True"
+                                    Grid.Row="1"
+                                    Grid.Column="0"
+                                    Grid.ColumnSpan="3">
+                            <DataGridRowsPresenter.GestureRecognizers>
+                                <ScrollGestureRecognizer CanHorizontallyScroll="True" CanVerticallyScroll="True" />
+                            </DataGridRowsPresenter.GestureRecognizers>
+                        </DataGridRowsPresenter>
 
-                            <DataGridRowsPresenter Name="PART_RowsPresenter"
-                                                   Grid.Row="1"
-                                                   Grid.Column="0"
-                                                   Grid.ColumnSpan="3">
-                                <DataGridRowsPresenter.GestureRecognizers>
-                                    <ScrollGestureRecognizer CanHorizontallyScroll="True" CanVerticallyScroll="True" />
-                                </DataGridRowsPresenter.GestureRecognizers>
-                            </DataGridRowsPresenter>
+                        <ScrollBar Name="PART_VerticalScrollbar"
+                                   Orientation="Vertical"
+                                   Grid.Column="2"
+                                   Grid.Row="1"
+                                   HorizontalAlignment="Right" />
+
+                        <Grid Grid.Column="1"
+                              Grid.ColumnSpan="2"
+                              Grid.Row="2"
+                              ColumnDefinitions="Auto,*">
+                            <Rectangle Name="PART_FrozenColumnScrollBarSpacer" />
+                            <ScrollBar Name="PART_HorizontalScrollbar"
+                                       Grid.Column="1"
+                                       Orientation="Horizontal" />
                         </Grid>
-                    </ScrollViewer>
+                    </Grid>
                 </Border>
             </ControlTemplate>
         </Setter>


### PR DESCRIPTION
Fixes #344

As reported, the scrollbar did not properly represent the length of the collection.
But also, the column headers should not have scrolled with the rows.