### PR TITLE
Fix CI builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>13</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/nuget.config
+++ b/nuget.config
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <packageSources>
-    <add key="AvaloniaCI" value="https://www.myget.org/F/avalonia-ci/api/v2" />
-  </packageSources>
+    <packageSources>
+        <clear />
+        <add key="AvaloniaCI" value="https://www.myget.org/F/avalonia-ci/api/v2" />
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    </packageSources>
+    <packageSourceMapping>
+        <!-- key value for <packageSource> should match key values from <packageSources> element -->
+        <packageSource key="nuget.org">
+            <package pattern="*" />
+        </packageSource>
+        <packageSource key="AvaloniaCI">
+            <package pattern="Avalonia*" />
+        </packageSource>
+    </packageSourceMapping>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -10,8 +10,5 @@
         <packageSource key="nuget.org">
             <package pattern="*" />
         </packageSource>
-        <packageSource key="AvaloniaCI">
-            <package pattern="Avalonia*" />
-        </packageSource>
     </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
Seems my recent changes to the nuget.config broke github CI build as can be seen [here](https://github.com/kikipoulet/SukiUI/actions/runs/12195606493/job/34021550365#step:5:20).

This adds sourcemapping to nuget.config, so that everything will be fetched from nuget.org