### PR TITLE
Change standard flat button style to match accent.

### DIFF
--- a/SukiUI/Controls/BusyArea.axaml
+++ b/SukiUI/Controls/BusyArea.axaml
@@ -62,7 +62,7 @@
                             
                             <ContentPresenter HorizontalAlignment="Center"
                                               VerticalAlignment="Center"
-                                              IsHitTestVisible="False" Content="{TemplateBinding IsBusy, Converter={x:Static converters:ProgressToContentCOnverter.Instance}}"></ContentPresenter>
+                                              IsHitTestVisible="False" Content="{TemplateBinding IsBusy, Converter={x:Static converters:ProgressToContentConverter.Instance}}"></ContentPresenter>
 
                             
                         </DockPanel>

--- a/SukiUI/Converters/ProgressToContentConverter.cs
+++ b/SukiUI/Converters/ProgressToContentConverter.cs
@@ -7,9 +7,9 @@ using SukiUI.Controls;
 
 namespace SukiUI.Converters
 {
-    public class ProgressToContentCOnverter : IValueConverter
+    public class ProgressToContentConverter : IValueConverter
     {
-        public static readonly ProgressToContentCOnverter Instance = new ProgressToContentCOnverter();
+        public static readonly ProgressToContentConverter Instance = new ProgressToContentConverter();
         
         
         public object? Convert(object? value, Type targetType, object? parameter, 

--- a/SukiUI/Theme/Button.axaml
+++ b/SukiUI/Theme/Button.axaml
@@ -37,7 +37,7 @@
                                 </Transitions>
                             </Viewbox.Transitions>
                        
-                           <ContentPresenter Content="{TemplateBinding theme:ButtonExtensions.ShowProgress, Converter={x:Static suki:ProgressToContentCOnverter.Instance}}"></ContentPresenter>
+                           <ContentPresenter Content="{TemplateBinding theme:ButtonExtensions.ShowProgress, Converter={x:Static suki:ProgressToContentConverter.Instance}}"/>
                           
                         </Viewbox>
                         <ContentPresenter HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
@@ -290,7 +290,7 @@
         <Style Selector="^.Flat">
             <Setter Property="Padding" Value="20,8,20,8" />
             <Setter Property="BorderThickness" Value="0" />
-            <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor}" />
+            <Setter Property="Background" Value="{DynamicResource SukiPrimaryColor75}" />
             <Setter Property="Foreground" Value="White" />
             <Setter Property="Transitions">
                 <Transitions>


### PR DESCRIPTION
### Changes
- Adjusted standard `Flat` style button to match the `Accent` one.
- Fixed weird naming of a converter.

I'm still not that happy with the implementation of the busy button spinner suddenly taking up unreserved space, it's especially weird looking in the new icon button when it just pushes the icon out.

I'm not sure there's a way to implement it in a tidy way though, so I guess it is what it is.