### PR TITLE
Fix DataGrid GroupRow styles

### DIFF
--- a/SukiUI.Demo/Features/ControlsLibrary/CollectionsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/CollectionsView.axaml
@@ -72,15 +72,16 @@
                                           MaxHeight="200"
                                           CanUserResizeColumns="{Binding IsDataGridColumnsResizable}"
                                           ItemsSource="{Binding DataGridContent}">
+                                    <DataGrid.Styles>
+                                        <Style Selector="DataGridRowGroupHeader">
+                                            <Setter Property="IsItemCountVisible" Value="True" />
+                                        </Style>
+                                    </DataGrid.Styles>
                                     <DataGrid.Columns>
-                                        <DataGridTextColumn Binding="{Binding StringColumn}" Header="String" />
-                                        <DataGridTextColumn Binding="{Binding IntColumn}"
-                                                            
-                                                            Header="Int" />
-                                        <DataGridCheckBoxColumn Binding="{Binding BoolColumn}"
-                                                               
-                                                                Header="Bool" />
-                                        
+                                        <DataGridTextColumn Binding="{Binding StringColumn, DataType=controlsLibrary:DataGridContentViewModel}" Header="String" />
+                                        <DataGridTextColumn Binding="{Binding IntColumn, DataType=controlsLibrary:DataGridContentViewModel}" Header="Int" />
+                                        <DataGridCheckBoxColumn Binding="{Binding BoolColumn, DataType=controlsLibrary:DataGridContentViewModel}" Header="Bool" />
+                                        <DataGridTextColumn Binding="{Binding Group, DataType=controlsLibrary:DataGridContentViewModel}" Header="Group" />
                                     </DataGrid.Columns>
                                 </DataGrid>
                             </showMeTheXaml:XamlDisplay>

--- a/SukiUI.Demo/Features/ControlsLibrary/CollectionsViewModel.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/CollectionsViewModel.cs
@@ -10,7 +10,7 @@ namespace SukiUI.Demo.Features.ControlsLibrary;
 public partial class CollectionsViewModel : DemoPageBase
 {
     public AvaloniaList<string> SimpleContent { get; } = [];
-    public AvaloniaList<DataGridContentViewModel> DataGridContent { get; } = [];
+    public DataGridCollectionView DataGridContent { get; }
     public AvaloniaList<Node> TreeViewContent { get; } = [];
     [ObservableProperty] private string _selectedSimpleContent;
     [ObservableProperty] private bool _isDataGridColumnsResizable;
@@ -18,7 +18,9 @@ public partial class CollectionsViewModel : DemoPageBase
     public CollectionsViewModel() : base("Collections", MaterialIconKind.ListBox)
     {
         SimpleContent.AddRange(Enumerable.Range(1, 50).Select(x => $"Option {x}"));
-        DataGridContent.AddRange(Enumerable.Range(1, 50).Select(x => new DataGridContentViewModel(x)));
+        DataGridContent = new DataGridCollectionView(Enumerable.Range(1, 50).Select(x => new DataGridContentViewModel(x)));
+        DataGridContent.GroupDescriptions.Add(new DataGridPathGroupDescription("Group"));
+        //DataGridContent.AddRange(Enumerable.Range(1, 50).Select(x => new DataGridContentViewModel(x)));
         SelectedSimpleContent = SimpleContent.First();
         TreeViewContent.AddRange(
             Enumerable.Range(1, 10).Select(x => new Node($"Outer {x}",
@@ -30,8 +32,9 @@ public partial class CollectionsViewModel : DemoPageBase
 public partial class DataGridContentViewModel(int value) : ObservableObject
 {
     [ObservableProperty] private string _stringColumn = $"Content {value}";
-    [ObservableProperty] private int _intColumn = value;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(Group))] private int _intColumn = value;
     [ObservableProperty] private bool _boolColumn = Random.Shared.Next(0, 2) == 0;
+    public string Group => IntColumn % 2 == 0 ? "Even" : "Odd";
 }
 
 public partial class Node(string value, IEnumerable<Node>? subNodes = null) : ObservableObject

--- a/SukiUI/Theme/DataGridStyle.axaml
+++ b/SukiUI/Theme/DataGridStyle.axaml
@@ -221,7 +221,7 @@
     </Style>
 
     <Style Selector="DataGridRowGroupHeader">
-        <Setter Property="Background" Value="{DynamicResource ThemeControlMidHighBrush}" />
+        <Setter Property="Background" Value="Transparent" />
         <Setter Property="Height" Value="20" />
         <Setter Property="Template">
             <ControlTemplate>
@@ -236,6 +236,8 @@
                     <ToggleButton Name="ExpanderButton"
                                   Grid.Row="1"
                                   Grid.Column="2"
+                                  FontWeight="DemiBold"
+                                  Foreground="{DynamicResource SukiText}"
                                   Margin="2,0,0,0" />
 
                     <StackPanel Grid.Row="1"
@@ -245,10 +247,14 @@
                                 Orientation="Horizontal">
                         <TextBlock Name="PropertyNameElement"
                                    Margin="4,0,0,0"
+                                   FontWeight="DemiBold"
                                    IsVisible="{TemplateBinding IsPropertyNameVisible}" />
-                        <TextBlock Margin="4,0,0,0" Text="{Binding Key}" />
+                        <TextBlock Margin="4,0,0,0" 
+                                   FontWeight="DemiBold"
+                                   Text="{Binding Key}" />
                         <TextBlock Name="ItemCountElement"
                                    Margin="4,0,0,0"
+                                   FontWeight="DemiBold"
                                    IsVisible="{TemplateBinding IsItemCountVisible}" />
                     </StackPanel>
 
@@ -256,7 +262,7 @@
                                        Grid.Row="0"
                                        Grid.RowSpan="3"
                                        Grid.Column="0"
-                                       DataGridFrozenGrid.IsFrozen="True" />
+                                       DataGridFrozenGrid.IsFrozen="True"/>
 
                 </DataGridFrozenGrid>
             </ControlTemplate>
@@ -274,7 +280,7 @@
                     <Path HorizontalAlignment="Center"
                           VerticalAlignment="Center"
                           Data="M 0 2 L 4 6 L 0 10 Z"
-                          Fill="Transparent" />
+                          Fill="{DynamicResource SukiText}" />
                 </Border>
             </ControlTemplate>
         </Setter>


### PR DESCRIPTION
This PR aim to fix the DataGrid GroupRow styles as explaned in #363

(Help wanted) It still has some annoyances I can't get to work:
- When click on expander arrow it will change arrow state but does not expand nor hide
- When click on header it will expand and hide but not change arrow state
- Missing Suki animations for expander

https://github.com/user-attachments/assets/564bf01d-82b4-4d28-b140-89d64aa2bb69

As we don't include DataGrid theme from Avalonia there are many things missing, as for example, we can't aim `DataGridRow` type for inline styling of row because it does not exists as ControlTheme: `<ControlTheme x:Key="{x:Type DataGridRow}" TargetType="DataGridRow">`.
A better approach would be include default DataGrid theme and override the key parts on Suki, or copy over from Avalonia and change every element to match Suki.
The [Fluent theme](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml) of DataGrid already include many ResourceDictionary that we can tune, however some key parts are still missing.

Sample effect of lacking stock ControlThemes:
![image](https://github.com/user-attachments/assets/9302c670-9b1b-46d4-bd89-c2fcca600b6b)
