### PR TITLE
Fix lack of vertical scroll for Dialogs

### DIFF
--- a/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsView.axaml
@@ -37,6 +37,13 @@
                     </suki:GroupBox>
                 </suki:GlassCard>
                 <suki:GlassCard>
+                    <suki:GroupBox Header="Long Dialog">
+                        <Button VerticalAlignment="Top" Margin="15,10,15,0"
+                                Command="{Binding OpenLongDialogCommand}"
+                                Content="Show Dialog" />
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
                     <suki:GroupBox Header="Multi Option Dialog">
                         <Button VerticalAlignment="Top" Margin="15,10,15,0"
                                 Command="{Binding OpenMultiOptionDialogCommand}"

--- a/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsViewModel.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using Avalonia.Controls;
 using Avalonia.Controls.Notifications;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -20,6 +21,20 @@ public partial class DialogsViewModel(ISukiDialogManager dialogManager, ISukiToa
         dialogManager.CreateDialog()
             .WithTitle("A Standard Dialog")
             .WithContent("This is a standard dialog. Click the button below to dismiss.")
+            .WithActionButton("Dismiss", _ => { }, true)
+            .TryShow();
+    }
+
+    [RelayCommand]
+    private void OpenLongDialog()
+    {
+        var listbox = new ListBox
+        {
+            ItemsSource = Enumerable.Range(0, 1000)
+        };
+        dialogManager.CreateDialog()
+            .WithTitle("A Long Dialog with a ListBox")
+            .WithContent(listbox)
             .WithActionButton("Dismiss", _ => { }, true)
             .TryShow();
     }

--- a/SukiUI/Controls/SukiDialog.axaml
+++ b/SukiUI/Controls/SukiDialog.axaml
@@ -20,33 +20,38 @@
                                 </Panel>
                         
                             </Border>
-                           
-                          
-                                           
-                                <StackPanel Margin="30,30,30,5" IsVisible="{Binding !IsViewModelOnly, RelativeSource={RelativeSource TemplatedParent}}" Spacing="24">
-                                    <Border Margin="0,10,0,0" IsVisible="{TemplateBinding IconColor, Converter={x:Static ObjectConverters.IsNotNull}}"></Border>
-                                    <TextBlock Margin="0,0,0,0" IsVisible="{TemplateBinding Title,Converter={x:Static StringConverters.IsNotNullOrEmpty}}" HorizontalAlignment="Center" FontSize="22" FontWeight="DemiBold" Text="{TemplateBinding Title}" />
-                                    <ContentControl MaxWidth="{TemplateBinding Content, Converter={x:Static dialogs:DialogContentMaxWidthValueConverter.Instance}}" Content="{TemplateBinding Content}" >
-                                        <ContentControl.Styles>
-                                            <Style Selector="TextBlock">
-                                                <Setter  Property="FontSize" Value="14" />
-                                                <Setter  Property="TextWrapping" Value="Wrap" />
-                                            </Style>
-                                        </ContentControl.Styles>
-                                    </ContentControl>
-                                    <ItemsControl Margin="0,2,0,0" ItemsSource="{TemplateBinding ActionButtons}">
-                                        <ItemsControl.Styles>
-                                            <Style Selector="Button">
-                                                <Setter Property="Margin" Value="15,0,0,25" />
-                                            </Style>
-                                        </ItemsControl.Styles>
-                                        <ItemsControl.ItemsPanel>
-                                            <ItemsPanelTemplate>
-                                                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right"/>
-                                            </ItemsPanelTemplate>
-                                        </ItemsControl.ItemsPanel>
-                                    </ItemsControl>
-                                </StackPanel>
+
+
+
+                            <Grid RowDefinitions="Auto,Auto,*,Auto"
+                                  ColumnDefinitions="*"
+                                  Margin="30,30,30,5" 
+                                  IsVisible="{Binding !IsViewModelOnly, RelativeSource={RelativeSource TemplatedParent}}">
+                                  
+                                <Border Grid.Row="0" Margin="0,10,0,0" IsVisible="{TemplateBinding IconColor, Converter={x:Static ObjectConverters.IsNotNull}}"></Border>
+                                  <TextBlock Grid.Row="1" Margin="0,24,0,0" IsVisible="{TemplateBinding Title,Converter={x:Static StringConverters.IsNotNullOrEmpty}}" HorizontalAlignment="Center" FontSize="22" FontWeight="DemiBold" Text="{TemplateBinding Title}" />
+                                  <ContentControl Grid.Row="2" Margin="0,24,0,0" MaxWidth="{TemplateBinding Content, Converter={x:Static dialogs:DialogContentMaxWidthValueConverter.Instance}}" Content="{TemplateBinding Content}" >
+                                      <ContentControl.Styles>
+                                          <Style Selector="TextBlock">
+                                              <Setter  Property="FontSize" Value="14" />
+                                              <Setter  Property="TextWrapping" Value="Wrap" />
+                                          </Style>
+                                      </ContentControl.Styles>
+                                  </ContentControl>
+                                  <ItemsControl Grid.Row="3" Margin="0,26,0,0" ItemsSource="{TemplateBinding ActionButtons}">
+                                      <ItemsControl.Styles>
+                                          <Style Selector="Button">
+                                              <Setter Property="Margin" Value="15,0,0,25" />
+                                          </Style>
+                                      </ItemsControl.Styles>
+                                      <ItemsControl.ItemsPanel>
+                                          <ItemsPanelTemplate>
+                                              <StackPanel Orientation="Horizontal" HorizontalAlignment="Right"/>
+                                          </ItemsPanelTemplate>
+                                      </ItemsControl.ItemsPanel>
+
+                                  </ItemsControl>
+                            </Grid>
                         
                             <ContentControl Content="{TemplateBinding ViewModel}" Margin="15"
                                             IsVisible="{TemplateBinding IsViewModelOnly}" />


### PR DESCRIPTION
StackPanel uses infinite Width/Height, no content can use scroll when inside StackPanel. This PR uses Grid instead with content as Fill. This resolves the problem and give us vertical scroll when required.

StackPanel is very convenient to use but this problem make it almost a bug rather than a useful control. I tend to avoid it at all cost.

Before VS after:
![image](https://github.com/user-attachments/assets/d2a81664-a2fe-4190-b3ad-4ab277d67c78)
