### PR TITLE
Fix NullReferenceException on Android at Startup

### DIFF
--- a/SukiUI/Utilities/Effects/SukiEffect.cs
+++ b/SukiUI/Utilities/Effects/SukiEffect.cs
@@ -68,19 +68,13 @@ namespace SukiUI.Utilities.Effects
             shaderName = shaderName.ToLowerInvariant();
             if (!shaderName.EndsWith(".sksl"))
                 shaderName += ".sksl";
-            var assembly = Assembly.GetEntryAssembly();
-            var resName = assembly!.GetManifestResourceNames()
+            var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
+            var resName = assembly.GetManifestResourceNames()
                 .FirstOrDefault(x => x.ToLowerInvariant().Contains(shaderName));
-            if (resName is null)
-            {
-                assembly = Assembly.GetExecutingAssembly();
-                resName = assembly.GetManifestResourceNames()
-                    .FirstOrDefault(x => x.ToLowerInvariant().Contains(shaderName));
-            }
-
             if (resName is null)
                 throw new FileNotFoundException(
                     $"Unable to find a file with the name \"{shaderName}\" anywhere in the assembly.");
+
             using var tr = new StreamReader(assembly.GetManifestResourceStream(resName)!);
             return FromString(tr.ReadToEnd());
         }


### PR DESCRIPTION
The nul-forgiving operator (!) has no effect at run time. It only affects the compiler's static flow analysis by changing the null state of the expression.
https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/null-forgiving

Whereas the null-coalescing operator ?? returns the value of its left-hand operand if it isn't null; otherwise, it evaluates the right-hand operand and returns its result.
https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/null-coalescing-operator

In this context, ?? operator should be used to simplify the logic and handle null reference exception.