### PR TITLE
Fix #410 for good - Add proper Loading of Resources for Android, iOS

### DIFF
--- a/SukiUI/Utilities/Effects/SukiEffect.cs
+++ b/SukiUI/Utilities/Effects/SukiEffect.cs
@@ -72,17 +72,22 @@ namespace SukiUI.Utilities.Effects
 
 
             var assembly = Assembly.GetEntryAssembly();
-            var resName = assembly!.GetManifestResourceNames()
+            var resName = assembly?.GetManifestResourceNames()
                 .FirstOrDefault(x => x.ToLowerInvariant().Contains(shaderName));
             
             if (resName is null)
             {
                 assembly = Assembly.GetExecutingAssembly();
-                resName = assembly!.GetManifestResourceNames()
+                resName = assembly?.GetManifestResourceNames()
                     .FirstOrDefault(x => x.ToLowerInvariant().Contains(shaderName));
             }
 
-
+            if (resName is null)
+            {
+                assembly = typeof(SukiEffect).Assembly;
+                resName = assembly?.GetManifestResourceNames()
+                    .FirstOrDefault(x => x.ToLowerInvariant().Contains(shaderName));
+            }
            
             if (resName is null)
                 throw new FileNotFoundException(


### PR DESCRIPTION
The fix provided for #410 is not solving the load issues for Android/iOS.
There it is not possible to use Assembly.GetEntryAssembly() / Assembly.GetExecutingAssembly(), they will always return null.
However you can call typeof(MyClass).Assembly to access an assembly if you know where the resources are that you are trying to find. 
This patch adds some NullChecks required to go through the implemented methods and adds the code required to load the shaders on mobile platforms