### PR TITLE
Fix #415

### DIFF
--- a/SukiUI.Demo/SukiUI.Demo.csproj
+++ b/SukiUI.Demo/SukiUI.Demo.csproj
@@ -9,7 +9,6 @@
 
   <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
     <PublishAot>true</PublishAot>
-    <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
After adding localization support in #402 the `InvariantGlobalization` property must be removed to avoid a crash.
Fixes: #415