### PR TITLE
Update for SukiWindow

### DIFF
--- a/SukiUI/Controls/SukiWindow.axaml
+++ b/SukiUI/Controls/SukiWindow.axaml
@@ -4,10 +4,8 @@
                     xmlns:suki="clr-namespace:SukiUI.Controls">
     <ControlTheme x:Key="SukiWindowTheme" TargetType="suki:SukiWindow">
         <Setter Property="Margin" Value="0" />
-        
         <Setter Property="TransparencyLevelHint" Value="Transparent"></Setter>
         <Setter Property="SystemDecorations" Value="{OnPlatform Full, Linux=None, x:TypeArguments=SystemDecorations}" />
-        
         <Setter Property="ExtendClientAreaChromeHints" Value="NoChrome" />
         <Setter Property="ExtendClientAreaTitleBarHeightHint" Value="-1" />
         <Setter Property="ExtendClientAreaToDecorationsHint" Value="True" />
@@ -17,9 +15,7 @@
             <ControlTemplate>
                 <Border Margin="{TemplateBinding Margin}"
                         ClipToBounds="True"
-                        CornerRadius="{OnPlatform '0',
-                                                  Linux='10',
-                                                  x:TypeArguments=CornerRadius}">
+                        CornerRadius="{Binding RootCornerRadius, RelativeSource={RelativeSource AncestorType={x:Type suki:SukiWindow}}}">
                     <VisualLayerManager Name="PART_VisualLayerManager" IsHitTestVisible="True">
                         <VisualLayerManager.ChromeOverlayLayer>
                             <!-- <suki:SukiHost /> -->
@@ -40,15 +36,13 @@
                                                  ShaderFile="{TemplateBinding BackgroundShaderFile}"
                                                  Style="{TemplateBinding BackgroundStyle}"
                                                  TransitionTime="{TemplateBinding BackgroundTransitionTime}"
-                                                 TransitionsEnabled="{TemplateBinding BackgroundTransitionsEnabled}" 
+                                                 TransitionsEnabled="{TemplateBinding BackgroundTransitionsEnabled}"
                                                  ForceSoftwareRendering="{TemplateBinding BackgroundForceSoftwareRendering}"/>
                             <Panel Background="White" IsHitTestVisible="False"
                                    IsVisible="{DynamicResource IsLight}"
                                    Opacity="0.1" />
-
                             <DockPanel LastChildFill="True">
                                 <Panel ContextMenu="{TemplateBinding TitleBarContextMenu}" DockPanel.Dock="Top">
-                                    
                                     <Panel.Styles>
                                         <Style Selector="suki|SukiWindow[ShowBottomBorder=True] /template/ Border#PART_BottomBorder">
                                             <Setter Property="BorderThickness" Value="0,0,0,1" />
@@ -136,13 +130,13 @@
                 </Border>
             </ControlTemplate>
         </Setter>
-        
+
         <Style Selector="^[ShowTitlebarBackground=False] /template/ Menu#PART_Menu">
             <Setter Property="Margin" Value="10,0,0,7"></Setter>
-            </Style>
+        </Style>
         <Style Selector="^[ShowTitlebarBackground=True] /template/ suki|GlassCard#AlternativeGlassMenuBackground">
             <Setter Property="IsVisible" Value="False"></Setter>
-        </Style> 
+        </Style>
 
         <Style Selector="^[WindowState=Maximized] /template/ PathIcon#MaximizeIcon">
             <Setter Property="Data" Value="{x:Static icons:Icons.WindowRestore}" />

--- a/SukiUI/Controls/SukiWindow.axaml.cs
+++ b/SukiUI/Controls/SukiWindow.axaml.cs
@@ -131,7 +131,7 @@ public class SukiWindow : Window
         get => GetValue(CanMaximizeProperty);
         set => SetValue(CanMaximizeProperty, value);
     }
-    private int _canMaximize = 0; // 0: uninitialized/notset, 1: true, 2: false
+    private bool _canMaximize = default;
 
     public static readonly StyledProperty<bool> CanMoveProperty =
         AvaloniaProperty.Register<SukiWindow, bool>(nameof(CanMove), defaultValue: true);
@@ -141,7 +141,7 @@ public class SukiWindow : Window
         get => GetValue(CanMoveProperty);
         set => SetValue(CanMoveProperty, value);
     }
-    private int _canMove = 0; // 0: uninitialized/notset, 1: true, 2: false
+    private bool _canMove = default;
 
     // Background properties
     public static readonly StyledProperty<bool> BackgroundAnimationEnabledProperty =
@@ -278,11 +278,11 @@ public class SukiWindow : Window
     {
         base.OnApplyTemplate(e);
 
-        // save the initial values of CanMaximize, CanMinimize, and CanMove
-        if (_canMaximize == 0)
-            _canMaximize = CanMaximize == true ? 1 : 2;
-        if (_canMove == 0)
-            _canMove = CanMove == true ? 1 : 2;
+        // save the initial values of CanMaximize and CanMove
+        if (_canMaximize == default)
+            _canMaximize = CanMaximize;
+        if (_canMove == default)
+            _canMove = CanMove;
 
         OnWindowStateChanged(WindowState);
         try
@@ -388,16 +388,16 @@ public class SukiWindow : Window
         if (state == WindowState.FullScreen)
         {
             // Disable window control capabilities
-            _canMaximize = CanMaximize == true ? 1 : 2;
+            _canMaximize = CanMaximize;
             CanMaximize = false;
-            _canMove = CanMove == true ? 1 : 2;
+            _canMove = CanMove;
             CanMove = false;
         }
         else
         {
             // Restore window control capabilities
-            CanMaximize = _canMaximize == 1 ? true : false;
-            CanMove = _canMove == 1 ? true : false;
+            CanMaximize = _canMaximize;
+            CanMove = _canMove;
         }
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) // only for windows platform

--- a/SukiUI/Controls/SukiWindow.axaml.cs
+++ b/SukiUI/Controls/SukiWindow.axaml.cs
@@ -99,7 +99,7 @@ public class SukiWindow : Window
     }
 
     public static readonly StyledProperty<CornerRadius> RootCornerRadiusProperty =
-        AvaloniaProperty.Register<Border, CornerRadius>(nameof(RootCornerRadius));
+        AvaloniaProperty.Register<Border, CornerRadius>(nameof(RootCornerRadius), defaultValue: default);
 
     public CornerRadius RootCornerRadius
     {
@@ -315,7 +315,7 @@ public class SukiWindow : Window
                 {
                     AddResizeGripForLinux(rootPanel);
                 }
-                if (RootCornerRadius == null)
+                if (RootCornerRadius == default)
                 {
                     RootCornerRadius = new CornerRadius(10);
                 }

--- a/SukiUI/Controls/SukiWindow.axaml.cs
+++ b/SukiUI/Controls/SukiWindow.axaml.cs
@@ -311,7 +311,7 @@ public class SukiWindow : Window
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                if (CanResize && e.NameScope.Get<Panel>("PART_Root") is { } rootPanel)
+                if (e.NameScope.Get<Panel>("PART_Root") is { } rootPanel)
                 {
                     AddResizeGripForLinux(rootPanel);
                 }
@@ -523,6 +523,7 @@ public class SukiWindow : Window
 
     private void RaiseResize(object? sender, PointerPressedEventArgs e)
     {
+        if (!CanResize) return;
         if (sender is not Border border || border.Tag is not string edge) return;
         if (VisualRoot is not Window window)
             return;

--- a/SukiUI/Controls/SukiWindow.axaml.cs
+++ b/SukiUI/Controls/SukiWindow.axaml.cs
@@ -115,7 +115,6 @@ public class SukiWindow : Window
         get => GetValue(CanMinimizeProperty);
         set => SetValue(CanMinimizeProperty, value);
     }
-    private int _canMinimize = 0; // 0: uninitialized/notset, 1: true, 2: false
 
     public static readonly StyledProperty<bool> ShowTitlebarBackgroundProperty =
         AvaloniaProperty.Register<SukiWindow, bool>(nameof(ShowTitlebarBackground), defaultValue: true);
@@ -282,8 +281,6 @@ public class SukiWindow : Window
         // save the initial values of CanMaximize, CanMinimize, and CanMove
         if (_canMaximize == 0)
             _canMaximize = CanMaximize == true ? 1 : 2;
-        if (_canMinimize == 0)
-            _canMinimize = CanMinimize == true ? 1 : 2;
         if (_canMove == 0)
             _canMove = CanMove == true ? 1 : 2;
 
@@ -393,8 +390,6 @@ public class SukiWindow : Window
             // Disable window control capabilities
             _canMaximize = CanMaximize == true ? 1 : 2;
             CanMaximize = false;
-            _canMinimize = CanMinimize == true ? 1 : 2;
-            CanMinimize = false;
             _canMove = CanMove == true ? 1 : 2;
             CanMove = false;
         }
@@ -402,7 +397,6 @@ public class SukiWindow : Window
         {
             // Restore window control capabilities
             CanMaximize = _canMaximize == 1 ? true : false;
-            CanMinimize = _canMinimize == 1 ? true : false;
             CanMove = _canMove == 1 ? true : false;
         }
 


### PR DESCRIPTION
1.Added ResizeGrip for SukiWindow on **Linux** to let window can resize.

2.Fixed the bug where the false property of CanMove failed to take effect.

3.**Only** set margin to 7 when WindowState is Maximized **on Windows platform**.

4.Added temporary variables to store CanMaximize and CanMove states before entering FullScreen mode, and restore them when WindowState returns to Normal. (It is not necessary to change the CanResize property in FullScreen State because it seems that users cannot change the window size in this state)

5.Made RootCornerRadius independently configurable (recommended to set only for Linux systems. It will auto-set to 10 on Linux if not explicitly configured).