### PR TITLE
Use PrimaryColor for floating watermark on TextBox

### DIFF
--- a/SukiUI/Theme/TextBoxStyles.xaml
+++ b/SukiUI/Theme/TextBoxStyles.xaml
@@ -21,6 +21,11 @@
                          Watermark="@gmail.com" />
                 <TextBox Width="200"
                          Margin="5"
+                         Text="suki"
+                         UseFloatingWatermark="True"
+                         Watermark="Username" />
+                <TextBox Width="200"
+                         Margin="5"
                          Classes="BottomBar"
                          Text="Elem" />
                 <TextBox Width="200"
@@ -178,6 +183,7 @@
 
                                 <TextBlock Name="floatingWatermark"
                                            DockPanel.Dock="Top"
+                                           Foreground="{DynamicResource SukiPrimaryColor}"
                                            Text="{TemplateBinding Watermark}">
                                     <TextBlock.IsVisible>
                                         <MultiBinding Converter="{x:Static BoolConverters.And}">


### PR DESCRIPTION
Current style:

![image](https://github.com/user-attachments/assets/eafb2445-bc4a-47df-81a2-b6bf195e632f)

This PR:

![image](https://github.com/user-attachments/assets/d8b6d081-a1f0-4965-997f-c62dd44a36c3)

Avalonia fluent theme follows same applying the primary color to floating watermark