### PR TITLE
Improve binding support for SettingsLayoutItem Header

### DIFF
--- a/SukiUI.Demo/Features/Theming/ThemingView.axaml
+++ b/SukiUI.Demo/Features/Theming/ThemingView.axaml
@@ -13,10 +13,7 @@
 
     <UserControl.Resources>
         <generic:List x:Key="Collection" x:TypeArguments="suki:SettingsLayoutItem">
-            <suki:SettingsLayoutItem x:Name="ThemeHeader">
-                <suki:SettingsLayoutItem.Header>
-                    <TextBlock Text="Base Theme" />
-                </suki:SettingsLayoutItem.Header>
+            <suki:SettingsLayoutItem x:Name="ThemeHeader" Header="Base Theme">
                 <suki:SettingsLayoutItem.Content>
                     <StackPanel HorizontalAlignment="Center"
                                 Orientation="Horizontal"
@@ -63,10 +60,7 @@
                 </suki:SettingsLayoutItem.Content>
             </suki:SettingsLayoutItem>
 
-            <suki:SettingsLayoutItem>
-                <suki:SettingsLayoutItem.Header>
-                    <TextBlock Text="Color Theme" />
-                </suki:SettingsLayoutItem.Header>
+            <suki:SettingsLayoutItem Header="Color Theme">
                 <suki:SettingsLayoutItem.Content>
                     <ItemsControl HorizontalAlignment="Center" ItemsSource="{Binding AvailableColors}">
                         <ItemsControl.ItemsPanel>
@@ -95,10 +89,7 @@
                 </suki:SettingsLayoutItem.Content>
             </suki:SettingsLayoutItem>
 
-            <suki:SettingsLayoutItem>
-                <suki:SettingsLayoutItem.Header>
-                    <TextBlock Text="Background" />
-                </suki:SettingsLayoutItem.Header>
+            <suki:SettingsLayoutItem Header="Background">
                 <suki:SettingsLayoutItem.Content>
                     <StackPanel>
                         <suki:GlassCard Margin="0,25,0,0" Padding="25">
@@ -186,7 +177,6 @@
 
     <suki:SukiStackPage Margin="20">
         <suki:SukiStackPage.Content>
-
             <suki:SettingsLayout Name="Theming" Items="{StaticResource Collection}" />
         </suki:SukiStackPage.Content>
     </suki:SukiStackPage>

--- a/SukiUI.Demo/Features/Theming/ThemingView.axaml
+++ b/SukiUI.Demo/Features/Theming/ThemingView.axaml
@@ -2,182 +2,192 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:generic="clr-namespace:System.Collections.Generic;assembly=System.Collections"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:objectModel="clr-namespace:System.Collections.ObjectModel;assembly=System.ObjectModel"
              xmlns:suki="https://github.com/kikipoulet/SukiUI"
              xmlns:theming="clr-namespace:SukiUI.Demo.Features.Theming"
              d:DesignHeight="450"
              d:DesignWidth="800"
              x:DataType="theming:ThemingViewModel"
              mc:Ignorable="d">
-    <suki:SukiStackPage Margin="20">
-        <suki:SukiStackPage.Content>
-            <suki:SettingsLayout Name="Theming">
-                <suki:SettingsLayout.Items>
-                    <objectModel:ObservableCollection x:TypeArguments="suki:SettingsLayoutItem">
-                        <suki:SettingsLayoutItem Header="Base Theme">
-                            <suki:SettingsLayoutItem.Content>
+
+    <UserControl.Resources>
+        <generic:List x:Key="Collection" x:TypeArguments="suki:SettingsLayoutItem">
+            <suki:SettingsLayoutItem x:Name="ThemeHeader">
+                <suki:SettingsLayoutItem.Header>
+                    <TextBlock Text="Base Theme" />
+                </suki:SettingsLayoutItem.Header>
+                <suki:SettingsLayoutItem.Content>
+                    <StackPanel HorizontalAlignment="Center"
+                                Orientation="Horizontal"
+                                Spacing="20">
+                        <RadioButton Width="180"
+                                     Height="160"
+                                     Padding="0"
+                                     Classes="GigaChips"
+                                     GroupName="RadioBaseTheme"
+                                     IsChecked="{Binding IsLightTheme}">
+                            <Border Margin="-50"
+                                    Background="#fafafa"
+                                    CornerRadius="{DynamicResource MediumCornerRadius}">
+                                <Grid>
+                                    <TextBlock Margin="58,42,42,42"
+                                               HorizontalAlignment="Center"
+                                               VerticalAlignment="Bottom"
+                                               FontWeight="DemiBold"
+                                               Foreground="#555555"
+                                               Text="Light Mode" />
+                                </Grid>
+                            </Border>
+                        </RadioButton>
+
+                        <RadioButton Width="180"
+                                     Height="160"
+                                     Classes="GigaChips"
+                                     GroupName="RadioBaseTheme"
+                                     IsChecked="{Binding !IsLightTheme}">
+                            <Border Margin="-50"
+                                    Background="#222222"
+                                    CornerRadius="{DynamicResource MediumCornerRadius}">
+                                <Grid>
+                                    <TextBlock Margin="58,42,42,42"
+                                               HorizontalAlignment="Center"
+                                               VerticalAlignment="Bottom"
+                                               FontWeight="DemiBold"
+                                               Foreground="#fafafa"
+                                               Text="Dark Mode" />
+                                </Grid>
+                            </Border>
+                        </RadioButton>
+                    </StackPanel>
+                </suki:SettingsLayoutItem.Content>
+            </suki:SettingsLayoutItem>
+
+            <suki:SettingsLayoutItem>
+                <suki:SettingsLayoutItem.Header>
+                    <TextBlock Text="Color Theme" />
+                </suki:SettingsLayoutItem.Header>
+                <suki:SettingsLayoutItem.Content>
+                    <ItemsControl HorizontalAlignment="Center" ItemsSource="{Binding AvailableColors}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
                                 <StackPanel HorizontalAlignment="Center"
                                             Orientation="Horizontal"
-                                            Spacing="20">
-                                    <RadioButton Width="180"
-                                                 Height="160"
-                                                 Padding="0"
-                                                 Classes="GigaChips"
-                                                 GroupName="RadioBaseTheme"
-                                                 IsChecked="{Binding IsLightTheme}">
-                                        <Border Margin="-50"
-                                                Background="#fafafa"
-                                                CornerRadius="{DynamicResource MediumCornerRadius}">
-                                            <Grid>
-                                                <TextBlock Margin="58,42,42,42"
-                                                           HorizontalAlignment="Center"
-                                                           VerticalAlignment="Bottom"
-                                                           FontWeight="DemiBold"
-                                                           Foreground="#555555"
-                                                           Text="Light Mode" />
-                                            </Grid>
-                                        </Border>
-                                    </RadioButton>
+                                            Spacing="10" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="suki:SukiColorTheme">
+                                <RadioButton Width="50"
+                                             Height="50"
+                                             Classes="GigaChips"
+                                             Command="{Binding ((theming:ThemingViewModel)DataContext).SwitchToColorThemeCommand, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type theming:ThemingView}}}"
+                                             CommandParameter="{Binding}"
+                                             CornerRadius="50"
+                                             GroupName="RadioColorTheme">
+                                    <Border Margin="-30"
+                                            Background="{Binding PrimaryBrush}"
+                                            CornerRadius="50" />
+                                </RadioButton>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </suki:SettingsLayoutItem.Content>
+            </suki:SettingsLayoutItem>
 
-                                    <RadioButton Width="180"
-                                                 Height="160"
-                                                 Classes="GigaChips"
-                                                 GroupName="RadioBaseTheme"
-                                                 IsChecked="{Binding !IsLightTheme}">
-                                        <Border Margin="-50"
-                                                Background="#222222"
-                                                CornerRadius="{DynamicResource MediumCornerRadius}">
-                                            <Grid>
-                                                <TextBlock Margin="58,42,42,42"
-                                                           HorizontalAlignment="Center"
-                                                           VerticalAlignment="Bottom"
-                                                           FontWeight="DemiBold"
-                                                           Foreground="#fafafa"
-                                                           Text="Dark Mode" />
-                                            </Grid>
-                                        </Border>
-                                    </RadioButton>
-                                </StackPanel>
-                            </suki:SettingsLayoutItem.Content>
-                        </suki:SettingsLayoutItem>
+            <suki:SettingsLayoutItem>
+                <suki:SettingsLayoutItem.Header>
+                    <TextBlock Text="Background" />
+                </suki:SettingsLayoutItem.Header>
+                <suki:SettingsLayoutItem.Content>
+                    <StackPanel>
+                        <suki:GlassCard Margin="0,25,0,0" Padding="25">
+                            <StackPanel Spacing="40">
+                                <DockPanel>
+                                    <ToggleSwitch VerticalAlignment="Top"
+                                                  Classes="Switch"
+                                                  DockPanel.Dock="Right"
+                                                  IsChecked="{Binding BackgroundAnimations}" />
+                                    <StackPanel HorizontalAlignment="Left">
+                                        <TextBlock FontSize="16"
+                                                   FontWeight="DemiBold"
+                                                   Text="Animated Background" />
+                                        <TextBlock Margin="0,12,70,0"
+                                                   Foreground="{DynamicResource SukiLowText}"
+                                                   Text="Enable/disable the animations for the background, which are driven by the currently active effect."
+                                                   TextWrapping="Wrap" />
+                                    </StackPanel>
+                                </DockPanel>
+                                <DockPanel>
+                                    <ToggleSwitch VerticalAlignment="Top"
+                                                  DockPanel.Dock="Right"
+                                                  IsChecked="{Binding BackgroundTransitions}" />
+                                    <StackPanel HorizontalAlignment="Left">
+                                        <TextBlock FontSize="16"
+                                                   FontWeight="DemiBold"
+                                                   Text="Background Transitions" />
+                                        <TextBlock Margin="0,12,70,0"
+                                                   Foreground="{DynamicResource SukiLowText}"
+                                                   Text="Enable/disable the transitions for the background, these will fade between the active effects when changed."
+                                                   TextWrapping="Wrap" />
+                                    </StackPanel>
+                                </DockPanel>
+                            </StackPanel>
+                        </suki:GlassCard>
+                        <suki:GlassCard Margin="0,45,0,0" Padding="25">
+                            <StackPanel Spacing="40">
+                                <DockPanel>
+                                    <ComboBox DockPanel.Dock="Right"
+                                              ItemsSource="{Binding AvailableBackgroundStyles}"
+                                              SelectedItem="{Binding BackgroundStyle}" />
+                                    <StackPanel HorizontalAlignment="Left">
+                                        <TextBlock FontSize="16"
+                                                   FontWeight="DemiBold"
+                                                   Text="Background Style" />
+                                        <TextBlock Margin="0,12,70,0"
+                                                   Foreground="{DynamicResource SukiLowText}"
+                                                   Text="Select from the included background styles."
+                                                   TextWrapping="Wrap" />
+                                    </StackPanel>
+                                </DockPanel>
+                                <DockPanel>
+                                    <StackPanel HorizontalAlignment="Left" DockPanel.Dock="Top">
+                                        <TextBlock FontSize="16"
+                                                   FontWeight="DemiBold"
+                                                   Text="Custom Shaders" />
+                                        <TextBlock Margin="0,12,70,0"
+                                                   Foreground="{DynamicResource SukiLowText}"
+                                                   Text="Click any of the buttons below to enable a background shader. Click it again to disable it. These are likely to put quite a load on your GPU and are purely to demonstrate and test the capabilities of the background renderer."
+                                                   TextWrapping="Wrap" />
+                                    </StackPanel>
+                                    <ItemsControl Margin="0,15,0,0" ItemsSource="{Binding CustomShaders}">
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <Button Margin="10"
+                                                        Command="{Binding $parent[theming:ThemingView].((theming:ThemingViewModel)DataContext).TryCustomShaderCommand}"
+                                                        CommandParameter="{Binding}"
+                                                        Content="{Binding}" />
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                        <ItemsControl.ItemsPanel>
+                                            <ItemsPanelTemplate>
+                                                <UniformGrid Rows="1" />
+                                            </ItemsPanelTemplate>
+                                        </ItemsControl.ItemsPanel>
+                                    </ItemsControl>
+                                </DockPanel>
+                            </StackPanel>
+                        </suki:GlassCard>
+                    </StackPanel>
+                </suki:SettingsLayoutItem.Content>
+            </suki:SettingsLayoutItem>
+        </generic:List>
+    </UserControl.Resources>
 
-                        <suki:SettingsLayoutItem Header="Color Theme">
-                            <suki:SettingsLayoutItem.Content>
-                                <ItemsControl HorizontalAlignment="Center" ItemsSource="{Binding AvailableColors}">
-                                    <ItemsControl.ItemsPanel>
-                                        <ItemsPanelTemplate>
-                                            <StackPanel HorizontalAlignment="Center"
-                                                        Orientation="Horizontal"
-                                                        Spacing="10" />
-                                        </ItemsPanelTemplate>
-                                    </ItemsControl.ItemsPanel>
-                                    <ItemsControl.ItemTemplate>
-                                        <DataTemplate x:DataType="suki:SukiColorTheme">
-                                            <RadioButton Width="50"
-                                                         Height="50"
-                                                         Classes="GigaChips"
-                                                         Command="{Binding ((theming:ThemingViewModel)DataContext).SwitchToColorThemeCommand, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type theming:ThemingView}}}"
-                                                         CommandParameter="{Binding}"
-                                                         CornerRadius="50"
-                                                         GroupName="RadioColorTheme">
-                                                <Border Margin="-30"
-                                                        Background="{Binding PrimaryBrush}"
-                                                        CornerRadius="50" />
-                                            </RadioButton>
-                                        </DataTemplate>
-                                    </ItemsControl.ItemTemplate>
-                                </ItemsControl>
-                            </suki:SettingsLayoutItem.Content>
-                        </suki:SettingsLayoutItem>
+    <suki:SukiStackPage Margin="20">
+        <suki:SukiStackPage.Content>
 
-                        <suki:SettingsLayoutItem Header="Background">
-                            <suki:SettingsLayoutItem.Content>
-                                <StackPanel>
-                                    <suki:GlassCard Margin="0,25,0,0" Padding="25">
-                                        <StackPanel Spacing="40">
-                                            <DockPanel>
-                                                <ToggleSwitch VerticalAlignment="Top"
-                                                              Classes="Switch"
-                                                              DockPanel.Dock="Right"
-                                                              IsChecked="{Binding BackgroundAnimations}" />
-                                                <StackPanel HorizontalAlignment="Left">
-                                                    <TextBlock FontSize="16"
-                                                               FontWeight="DemiBold"
-                                                               Text="Animated Background" />
-                                                    <TextBlock Margin="0,12,70,0"
-                                                               Foreground="{DynamicResource SukiLowText}"
-                                                               Text="Enable/disable the animations for the background, which are driven by the currently active effect."
-                                                               TextWrapping="Wrap" />
-                                                </StackPanel>
-                                            </DockPanel>
-                                            <DockPanel>
-                                                <ToggleSwitch VerticalAlignment="Top"
-                                                              DockPanel.Dock="Right"
-                                                              IsChecked="{Binding BackgroundTransitions}" />
-                                                <StackPanel HorizontalAlignment="Left">
-                                                    <TextBlock FontSize="16"
-                                                               FontWeight="DemiBold"
-                                                               Text="Background Transitions" />
-                                                    <TextBlock Margin="0,12,70,0"
-                                                               Foreground="{DynamicResource SukiLowText}"
-                                                               Text="Enable/disable the transitions for the background, these will fade between the active effects when changed."
-                                                               TextWrapping="Wrap" />
-                                                </StackPanel>
-                                            </DockPanel>
-
-                                        </StackPanel>
-                                    </suki:GlassCard>
-                                    <suki:GlassCard Margin="0,45,0,0" Padding="25">
-                                        <StackPanel Spacing="40">
-                                            <DockPanel>
-                                                <ComboBox DockPanel.Dock="Right"
-                                                          ItemsSource="{Binding AvailableBackgroundStyles}"
-                                                          SelectedItem="{Binding BackgroundStyle}" />
-                                                <StackPanel HorizontalAlignment="Left">
-                                                    <TextBlock FontSize="16"
-                                                               FontWeight="DemiBold"
-                                                               Text="Background Style" />
-                                                    <TextBlock Margin="0,12,70,0"
-                                                               Foreground="{DynamicResource SukiLowText}"
-                                                               Text="Select from the included background styles."
-                                                               TextWrapping="Wrap" />
-                                                </StackPanel>
-                                            </DockPanel>
-                                            <DockPanel>
-                                                <StackPanel HorizontalAlignment="Left" DockPanel.Dock="Top">
-                                                    <TextBlock FontSize="16"
-                                                               FontWeight="DemiBold"
-                                                               Text="Custom Shaders" />
-                                                    <TextBlock Margin="0,12,70,0"
-                                                               Foreground="{DynamicResource SukiLowText}"
-                                                               Text="Click any of the buttons below to enable a background shader. Click it again to disable it. These are likely to put quite a load on your GPU and are purely to demonstrate and test the capabilities of the background renderer."
-                                                               TextWrapping="Wrap" />
-                                                </StackPanel>
-                                                <ItemsControl Margin="0,15,0,0" ItemsSource="{Binding CustomShaders}">
-                                                    <ItemsControl.ItemTemplate>
-                                                        <DataTemplate>
-                                                            <Button Margin="10"
-                                                                    Command="{Binding $parent[theming:ThemingView].((theming:ThemingViewModel)DataContext).TryCustomShaderCommand}"
-                                                                    CommandParameter="{Binding}"
-                                                                    Content="{Binding}" />
-                                                        </DataTemplate>
-                                                    </ItemsControl.ItemTemplate>
-                                                    <ItemsControl.ItemsPanel>
-                                                        <ItemsPanelTemplate>
-                                                            <UniformGrid Rows="1" />
-                                                        </ItemsPanelTemplate>
-                                                    </ItemsControl.ItemsPanel>
-                                                </ItemsControl>
-                                            </DockPanel>
-                                        </StackPanel>
-                                    </suki:GlassCard>
-                                </StackPanel>
-                            </suki:SettingsLayoutItem.Content>
-                        </suki:SettingsLayoutItem>
-                    </objectModel:ObservableCollection>
-                </suki:SettingsLayout.Items>
-            </suki:SettingsLayout>
+            <suki:SettingsLayout Name="Theming" Items="{StaticResource Collection}" />
         </suki:SukiStackPage.Content>
     </suki:SukiStackPage>
 </UserControl>

--- a/SukiUI/Controls/Settings/SettingsLayout.axaml
+++ b/SukiUI/Controls/Settings/SettingsLayout.axaml
@@ -8,9 +8,9 @@
              d:DesignHeight="450"
              d:DesignWidth="800"
              mc:Ignorable="d">
+
     <UserControl.Styles>
         <Style Selector="RadioButton.MenuChip">
-
             <Setter Property="Background" Value="Transparent" />
             <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderMidBrush}" />
             <Setter Property="BorderThickness" Value="0" />
@@ -54,22 +54,17 @@
 
         <Style Selector="RadioButton.MenuChip:checked">
             <Setter Property="TextBlock.FontWeight" Value="{DynamicResource DefaultDemiBold}" />
-
             <Setter Property="BorderThickness" Value="0,0,0,0" />
             <Setter Property="BorderBrush" Value="{DynamicResource SukiPrimaryColor}" />
-
         </Style>
 
         <Style Selector="RadioButton.MenuChip:pointerover /template/ Border">
-
             <Setter Property="Background" Value="{DynamicResource SukiLightBackground}" />
-
         </Style>
 
         <Style Selector="RadioButton.MenuChip  TextBlock">
             <Setter Property="FontSize" Value="50" />
         </Style>
-
 
         <Style Selector="RadioButton.MenuChip:checked  TextBlock">
             <Setter Property="FontWeight" Value="{DynamicResource DefaultDemiBold}" />
@@ -95,11 +90,9 @@
 
         <Style Selector="RadioButton.MenuChip:checked /template/ Border">
             <Setter Property="Transitions">
-
                 <Transitions>
                     <BrushTransition Property="Background" Duration="0:0:0.15" />
                 </Transitions>
-
             </Setter>
 
             <Setter Property="TextBlock.FontWeight" Value="{DynamicResource DefaultDemiBold}" />
@@ -111,11 +104,9 @@
 
         <Style Selector="RadioButton.MenuChip /template/ ContentPresenter#PART_ContentPresenter">
             <Setter Property="Transitions">
-
                 <Transitions>
                     <ThicknessTransition Property="Margin" Duration="0:0:0.25" />
                 </Transitions>
-
             </Setter>
         </Style>
 
@@ -137,6 +128,5 @@
                 </ControlTemplate>
             </Setter>
         </Style>
-
     </UserControl.Styles>
 </UserControl>

--- a/SukiUI/Controls/Settings/SettingsLayout.axaml.cs
+++ b/SukiUI/Controls/Settings/SettingsLayout.axaml.cs
@@ -4,52 +4,27 @@ using Avalonia.Animation.Easings;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
-using Avalonia.Data;
 using Avalonia.LogicalTree;
 using Avalonia.Markup.Xaml;
 using Avalonia.Styling;
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace SukiUI.Controls;
 
-public class SettingsLayoutItem : Control
-{
-    public static readonly DirectProperty<SettingsLayoutItem, string?> HeaderProperty =
-        AvaloniaProperty.RegisterDirect<SettingsLayoutItem, string?>(
-            nameof(Header),
-            o => o.Header,
-            (o, v) => o.Header = v);
-
-    public string? Header
-    {
-        get { return _header; }
-        set { SetAndRaise(HeaderProperty, ref _header, value); }
-    }
-
-    private string? _header;
-
-    public static readonly DirectProperty<SettingsLayoutItem, Control?> ContentProperty =
-    AvaloniaProperty.RegisterDirect<SettingsLayoutItem, Control?>(
-        nameof(Content),
-        o => o.Content,
-        (o, v) => o.Content = v);
-
-    public Control? Content
-    {
-        get { return _content; }
-        set { SetAndRaise(ContentProperty, ref _content, value); }
-    }
-
-    private Control? _content;
-}
-
 public partial class SettingsLayout : UserControl
 {
+    public static readonly DirectProperty<SettingsLayout, IEnumerable<SettingsLayoutItem>> ItemsProperty =
+    AvaloniaProperty.RegisterDirect<SettingsLayout, IEnumerable<SettingsLayoutItem>>(
+        nameof(Items),
+        o => o.Items);
+
+    private IEnumerable<SettingsLayoutItem> _bounds;
+
+    public IEnumerable<SettingsLayoutItem> Items
+    {
+        get { return _bounds; }
+        set { SetAndRaise(ItemsProperty, ref _bounds, value); }
+    }
+
     public static readonly DirectProperty<SettingsLayout, double> MinWidthWhetherStackShowProperty =
         AvaloniaProperty.RegisterDirect<SettingsLayout, double>(
             nameof(MinWidthWhetherStackSummaryShow), o => o.MinWidthWhetherStackSummaryShow,
@@ -63,16 +38,6 @@ public partial class SettingsLayout : UserControl
         InitializeComponent();
     }
 
-    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
-    {
-        base.OnApplyTemplate(e);
-        UpdateItems();
-    }
-
-    protected override void OnDetachedFromLogicalTree(LogicalTreeAttachmentEventArgs e)
-    {
-    }
-
     private void InitializeComponent()
     {
         AvaloniaXamlLoader.Load(this);
@@ -81,13 +46,13 @@ public partial class SettingsLayout : UserControl
     private double _minWidthWhetherStackSummaryShow = 1100;
 
     /// <summary>
-    /// Get or set a value that represents the minimum width for displaying the StackSummary in the SettingsLayout. 
+    /// Get or set a value that represents the minimum width for displaying the StackSummary in the SettingsLayout.
     /// If the width of the SettingsLayout is less than this value, the StackSummary will not be displayed.
     /// The default value is 1100, and the minimum configurable value is 1.
     /// </summary>
     public double MinWidthWhetherStackSummaryShow
     {
-        get=> _minWidthWhetherStackSummaryShow;
+        get => _minWidthWhetherStackSummaryShow;
         set
         {
             if (value < 1)
@@ -114,18 +79,14 @@ public partial class SettingsLayout : UserControl
         }
     }
 
-    private ObservableCollection<SettingsLayoutItem> _items;
-
-    public static readonly DirectProperty<SettingsLayout, ObservableCollection<SettingsLayoutItem>> StepsProperty =
-        AvaloniaProperty.RegisterDirect<SettingsLayout, ObservableCollection<SettingsLayoutItem>>(nameof(Items),
-            l => l.Items,
-            (numpicker, v) => { numpicker.Items = v; }, defaultBindingMode: BindingMode.TwoWay,
-            enableDataValidation: true);
-
-    public ObservableCollection<SettingsLayoutItem> Items
+    protected override void OnDetachedFromLogicalTree(LogicalTreeAttachmentEventArgs e)
     {
-        get { return _items; }
-        set { SetAndRaise(StepsProperty, ref _items, value); }
+    }
+
+    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+    {
+        base.OnApplyTemplate(e);
+        UpdateItems();
     }
 
     private void UpdateItems()
@@ -135,14 +96,14 @@ public partial class SettingsLayout : UserControl
             return;
         }
 
-        var stackSummary = (StackPanel)this.GetTemplateChildren().First(n => n.Name == "StackSummary");
-        var myScroll = (ScrollViewer)this.GetTemplateChildren().First(n => n.Name == "MyScroll");
+        var stackSummary = this.GetTemplateChildren().First(n => n.Name == "StackSummary") as StackPanel;
+        var myScroll = this.GetTemplateChildren().First(n => n.Name == "MyScroll") as ScrollViewer;
 
-        if (myScroll.Content is not StackPanel stackItems)
+        if (myScroll?.Content is not StackPanel stackItems)
             return;
 
-        stackItems.Children.Clear();
-        stackSummary.Children.Clear();
+        if (stackSummary is not StackPanel)
+            return;
 
         var radios = new List<RadioButton>();
         var borders = new List<Border>();
@@ -151,12 +112,17 @@ public partial class SettingsLayout : UserControl
 
         foreach (var settingsLayoutItem in Items)
         {
+            if (settingsLayoutItem.Header is null)
+            {
+                continue;
+            }
+
             var border = new Border
             {
                 Child = new GroupBox()
                 {
                     Margin = new Thickness(10, 20),
-                    Header = new TextBlock() { Text = settingsLayoutItem.Header },
+                    Header = settingsLayoutItem.Header,
                     Content = new Border()
                     {
                         Margin = new Thickness(35, 12),
@@ -170,8 +136,8 @@ public partial class SettingsLayout : UserControl
 
             var summaryButton = new RadioButton()
             {
-                Content = new TextBlock() { Text = settingsLayoutItem.Header, FontSize = 17 },
-                Classes = {  "MenuChip" }
+                Content = new TextBlock() { [!TextBlock.TextProperty] = settingsLayoutItem.Header[!TextBlock.TextProperty], FontSize = 17 },
+                Classes = { "MenuChip" }
             };
             summaryButton.Click += async (sender, args) =>
             {
@@ -200,11 +166,9 @@ public partial class SettingsLayout : UserControl
         };
     }
 
-    private Mutex mut = new Mutex();
-
     private double LastDesiredSize = -1;
 
-    private async void DockPanel_SizeChanged(object sender, SizeChangedEventArgs e)
+    private void DockPanel_SizeChanged(object sender, SizeChangedEventArgs e)
     {
         var stack = this.GetTemplateChildren().First(n => n.Name == "StackSummary");
         var desiredSize = e.NewSize.Width > MinWidthWhetherStackSummaryShow ? StackSummaryWidth : 0;
@@ -218,8 +182,6 @@ public partial class SettingsLayout : UserControl
             stack.Animate<double>(WidthProperty, stack.Width, desiredSize, TimeSpan.FromMilliseconds(800));
     }
 
-    private bool isAnimatingWidth = false;
-    private bool isAnimatingMargin = false;
     private bool isAnimatingScroll = false;
 
     private async Task AnimateScroll(double desiredScroll)

--- a/SukiUI/Controls/Settings/SettingsLayout.axaml.cs
+++ b/SukiUI/Controls/Settings/SettingsLayout.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Animation.Easings;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
+using Avalonia.Data;
 using Avalonia.LogicalTree;
 using Avalonia.Markup.Xaml;
 using Avalonia.Styling;
@@ -117,12 +118,18 @@ public partial class SettingsLayout : UserControl
                 continue;
             }
 
+            var header = new TextBlock();
+            header.Bind(TextBlock.TextProperty, new Binding(nameof(SettingsLayoutItem.Header))
+            {
+                Source = settingsLayoutItem
+            });
+
             var border = new Border
             {
                 Child = new GroupBox()
                 {
                     Margin = new Thickness(10, 20),
-                    Header = settingsLayoutItem.Header,
+                    Header = header,
                     Content = new Border()
                     {
                         Margin = new Thickness(35, 12),
@@ -134,9 +141,15 @@ public partial class SettingsLayout : UserControl
             borders.Add(border);
             stackItems.Children.Add(border);
 
+            var textBlock = new TextBlock { FontSize = 17 };
+            textBlock.Bind(TextBlock.TextProperty, new Binding(nameof(SettingsLayoutItem.Header))
+            {
+                Source = settingsLayoutItem
+            });
+
             var summaryButton = new RadioButton()
             {
-                Content = new TextBlock() { [!TextBlock.TextProperty] = settingsLayoutItem.Header[!TextBlock.TextProperty], FontSize = 17 },
+                Content = textBlock,
                 Classes = { "MenuChip" }
             };
             summaryButton.Click += async (sender, args) =>

--- a/SukiUI/Controls/Settings/SettingsLayoutItem.cs
+++ b/SukiUI/Controls/Settings/SettingsLayoutItem.cs
@@ -5,19 +5,19 @@ namespace SukiUI.Controls;
 
 public class SettingsLayoutItem : Control
 {
-    public static readonly DirectProperty<SettingsLayoutItem, TextBlock?> HeaderProperty =
-        AvaloniaProperty.RegisterDirect<SettingsLayoutItem, TextBlock?>(
+    public static readonly DirectProperty<SettingsLayoutItem, string?> HeaderProperty =
+        AvaloniaProperty.RegisterDirect<SettingsLayoutItem, string?>(
             nameof(Header),
             o => o.Header,
             (o, v) => o.Header = v);
 
-    public TextBlock? Header
+    public string? Header
     {
         get { return _header; }
         set { SetAndRaise(HeaderProperty, ref _header, value); }
     }
 
-    private TextBlock? _header;
+    private string? _header;
 
     public static readonly DirectProperty<SettingsLayoutItem, Control?> ContentProperty =
     AvaloniaProperty.RegisterDirect<SettingsLayoutItem, Control?>(

--- a/SukiUI/Controls/Settings/SettingsLayoutItem.cs
+++ b/SukiUI/Controls/Settings/SettingsLayoutItem.cs
@@ -1,0 +1,35 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+
+namespace SukiUI.Controls;
+
+public class SettingsLayoutItem : Control
+{
+    public static readonly DirectProperty<SettingsLayoutItem, TextBlock?> HeaderProperty =
+        AvaloniaProperty.RegisterDirect<SettingsLayoutItem, TextBlock?>(
+            nameof(Header),
+            o => o.Header,
+            (o, v) => o.Header = v);
+
+    public TextBlock? Header
+    {
+        get { return _header; }
+        set { SetAndRaise(HeaderProperty, ref _header, value); }
+    }
+
+    private TextBlock? _header;
+
+    public static readonly DirectProperty<SettingsLayoutItem, Control?> ContentProperty =
+    AvaloniaProperty.RegisterDirect<SettingsLayoutItem, Control?>(
+        nameof(Content),
+        o => o.Content,
+        (o, v) => o.Content = v);
+
+    public Control? Content
+    {
+        get { return _content; }
+        set { SetAndRaise(ContentProperty, ref _content, value); }
+    }
+
+    private Control? _content;
+}


### PR DESCRIPTION
~~**Breaking changes**~~
- ~~turn SettingsLayoutItem Header into TextBlock (instead of string)~~

**What**
- ~~use SettingsLayoutItem Header as direct content in the settings collection~~
- bind SettingsLayoutItem Header to header in the navigation panel /stack summary panel
- bind SettingsLayoutItem Headers to headers in the Scrollviewer StackPanel
- use IEnumerable<SettingsLayoutItem> for SettingsLayout.Items since there is no support for updating them
- removed some useless code

**Why**
- addresses #432 