### PR TITLE
Dialog fixes and improvements.

### DIFF
--- a/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsView.axaml
@@ -75,6 +75,13 @@
                     </suki:GroupBox>
                 </suki:GlassCard>
                 <suki:GlassCard>
+                    <suki:GroupBox Header="ViewModel With Action Buttons Dialog">
+                        <Button VerticalAlignment="Top" Margin="15,10,15,0"
+                                Command="{Binding OpenViewModelWithActionButtonsDialogCommand}"
+                                Content="Show Dialog" />
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
                     <suki:GroupBox Header="Window Dialog Demo">
                         <Button VerticalAlignment="Top" Margin="15,10,15,0"
                                 Command="{Binding OpenDialogWindowDemoCommand}"

--- a/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsViewModel.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsViewModel.cs
@@ -92,6 +92,17 @@ public partial class DialogsViewModel(ISukiDialogManager dialogManager, ISukiToa
     }
 
     [RelayCommand]
+    private void OpenViewModelWithActionButtonsDialog()
+    {
+        dialogManager.CreateDialog()
+            .OfType(NotificationType.Warning)
+            .WithTitle("Dialog with content set to a VM")
+            .WithViewModel(dialog => new VmDialogViewModel(dialog), false)
+            .WithActionButton("Extra Close Button", _ => { }, true, "Flat")
+            .TryShow();
+    }
+
+    [RelayCommand]
     private void OpenDialogWindowDemo() => new DialogWindowDemo(dialogManager).Show();
         
 }

--- a/SukiUI/Controls/SukiDialog.axaml
+++ b/SukiUI/Controls/SukiDialog.axaml
@@ -3,77 +3,78 @@
                     xmlns:suki="https://github.com/kikipoulet/SukiUI"
                     xmlns:dialogs="clr-namespace:SukiUI.Dialogs">
     <ControlTheme TargetType="suki:SukiDialog" x:Key="SukiDialogTheme">
-        <Setter Property="ClipToBounds" Value="False"/> 
+        <Setter Property="ClipToBounds" Value="False" />
         <Setter Property="Template">
             <ControlTemplate>
                 <Panel>
-                    
-                    <Border Padding="0"  Margin="0,55,0,0"
-                            ClipToBounds="True"  MinWidth="450" 
-                            
+                    <Border Padding="0" 
+                            Margin="0,55,0,0"
+                            ClipToBounds="True" 
+                            MinWidth="450"
                             CornerRadius="25">
                         <Panel>
-                            
-                            <Border IsVisible="{TemplateBinding ShowCardBackground}" CornerRadius="25" Background="{DynamicResource SukiCardBackground}">
+                            <Border IsVisible="{TemplateBinding ShowCardBackground}" CornerRadius="25"
+                                    Background="{DynamicResource SukiCardBackground}">
                                 <Panel Background="{DynamicResource PopupGradientBrush}" Margin="-5">
-                               
                                 </Panel>
-                        
                             </Border>
-
-
-
                             <Grid RowDefinitions="Auto,Auto,*,Auto"
                                   ColumnDefinitions="*"
-                                  Margin="30,30,30,5" 
+                                  Margin="30,30,30,5"
                                   IsVisible="{Binding !IsViewModelOnly, RelativeSource={RelativeSource TemplatedParent}}">
-                                  
-                                <Border Grid.Row="0" Margin="0,10,0,0" IsVisible="{TemplateBinding IconColor, Converter={x:Static ObjectConverters.IsNotNull}}"></Border>
-                                  <TextBlock Grid.Row="1" Margin="0,24,0,0" IsVisible="{TemplateBinding Title,Converter={x:Static StringConverters.IsNotNullOrEmpty}}" HorizontalAlignment="Center" FontSize="22" FontWeight="DemiBold" Text="{TemplateBinding Title}" />
-                                  <ContentControl Grid.Row="2" Margin="0,24,0,0" MaxWidth="{TemplateBinding Content, Converter={x:Static dialogs:DialogContentMaxWidthValueConverter.Instance}}" Content="{TemplateBinding Content}" >
-                                      <ContentControl.Styles>
-                                          <Style Selector="TextBlock">
-                                              <Setter  Property="FontSize" Value="14" />
-                                              <Setter  Property="TextWrapping" Value="Wrap" />
-                                          </Style>
-                                      </ContentControl.Styles>
-                                  </ContentControl>
-                                  <ItemsControl Grid.Row="3" Margin="0,26,0,0" ItemsSource="{TemplateBinding ActionButtons}">
-                                      <ItemsControl.Styles>
-                                          <Style Selector="Button">
-                                              <Setter Property="Margin" Value="15,0,0,25" />
-                                          </Style>
-                                      </ItemsControl.Styles>
-                                      <ItemsControl.ItemsPanel>
-                                          <ItemsPanelTemplate>
-                                              <StackPanel Orientation="Horizontal" HorizontalAlignment="Right"/>
-                                          </ItemsPanelTemplate>
-                                      </ItemsControl.ItemsPanel>
-
-                                  </ItemsControl>
+                                <Border Grid.Row="0" Margin="0,10,0,0"
+                                        IsVisible="{TemplateBinding IconColor, Converter={x:Static ObjectConverters.IsNotNull}}">
+                                </Border>
+                                <TextBlock Grid.Row="1" Margin="0,24,0,0"
+                                           IsVisible="{TemplateBinding Title,Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                                           HorizontalAlignment="Center" FontSize="22" FontWeight="DemiBold"
+                                           Text="{TemplateBinding Title}" />
+                                <ContentControl Grid.Row="2" Margin="0,24,0,0"
+                                                MaxWidth="{TemplateBinding Content, Converter={x:Static dialogs:DialogContentMaxWidthValueConverter.Instance}}"
+                                                Content="{TemplateBinding Content}">
+                                    <ContentControl.Styles>
+                                        <Style Selector="TextBlock">
+                                            <Setter Property="FontSize" Value="14" />
+                                            <Setter Property="TextWrapping" Value="Wrap" />
+                                        </Style>
+                                    </ContentControl.Styles>
+                                </ContentControl>
+                                <ItemsControl Grid.Row="3" Margin="0,26,0,0"
+                                              ItemsSource="{TemplateBinding ActionButtons}">
+                                    <ItemsControl.Styles>
+                                        <Style Selector="Button">
+                                            <Setter Property="Margin" Value="15,0,0,25" />
+                                        </Style>
+                                    </ItemsControl.Styles>
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" />
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                </ItemsControl>
                             </Grid>
-                        
                             <ContentControl Content="{TemplateBinding ViewModel}" Margin="15"
                                             IsVisible="{TemplateBinding IsViewModelOnly}" />
                         </Panel>
                     </Border>
-                    <Border CornerRadius="50"  HorizontalAlignment="Center"
-                                    VerticalAlignment="Top" 
-                                    Margin="-15,-15,0,0" Width="100" Height="100">
-                    <Panel >
-                        <Border Width="90" HorizontalAlignment="Center"
-                                Height="100"
-                                IsVisible="{TemplateBinding IconColor, Converter={x:Static ObjectConverters.IsNotNull}}"
-                      
-                                BoxShadow="{DynamicResource SukiBigPopupShadow}"
-                                CornerRadius="50" />
-                        <Ellipse HorizontalAlignment="Center" VerticalAlignment="Center" Width="100" Height="100" Fill="{TemplateBinding IconColor}"/>
-                        <PathIcon HorizontalAlignment="Center" VerticalAlignment="Center" Data="{TemplateBinding Icon}"
-                                  Foreground="White"
-                                  Width="28"
-                                  Height="28" />
-                        
-                    </Panel>
+                    <Border CornerRadius="50" HorizontalAlignment="Center"
+                            VerticalAlignment="Top"
+                            Margin="-15,-15,0,0" Width="100" Height="100">
+                        <Panel>
+                            <Border Width="90" HorizontalAlignment="Center"
+                                    Height="100"
+                                    IsVisible="{TemplateBinding IconColor, Converter={x:Static ObjectConverters.IsNotNull}}"
+
+                                    BoxShadow="{DynamicResource SukiBigPopupShadow}"
+                                    CornerRadius="50" />
+                            <Ellipse HorizontalAlignment="Center" VerticalAlignment="Center" Width="100" Height="100"
+                                     Fill="{TemplateBinding IconColor}" />
+                            <PathIcon HorizontalAlignment="Center" VerticalAlignment="Center"
+                                      Data="{TemplateBinding Icon}"
+                                      Foreground="White"
+                                      Width="28"
+                                      Height="28" />
+                        </Panel>
                     </Border>
                 </Panel>
             </ControlTemplate>

--- a/SukiUI/Controls/SukiDialog.cs
+++ b/SukiUI/Controls/SukiDialog.cs
@@ -35,7 +35,7 @@ namespace SukiUI.Controls
 
         public static readonly StyledProperty<bool> IsViewModelOnlyProperty = AvaloniaProperty.Register<SukiDialog, bool>(nameof(IsViewModelOnly));
 
-        internal bool IsViewModelOnly
+        public bool IsViewModelOnly
         {
             get => GetValue(IsViewModelOnlyProperty);
             set => SetValue(IsViewModelOnlyProperty, value);
@@ -81,15 +81,18 @@ namespace SukiUI.Controls
         
         public SukiDialog()
         {
-            ActionButtons = new ObservableCollection<object>();
+            ActionButtons = [];
         }
         
         public void Dismiss() => Manager?.TryDismissDialog(this);
-        
-        protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+
+        public void ResetToDefault()
         {
-            base.OnApplyTemplate(e);
-            IsViewModelOnly = ViewModel != null;
+            ActionButtons.Clear();
+            ViewModel = null;
+            Title = null;
+            Content = null;
+            IsViewModelOnly = false;
         }
     }
 }

--- a/SukiUI/Dialogs/FluentSukiDialogBuilder.cs
+++ b/SukiUI/Dialogs/FluentSukiDialogBuilder.cs
@@ -52,9 +52,9 @@ namespace SukiUI.Dialogs
         /// Gives the dialog a ViewModel. If this is used, Title/Content are ignored and only the ViewModel is rendered - the View being located by the usual strategy.
         /// This is useful for custom dialogs.
         /// </summary>
-        public static SukiDialogBuilder WithViewModel(this SukiDialogBuilder builder, Func<ISukiDialog,object> viewModel)
+        public static SukiDialogBuilder WithViewModel(this SukiDialogBuilder builder, Func<ISukiDialog,object> viewModel, bool isViewModelOnly = true)
         {
-            builder.SetViewModel(viewModel);
+            builder.SetViewModel(viewModel, isViewModelOnly);
             return builder;
         }
 

--- a/SukiUI/Dialogs/ISukiDialog.cs
+++ b/SukiUI/Dialogs/ISukiDialog.cs
@@ -11,11 +11,13 @@ namespace SukiUI.Dialogs
         string? Title { get; set; }
         object? Content { get; set; }
         object? Icon { get; set; }
+        bool IsViewModelOnly { get; set; }
         IBrush? IconColor { get; set; }
         ObservableCollection<object> ActionButtons { get; }
         Action<ISukiDialog>? OnDismissed { get; set; }
         bool CanDismissWithBackgroundClick { get; set; }
         bool ShowCardBackground { get; set; }
         void Dismiss();
+        void ResetToDefault();
     }
 }

--- a/SukiUI/Dialogs/SukiDialogBuilder.cs
+++ b/SukiUI/Dialogs/SukiDialogBuilder.cs
@@ -28,9 +28,18 @@ namespace SukiUI.Dialogs
 
         public void SetContent(object content) => Dialog.Content = content;
 
-        public void SetViewModel(Func<ISukiDialog,object> viewModel)
+        public void SetViewModel(Func<ISukiDialog,object> viewModel, bool isViewModelOnly)
         {
-            Dialog.ViewModel = viewModel(Dialog);
+            if (isViewModelOnly)
+            {
+                Dialog.ViewModel = viewModel(Dialog);
+                Dialog.IsViewModelOnly = true;
+            }
+            else
+            {
+                Dialog.Content = viewModel(Dialog);
+                Dialog.IsViewModelOnly = false;
+            }
         }
         
         public void SetType(NotificationType notificationType)

--- a/SukiUI/Dialogs/SukiDialogManager.cs
+++ b/SukiUI/Dialogs/SukiDialogManager.cs
@@ -1,3 +1,5 @@
+using SukiUI.Helpers;
+
 namespace SukiUI.Dialogs
 {
     public class SukiDialogManager : ISukiDialogManager

--- a/SukiUI/Helpers/DialogPool.cs
+++ b/SukiUI/Helpers/DialogPool.cs
@@ -7,20 +7,29 @@ namespace SukiUI.Helpers
 {
     internal static class DialogPool
     {
-        private static readonly ConcurrentBag<ISukiDialog> Pool = new();
+        private static readonly ConcurrentStack<ISukiDialog> Pool = new();
+
+        static DialogPool()
+        {
+            Pool.Push(new SukiDialog());
+            Pool.Push(new SukiDialog());
+        }
         
         internal static ISukiDialog Get()
         {
-            var dialog = Pool.TryTake(out var item) ? item : new SukiDialog();
-            return dialog;//.ResetToDefault();
+            var dialog = Pool.TryPop(out var item) ? item : new SukiDialog();
+            dialog.ResetToDefault();
+            return dialog;
         }
 
-        internal static void Return(ISukiDialog toast) => Pool.Add(toast);
+        internal static void Return(ISukiDialog dialog) => Pool.Push(dialog);
 
         internal static void Return(IEnumerable<ISukiDialog> dialogs)
         {
             foreach (var dialog in dialogs)
-                Pool.Add(dialog);
+            {
+                Pool.Push(dialog);
+            }
         }
     }
 }


### PR DESCRIPTION
### Changes
- Now actually returns dialogs to the pool and reuses them.
  - It statically creates 2 at initialisation, without this we'd need to synchronise the animation system up with returning it to the pool, and I'd rather not do that.
- Dialogs can optionally use a ViewModel as content now by setting the `WithViewModel` optional parameter to false - Fixes: #441
- Tidy up the formatting a bit in SukiDialog.axaml