### PR TITLE
Full Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release
+
+on:
+  push:
+    tags: 
+      - "*.*.*"
+
+env:
+  VERSION: ${{ github.ref_name }}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Build
+        run: |
+          dotnet build -c Release SukiUI/SukiUI.csproj -p:Version=${{ env.VERSION }}
+          dotnet build -c Release SukiUI.Dock/SukiUI.Dock.csproj -p:Version=${{ env.VERSION }}
+
+      - name: Pack
+        run: |
+          dotnet pack -c Release -o . SukiUI/SukiUI.csproj -p:Version=${{ env.VERSION }}
+          dotnet pack -c Release -o . SukiUI.Dock/SukiUI.Dock.csproj -p:Version=${{ env.VERSION }}
+          ls
+
+      - name: Publish NuGet Package
+        run: dotnet nuget push *.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >
+          gh release create ${{ env.VERSION }}
+          --repo ${{ github.event.repository.full_name }}
+          --title ${{ env.VERSION }}
+          --verify-tag
+          --generate-notes

--- a/SukiUI.Dock/SukiUI.Dock.csproj
+++ b/SukiUI.Dock/SukiUI.Dock.csproj
@@ -2,13 +2,11 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>6.0.0-beta7</Version>
   </PropertyGroup>
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>6.0.0-beta7</PackageVersion>
     <PackageDescription></PackageDescription>
     <PackageTags>avalonia;avaloniaui;ui;theme;dock;docking;sukiui</PackageTags>
     <PackageProjectUrl>https://github.com/kikipoulet/SukiUI</PackageProjectUrl>

--- a/SukiUI/SukiUI.csproj
+++ b/SukiUI/SukiUI.csproj
@@ -4,9 +4,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <RootNamespace>SukiUI</RootNamespace>
-    <Version>5.0.4</Version>
-    <FileVersion>2.0.0</FileVersion>
-    <AssemblyVersion>2.0.0</AssemblyVersion>
     <UserSecretsId>712f85e4-12d3-41b0-a417-5714a113666f</UserSecretsId>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
@@ -14,7 +11,6 @@
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>6.0.0-beta8</PackageVersion>
     <PackageDescription></PackageDescription>
     <PackageTags>avalonia;avaloniaui;ui;theme;sukiui</PackageTags>
     <PackageProjectUrl>https://github.com/kikipoulet/SukiUI</PackageProjectUrl>


### PR DESCRIPTION
## Overview
Adds a GitHub Actions workflow that automates the release process. Push a tag (e.g., `6.0.2`) and the workflow automatically builds the project, creates a GitHub Release, and publishes to NuGet.

## Required Setup
Before using this workflow, repository administrators need to:

1. Enable workflow write permissions:
   - Navigate to: Repository Settings → Actions → General → Workflow permissions
   - Select: "Read and write permissions"

2. Configure NuGet publishing:
   - Generate a NuGet API key
   - Add it as a repository secret:
     - Navigate to: Settings → Secrets and variables → Actions
     - Create new secret named: `NUGET_API_KEY`

## Usage
Simply push a tag (e.g., `6.0.2`) to trigger the automated release process.