### PR TITLE
Fix demo on linux and housekeeping

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,28 +3,29 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Avalonia.AvaloniaEdit" Version="11.1.0" />
-    <PackageVersion Include="Avalonia.Controls.ColorPicker" Version="11.2.4" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.2.4" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.2.4" />
+    <PackageVersion Include="Avalonia.AvaloniaEdit" Version="11.2.0" />
+    <PackageVersion Include="Avalonia.Controls.ColorPicker" Version="11.2.5" />
+    <PackageVersion Include="Avalonia.Desktop" Version="11.2.5" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.2.5" />
     <PackageVersion Include="Avalonia.Diagnostics" Version="11.2.1" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.2.4" />
-    <PackageVersion Include="AvaloniaEdit.TextMate" Version="11.1.0" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.2.5" />
+    <PackageVersion Include="AvaloniaEdit.TextMate" Version="11.2.0" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-    <PackageVersion Include="Dock.Model" Version="11.2.0" />
-    <PackageVersion Include="Dock.Model.Mvvm" Version="11.2.0" />
-    <PackageVersion Include="Dock.Serializer" Version="11.2.0" />
+    <PackageVersion Include="Dock.Model" Version="11.2.0.2" />
+    <PackageVersion Include="Dock.Model.Mvvm" Version="11.2.0.2" />
+    <PackageVersion Include="Dock.Serializer" Version="11.2.0.2" />
     <PackageVersion Include="Material.Icons.Avalonia" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.2" />
     <PackageVersion Include="ShowMeTheXaml.Avalonia" Version="1.5.1" />
     <PackageVersion Include="ShowMeTheXaml.Avalonia.Generator" Version="1.5.1" />
-    <PackageVersion Include="Avalonia" Version="11.2.4" />
-    <PackageVersion Include="Avalonia.Skia" Version="11.2.4" />
+    <PackageVersion Include="Avalonia" Version="11.2.5" />
+    <PackageVersion Include="Avalonia.Skia" Version="11.2.5" />
     <PackageVersion Include="SkiaSharp" Version="3.118.0-preview.2.3" />
-    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.2.4" />
-    <PackageVersion Include="Avalonia.Themes.Simple" Version="11.2.4" />
-    <PackageVersion Include="Dock.Avalonia" Version="11.2.0" />
-    <PackageVersion Include="Dock.Model.Avalonia" Version="11.2.0" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.118.0-preview.2.3" />
+    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.2.5" />
+    <PackageVersion Include="Avalonia.Themes.Simple" Version="11.2.5" />
+    <PackageVersion Include="Dock.Avalonia" Version="11.2.0.2" />
+    <PackageVersion Include="Dock.Model.Avalonia" Version="11.2.0.2" />
     <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.6.0.2" />
     <PackageVersion Include="System.Text.Json" Version="9.0.2" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Avalonia.AvaloniaEdit" Version="11.2.0" />

--- a/SukiUI.Demo/SukiUI.Demo.csproj
+++ b/SukiUI.Demo/SukiUI.Demo.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="ShowMeTheXaml.Avalonia" />
     <PackageReference Include="ShowMeTheXaml.Avalonia.Generator" />
     <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SukiUI/SukiUI.csproj
+++ b/SukiUI/SukiUI.csproj
@@ -26,9 +26,6 @@
     <PackageReference Include="System.Linq.Dynamic.Core" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(RuntimeIdentifier.StartsWith('linux'))">
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
-  </ItemGroup>
 
   <ItemGroup>
     <AvaloniaResource Include="**\*.xaml" />
@@ -121,9 +118,4 @@
     <None Remove="Content\Shaders\Background\backgroundshadcn.sksl" />
     <EmbeddedResource Include="Content\Shaders\Background\backgroundshadcn.sksl" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageVersion Update="SkiaSharp.NativeAssets.Linux" />
-  </ItemGroup>
-
 </Project>

--- a/SukiUI/SukiUI.csproj
+++ b/SukiUI/SukiUI.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="SkiaSharp" />
     <PackageReference Include="Avalonia.Controls.DataGrid" />
     <PackageReference Include="Avalonia.Themes.Simple" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
     <PackageReference Include="System.Linq.Dynamic.Core" />
   </ItemGroup>
 

--- a/SukiUI/SukiUI.csproj
+++ b/SukiUI/SukiUI.csproj
@@ -23,8 +23,11 @@
     <PackageReference Include="SkiaSharp" />
     <PackageReference Include="Avalonia.Controls.DataGrid" />
     <PackageReference Include="Avalonia.Themes.Simple" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
     <PackageReference Include="System.Linq.Dynamic.Core" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(RuntimeIdentifier.StartsWith('linux'))">
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SukiUI/SukiUI.csproj
+++ b/SukiUI/SukiUI.csproj
@@ -119,4 +119,8 @@
     <EmbeddedResource Include="Content\Shaders\Background\backgroundshadcn.sksl" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageVersion Update="SkiaSharp.NativeAssets.Linux" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
**What**
- updated all avalonia nuget packages to latest stable release (11.2.5)
- updated Dock nuget packages to latest stable release (11.2.0.2)
- added reference for `SkiaSharp.NativeAssets.Linux` with the same version as `SkiaSharp` (3.118.0-preview.2.3) to demo app
  - idk why we are referencing a preview version of skiasharp, but i'm pretty sure this breaks the demo app
- enabled transitive pinning, which makes sure we use the same version for every transitive dependency as defined in the `Directory.Packages.props`. Details [here](https://learn.microsoft.com/en-us/nuget/consume-packages/Central-Package-Management#transitive-pinning)

**Why**
- adresses #445 

