### PR TITLE
Allow sidemenu content to be disabled

### DIFF
--- a/SukiUI.Demo/SukiUIDemoView.axaml
+++ b/SukiUI.Demo/SukiUIDemoView.axaml
@@ -277,7 +277,9 @@
     </suki:SukiWindow.MenuItems>
     <suki:SukiSideMenu IsSearchEnabled="True"
                        ItemsSource="{Binding DemoPages}"
-                       SelectedItem="{Binding ActivePage}">
+                       SelectedItem="{Binding ActivePage}"
+                       IsContentVisible="False"
+                       >
         <suki:SukiSideMenu.Styles>
             <Style Selector="Image.AppIcon">
                 <Setter Property="Transitions">

--- a/SukiUI.Demo/SukiUIDemoView.axaml
+++ b/SukiUI.Demo/SukiUIDemoView.axaml
@@ -278,7 +278,6 @@
     <suki:SukiSideMenu IsSearchEnabled="True"
                        ItemsSource="{Binding DemoPages}"
                        SelectedItem="{Binding ActivePage}"
-                       IsContentVisible="False"
                        >
         <suki:SukiSideMenu.Styles>
             <Style Selector="Image.AppIcon">

--- a/SukiUI/Controls/SukiSideMenu.axaml
+++ b/SukiUI/Controls/SukiSideMenu.axaml
@@ -129,7 +129,7 @@
                             Margin="0,0,0,0"
                             Background="{DynamicResource SukiBackground}"
                             BorderBrush="{DynamicResource SukiBorderBrush}"
-                            BorderThickness="0,0,0,0">
+                            BorderThickness="0,0,0,0" IsVisible="{TemplateBinding IsContentVisible}">
                         <suki:SukiTransitioningContentControl Name="PART_TransitioningContentControl" />
                     </Border>
                 </SplitView>

--- a/SukiUI/Controls/SukiSideMenu.axaml.cs
+++ b/SukiUI/Controls/SukiSideMenu.axaml.cs
@@ -21,10 +21,19 @@ public class SukiSideMenu : TreeView
 
     public static readonly StyledProperty<bool> IsSearchEnabledProperty =
         AvaloniaProperty.Register<SukiSideMenu, bool>(nameof(IsSearchEnabled), defaultValue: false);
+    
+    public static readonly StyledProperty<bool> IsContentVisibleProperty =
+        AvaloniaProperty.Register<SukiSideMenu, bool>(nameof(IsContentVisible), defaultValue: true);
 
     public static readonly StyledProperty<bool> SidebarToggleEnabledProperty =
         AvaloniaProperty.Register<SukiWindow, bool>(nameof(SidebarToggleEnabled), defaultValue: true);
-
+    
+    public bool IsContentVisible
+    {
+        get => GetValue(IsContentVisibleProperty);
+        set => SetValue(IsContentVisibleProperty, value);
+    }
+    
     public bool SidebarToggleEnabled
     {
         get => GetValue(SidebarToggleEnabledProperty);


### PR DESCRIPTION
Hi, this is my first pr to an open source project. I love this library, however I would like to change the way the sidemenu works. How it currently works seems to be with a splitview, with the side menu on the left and main content on the right. I do not want the main content, because I render my views a different way, so the default was causing unintended issues. I have made a change to the project, which allows for the main content section to be hidden when setting the  IsContentVisible in the sidemenu to False. I have set the default to True so that it is an opt in functionality and wont affect existing codebase functionality. 

Without IsContentVisible:
<img width="1246" alt="Screenshot 2025-04-14 at 4 36 27 PM" src="https://github.com/user-attachments/assets/38d313c2-cae2-4ef0-ae27-e5b6d78b3b7a" />

Because I was not using the default pagecontent it would render out the binding. Setting IsContentVisible=False, fixes this issue.

Thanks.