### PR TITLE
[Performance] Remove unnecessary allocations in `FluentAnimator<T>`

### DIFF
--- a/SukiUI/Helpers/FluentAnimator.cs
+++ b/SukiUI/Helpers/FluentAnimator.cs
@@ -1,97 +1,89 @@
-﻿using Avalonia.Styling;
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Animation;
 using Avalonia.Animation.Easings;
-using System;
-using System.Threading;
+using Avalonia.Styling;
 
 namespace SukiUI.Helpers;
 
+/*
+ * _myButton.Animate(OpacityProperty)
+ *          .From(0).To(1)
+ *          .WithDuration(TimeSpan.FromMilliseconds(1000))
+ *          .WithEasing(new CubicEaseOut())
+ *          .Start();
+ */
 
 public static class FluentAnimatorExtensions
 {
-    public static FluentAnimator<T> Animate<T>(this Animatable control, AvaloniaProperty<T> property)
-    {
-        return new FluentAnimator<T>(control, property);
-    }
+    public static FluentAnimator<T> Animate<T>(this Animatable control, AvaloniaProperty<T> property) => new FluentAnimator<T>(control, property);
 }
 
-
-/*
- * var tokensource = MyButton.Animate(OpacityProperty)
-                             .From(0).To(1)
-                             .WithDuration(TimeSpan.FromMilliseconds(1000))
-                             .WithEasing(new CubicEaseOut())
-                             .Start();
- * 
- */
-
-public class FluentAnimator<T>
+public ref struct FluentAnimator<T>(Animatable control, AvaloniaProperty<T> property)
 {
-    private readonly Animatable _control;
-    private readonly AvaloniaProperty<T> _property;
-    private T _from;
-    private T _to;
-    private TimeSpan _duration = TimeSpan.FromMilliseconds(500);
-    private Easing _easing = new CubicEaseInOut();
+    private static readonly TimeSpan _defaultDuration = TimeSpan.FromSeconds(.5);
+    private static readonly Easing _defaultEasing = new CubicEaseInOut();
 
-    public FluentAnimator(Animatable control, AvaloniaProperty<T> property)
-    {
-        _control = control;
-        _property = property;
-    }
-    
-    public FluentAnimator<T> From(T value)
-    {
-        _from = value;
-        return this;
-    }
+    private T? _from;
+    private T? _to;
+    private TimeSpan? _duration;
+    private Easing? _easing;
 
-    public FluentAnimator<T> To(T value)
-    {
-        _to = value;
-        return this;
-    }
+    private CancellationToken _cancellation;
 
-    public FluentAnimator<T> WithDuration(TimeSpan duration)
-    {
-        _duration = duration;
-        return this;
-    }
+    public FluentAnimator<T> From(T value) => this with { _from = value };
 
-    public FluentAnimator<T> WithEasing(Easing easing)
-    {
-        _easing = easing;
-        return this;
-    }
+    public FluentAnimator<T> To(T value) => this with { _to = value };
 
-    public CancellationTokenSource Start()
+    public FluentAnimator<T> WithDuration(TimeSpan duration) => this with { _duration = duration };
+
+    public FluentAnimator<T> WithEasing(Easing easing) => this with { _easing = easing };
+
+    public FluentAnimator<T> WithCancellationToken(CancellationToken cancellation) => this with { _cancellation = cancellation };
+
+    public readonly void Start() => _ = RunAsync();
+
+    public readonly Task RunAsync()
     {
-        var tokenSource = new CancellationTokenSource();
-        
-        new Animation
+        if (_to == null)
         {
-            Duration = _duration,
-            FillMode = FillMode.Forward,
-            Easing = _easing,
-            IterationCount = new IterationCount(1),
-            PlaybackDirection = PlaybackDirection.Normal,
-            Children =
-            {
-                new KeyFrame
-                {
-                    Setters = { new Setter { Property = _property, Value = _from } },
-                    KeyTime = TimeSpan.Zero
-                },
-                new KeyFrame
-                {
-                    Setters = { new Setter { Property = _property, Value = _to } },
-                    KeyTime = _duration
-                }
-            }
-        }.RunAsync(_control, tokenSource.Token);
+            throw new InvalidOperationException("The 'To' value must be set before starting the animation.");
+        }
 
-        return tokenSource;
+        var duration = _duration ?? _defaultDuration;
+        var easing = _easing ?? _defaultEasing;
+
+        var animation = new Animation
+        {
+            Duration = duration,
+            Easing = easing,
+            FillMode = FillMode.Forward,
+        };
+
+        if (_from != null)
+        {
+            var fromKeyFrame = new KeyFrame
+            {
+                Cue = new Cue(0),
+                Setters =
+                {
+                    new Setter { Property = property, Value = _from }
+                }
+            };
+
+            animation.Children.Add(fromKeyFrame);
+        }
+
+        var toKeyFrame = new KeyFrame
+        {
+            Cue = new Cue(1),
+            Setters =
+            {
+                new Setter { Property = property, Value = _to }
+            }
+        };
+
+        animation.Children.Add(toKeyFrame);
+
+        return animation.RunAsync(control, _cancellation);
     }
 }
-


### PR DESCRIPTION
- Convert `FluentAnimator<T>` to `ref struct` since it only lives on the stack
- Use global `CubicEaseInOut` instead of creating new instances per animation
- Replace `CancellationTokenSource` return with `WithCancellationToken` method to avoid unnecessary allocations when cancellation isn't needed
- Add ability to run animation without setting From value - uses current value as starting point
- Add `RunAsync` method to allow awaiting animation completion