### PR TITLE
Add native window option to SukiMessageBox

### DIFF
--- a/Settings.XamlStyler
+++ b/Settings.XamlStyler
@@ -34,7 +34,7 @@
     "ReorderCanvasChildren": false,
     "ReorderSetters": 0,
     "FormatMarkupExtension": true,
-    "NoNewLineMarkupExtensions": "x:Bind, Binding",
+    "NoNewLineMarkupExtensions": "x:Bind, Binding, TemplateBinding",
     "ThicknessSeparator": 2,
     "ThicknessAttributes": "Margin, Padding, BorderThickness, ThumbnailClipMargin",
     "FormatOnSave": true,

--- a/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsView.axaml
@@ -162,6 +162,7 @@
                                     <StackPanel Spacing="10">
                                         <CheckBox Content="Use alternative header style" IsChecked="{Binding UseAlternativeHeaderStyle}" />
                                         <CheckBox Content="Show header/content separator" IsChecked="{Binding ShowHeaderContentSeparator}" />
+                                        <CheckBox Content="Use native window" IsChecked="{Binding UseNativeWindow}" />
                                         <Button Margin="15,10,15,0"
                                                 VerticalAlignment="Top"
                                                 Command="{Binding OpenCustomMarkdownMessageBoxCommand}"
@@ -211,6 +212,17 @@
                                     <Button Margin="15,10,15,0"
                                             VerticalAlignment="Top"
                                             Command="{Binding OpenLongMessageBoxCommand}"
+                                            CommandParameter="{x:False}"
+                                            Content="Open" />
+                                </suki:GroupBox>
+                            </suki:GlassCard>
+
+                            <suki:GlassCard Width="250">
+                                <suki:GroupBox Header="Long Native Window">
+                                    <Button Margin="15,10,15,0"
+                                            VerticalAlignment="Top"
+                                            Command="{Binding OpenLongMessageBoxCommand}"
+                                            CommandParameter="{x:True}"
                                             Content="Open" />
                                 </suki:GroupBox>
                             </suki:GlassCard>
@@ -249,10 +261,13 @@
                                             Content="Open" />
                                 </suki:GroupBox>
                             </suki:GlassCard>
-                          
-                             <suki:GlassCard>
+
+                            <suki:GlassCard>
                                 <suki:GroupBox Header="Native Window Dialog Demo">
-                                  <Button Margin="15,10,15,0" VerticalAlignment="Top" Command="{Binding OpenDialogNativeWindowDemoCommand}" Content="Open" />
+                                    <Button Margin="15,10,15,0"
+                                            VerticalAlignment="Top"
+                                            Command="{Binding OpenDialogNativeWindowDemoCommand}"
+                                            Content="Open" />
                                 </suki:GroupBox>
                             </suki:GlassCard>
                         </WrapPanel>

--- a/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsViewModel.MessageBoxes.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsViewModel.MessageBoxes.cs
@@ -87,10 +87,9 @@ namespace SukiUI.Demo.Features.ControlsLibrary.Dialogs
                 Header = "Reformat file",
                 Content = "Are you sure you want to process this action?",
                 ActionButtonsPreset = SelectedMessageBoxButtons,
-                FooterLeftItemsSource = new[]
-                    {
+                FooterLeftItemsSource = [
                     SukiMessageBoxButtonsFactory.CreateButton("About"),
-                }
+                ]
             });
 
             toastManager.CreateToast()
@@ -153,6 +152,9 @@ namespace SukiUI.Demo.Features.ControlsLibrary.Dialogs
                            """
                 },
                 ActionButtonsSource = [autoUpgradeButton, manualUpgradeButton, cancelButton]
+            }, new SukiMessageBoxOptions
+            {
+                UseNativeWindow = UseNativeWindow
             });
 
             if (result is SukiMessageBoxResult.Yes)
@@ -230,10 +232,7 @@ namespace SukiUI.Demo.Features.ControlsLibrary.Dialogs
             {
                 IconPreset = SukiMessageBoxIcons.Success,
                 ActionButtonsPreset = SukiMessageBoxButtons.OK,
-                FooterLeftItemsSource = new Control[]
-                {
-                checkBox
-                },
+                FooterLeftItemsSource = [checkBox],
                 Content = "The operation was completed successfully.\nTook: 25 seconds.",
             });
 
@@ -255,21 +254,20 @@ namespace SukiUI.Demo.Features.ControlsLibrary.Dialogs
                       There's not internet connection to perform this action.
                       Do you want to queue a retry in 10 seconds?
                       """,
-                FooterLeftItemsSource = new Control[]
-                {
-                new Border()
-                {
-                    Background = Brushes.Red,
-                    Width = 16,
-                    Height = 16,
-                    CornerRadius = new CornerRadius(50),
-                },
-                new SelectableTextBlock()
-                {
-                    VerticalAlignment = VerticalAlignment.Center,
-                    Text = "Status: Offline",
-                },
-                },
+                FooterLeftItemsSource = [
+                    new Border
+                    {
+                        Background = Brushes.Red,
+                        Width = 16,
+                        Height = 16,
+                        CornerRadius = new CornerRadius(50),
+                    },
+                    new SelectableTextBlock
+                    {
+                        VerticalAlignment = VerticalAlignment.Center,
+                        Text = "Status: Offline",
+                    },
+                ],
                 ActionButtonsPreset = SukiMessageBoxButtons.YesNo
             });
 
@@ -307,15 +305,14 @@ namespace SukiUI.Demo.Features.ControlsLibrary.Dialogs
                         IconPreset = SukiMessageBoxIcons.Error,
                         Header = $"Exception: {e.GetType().Name}",
                         Content = e.ToString(),
-                        FooterLeftItemsSource = new Control[]
-                        {
+                        FooterLeftItemsSource = [
                         SukiMessageBoxButtonsFactory.CreateButton("Copy details"),
-                        new SelectableTextBlock()
-                        {
-                            VerticalAlignment = VerticalAlignment.Center,
-                            Text = $"Retry count: {retryCount}",
-                        },
-                        },
+                            new SelectableTextBlock()
+                            {
+                                VerticalAlignment = VerticalAlignment.Center,
+                                Text = $"Retry count: {retryCount}",
+                            },
+                        ],
                         ActionButtonsPreset = SukiMessageBoxButtons.RetryIgnoreAbort
                     });
 
@@ -333,7 +330,7 @@ namespace SukiUI.Demo.Features.ControlsLibrary.Dialogs
         }
 
         [RelayCommand]
-        private async Task OpenLongMessageBox()
+        private async Task OpenLongMessageBox(bool useNativeWindow = false)
         {
             var text = """"
                    ====================================================================================================
@@ -424,16 +421,18 @@ namespace SukiUI.Demo.Features.ControlsLibrary.Dialogs
             var result = await SukiMessageBox.ShowDialog(new SukiMessageBoxHost
             {
                 Content = text,
-                FooterLeftItemsSource = new Control[]
-                {
-                new SelectableTextBlock()
-                {
-                    VerticalAlignment = VerticalAlignment.Center,
-                    FontWeight = FontWeight.Bold,
-                    Text = $"Text length: {text.Length:N}",
-                },
-                },
+                FooterLeftItemsSource = [
+                    new SelectableTextBlock
+                    {
+                        VerticalAlignment = VerticalAlignment.Center,
+                        FontWeight = FontWeight.Bold,
+                        Text = $"Text length: {text.Length:N}",
+                    },
+                ],
                 ActionButtonsPreset = SukiMessageBoxButtons.OK
+            }, new SukiMessageBoxOptions
+            {
+                UseNativeWindow = useNativeWindow
             });
 
             toastManager.CreateToast()

--- a/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsViewModel.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsViewModel.cs
@@ -35,8 +35,9 @@ public partial class DialogsViewModel(ISukiDialogManager dialogManager, ISukiToa
     public SukiMessageBoxButtons[] MessageBoxButtons { get; } = Enum.GetValues<SukiMessageBoxButtons>();
 
     [ObservableProperty] private SukiMessageBoxButtons _selectedMessageBoxButtons = SukiMessageBoxButtons.YesNoCancel;
-    [ObservableProperty] private bool _useAlternativeHeaderStyle = false;
+    [ObservableProperty] private bool _useAlternativeHeaderStyle;
     [ObservableProperty] private bool _showHeaderContentSeparator = true;
+    [ObservableProperty] private bool _useNativeWindow;
 
     private void ShowOptionToast(int option)
     {

--- a/SukiUI.Demo/Features/ControlsLibrary/TextView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/TextView.axaml
@@ -63,38 +63,42 @@
                         </showMeTheXaml:XamlDisplay>
 
                         <showMeTheXaml:XamlDisplay UniqueId="TextBlock5">
-                            <TextBlock Classes="Caption" />
+                            <TextBlock Classes="h5" />
                         </showMeTheXaml:XamlDisplay>
 
                         <showMeTheXaml:XamlDisplay UniqueId="TextBlock6">
-                            <TextBlock Classes="Primary" />
+                            <TextBlock Classes="Caption" />
                         </showMeTheXaml:XamlDisplay>
 
                         <showMeTheXaml:XamlDisplay UniqueId="TextBlock7">
-                            <TextBlock Classes="Accent" />
+                            <TextBlock Classes="Primary" />
                         </showMeTheXaml:XamlDisplay>
 
                         <showMeTheXaml:XamlDisplay UniqueId="TextBlock8">
-                            <TextBlock Classes="Success" />
+                            <TextBlock Classes="Accent" />
                         </showMeTheXaml:XamlDisplay>
 
                         <showMeTheXaml:XamlDisplay UniqueId="TextBlock9">
-                            <TextBlock Classes="Information" />
+                            <TextBlock Classes="Success" />
                         </showMeTheXaml:XamlDisplay>
 
                         <showMeTheXaml:XamlDisplay UniqueId="TextBlock10">
-                            <TextBlock Classes="Warning" />
+                            <TextBlock Classes="Information" />
                         </showMeTheXaml:XamlDisplay>
 
                         <showMeTheXaml:XamlDisplay UniqueId="TextBlock11">
-                            <TextBlock Classes="Danger" />
+                            <TextBlock Classes="Warning" />
                         </showMeTheXaml:XamlDisplay>
 
                         <showMeTheXaml:XamlDisplay UniqueId="TextBlock12">
-                            <TextBlock />
+                            <TextBlock Classes="Danger" />
                         </showMeTheXaml:XamlDisplay>
 
                         <showMeTheXaml:XamlDisplay UniqueId="TextBlock13">
+                            <TextBlock />
+                        </showMeTheXaml:XamlDisplay>
+
+                        <showMeTheXaml:XamlDisplay UniqueId="TextBlock14">
                             <TextBlock IsEnabled="False" />
                         </showMeTheXaml:XamlDisplay>
 
@@ -141,38 +145,42 @@
                         </showMeTheXaml:XamlDisplay>
 
                         <showMeTheXaml:XamlDisplay UniqueId="SelectableTextBlock5">
-                            <SelectableTextBlock Classes="Caption" />
+                            <SelectableTextBlock Classes="h5" />
                         </showMeTheXaml:XamlDisplay>
 
                         <showMeTheXaml:XamlDisplay UniqueId="SelectableTextBlock6">
-                            <SelectableTextBlock Classes="Primary" />
+                            <SelectableTextBlock Classes="Caption" />
                         </showMeTheXaml:XamlDisplay>
 
                         <showMeTheXaml:XamlDisplay UniqueId="SelectableTextBlock7">
-                            <SelectableTextBlock Classes="Accent" />
+                            <SelectableTextBlock Classes="Primary" />
                         </showMeTheXaml:XamlDisplay>
 
                         <showMeTheXaml:XamlDisplay UniqueId="SelectableTextBlock8">
-                            <SelectableTextBlock Classes="Success" />
+                            <SelectableTextBlock Classes="Accent" />
                         </showMeTheXaml:XamlDisplay>
 
                         <showMeTheXaml:XamlDisplay UniqueId="SelectableTextBlock9">
-                            <SelectableTextBlock Classes="Information" />
+                            <SelectableTextBlock Classes="Success" />
                         </showMeTheXaml:XamlDisplay>
 
                         <showMeTheXaml:XamlDisplay UniqueId="SelectableTextBlock10">
-                            <SelectableTextBlock Classes="Warning" />
+                            <SelectableTextBlock Classes="Information" />
                         </showMeTheXaml:XamlDisplay>
 
                         <showMeTheXaml:XamlDisplay UniqueId="SelectableTextBlock11">
-                            <SelectableTextBlock Classes="Danger" />
+                            <SelectableTextBlock Classes="Warning" />
                         </showMeTheXaml:XamlDisplay>
 
                         <showMeTheXaml:XamlDisplay UniqueId="SelectableTextBlock12">
-                            <SelectableTextBlock />
+                            <SelectableTextBlock Classes="Danger" />
                         </showMeTheXaml:XamlDisplay>
 
                         <showMeTheXaml:XamlDisplay UniqueId="SelectableTextBlock13">
+                            <SelectableTextBlock />
+                        </showMeTheXaml:XamlDisplay>
+
+                        <showMeTheXaml:XamlDisplay UniqueId="SelectableTextBlock14">
                             <SelectableTextBlock IsEnabled="False" />
                         </showMeTheXaml:XamlDisplay>
 

--- a/SukiUI/Controls/Hosts/SukiMessageBoxHost.axaml
+++ b/SukiUI/Controls/Hosts/SukiMessageBoxHost.axaml
@@ -1,29 +1,27 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:generic="clr-namespace:System.Collections.Generic;assembly=netstandard"
+                    xmlns:converters="clr-namespace:Avalonia.Controls.Converters;assembly=Avalonia.Controls"
                     xmlns:icons="https://github.com/kikipoulet/SukiUI"
                     xmlns:suki="using:SukiUI.Controls">
 
     <Design.PreviewWith>
         <StackPanel Width="600" Spacing="10">
-            <suki:SukiMessageBoxHost Header="Changelog version 1.0:"
-                                     IconPreset="Star"
-                                     ShowHeaderContentSeparator="True">
+            <suki:SukiMessageBoxHost IconPreset="Star" ShowHeaderContentSeparator="True">
                 <suki:SukiMessageBoxHost.FooterLeftItemsSource>
-                    <generic:List x:TypeArguments="Control">
-                        <Border Width="20"
-                                Height="20"
-                                Background="DarkGreen"
-                                CornerRadius="50" />
-                    </generic:List>
+                    <Border Width="20"
+                            Height="20"
+                            Background="DarkGreen"
+                            CornerRadius="50" />
                 </suki:SukiMessageBoxHost.FooterLeftItemsSource>
 
+                <suki:SukiMessageBoxHost.Header>
+                    <SelectableTextBlock Text="Changelog version 1.0:" />
+                </suki:SukiMessageBoxHost.Header>
+
                 <suki:SukiMessageBoxHost.ActionButtonsSource>
-                    <generic:List x:TypeArguments="Button">
-                        <Button Classes="Flat Accent" Content="Upgrade now" />
-                        <Button Classes="Flat" Content="Manual download" />
-                        <Button Classes="Flat" Content="Cancel" />
-                    </generic:List>
+                    <Button Classes="Flat Accent" Content="Upgrade now" />
+                    <Button Classes="Flat" Content="Manual download" />
+                    <Button Classes="Flat" Content="Cancel" />
                 </suki:SukiMessageBoxHost.ActionButtonsSource>
 
                 <SelectableTextBlock Text="- Added new user authentication module.&#10;- Fixed bug with the search functionality where results were not displaying correctly.&#10;- Improved performance on mobile devices.&#10;- Updated dependencies for security patches." TextWrapping="Wrap" />
@@ -61,6 +59,13 @@
         </StackPanel>
     </Design.PreviewWith>
 
+    <converters:MarginMultiplierConverter x:Key="FooterBetweenMarginConverter"
+                                          Indent="1"
+                                          Left="True"
+                                          Right="True" />
+
+    <Thickness x:Key="IconTitleMargin">0,0,15,0</Thickness>
+
     <ControlTheme x:Key="{x:Type suki:SukiMessageBoxHost}" TargetType="suki:SukiMessageBoxHost">
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="Padding" Value="20" />
@@ -69,6 +74,7 @@
                 <DockPanel Margin="{TemplateBinding Padding}" LastChildFill="True">
                     <Grid Name="PART_AlternativeHeaderGrid"
                           Margin="10,0,10,15"
+                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                           ColumnDefinitions="Auto,*"
                           DockPanel.Dock="Top"
                           RowDefinitions="Auto">
@@ -80,34 +86,30 @@
                                          RelativeSource="{RelativeSource TemplatedParent}" />
                             </MultiBinding>
                         </Grid.IsVisible>
-                        <ContentControl Grid.Row="0"
-                                        Grid.Column="0"
-                                        Margin="0,0,10,0"
-                                        Content="{TemplateBinding Icon}"
-                                        FontWeight="DemiBold"
-                                        IsVisible="{Binding Icon, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static ObjectConverters.IsNotNull}}" />
-                        <ContentControl Grid.Row="0"
-                                        Grid.Column="1"
-                                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                        Content="{TemplateBinding Header}"
-                                        ContentTemplate="{TemplateBinding HeaderTemplate}"
-                                        FontWeight="DemiBold" />
+                        <ContentPresenter Name="PART_AlternativeIcon"
+                                          Grid.Row="0"
+                                          Grid.Column="0"
+                                          Margin="{StaticResource IconTitleMargin}"
+                                          Content="{TemplateBinding Icon}"
+                                          IsVisible="{Binding Icon, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static ObjectConverters.IsNotNull}}" />
+                        <ContentPresenter Name="PART_AlternativeHeader"
+                                          Grid.Row="0"
+                                          Grid.Column="1"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          Content="{TemplateBinding Header}"
+                                          ContentTemplate="{TemplateBinding HeaderTemplate}" />
                     </Grid>
 
 
                     <Grid Name="PART_FooterGrid"
                           Margin="0,20,0,0"
-                          ColumnDefinitions="Auto,20,*"
+                          ColumnDefinitions="*,Auto,Auto"
                           DockPanel.Dock="Bottom"
                           RowDefinitions="Auto">
                         <Grid.IsVisible>
                             <MultiBinding Converter="{x:Static BoolConverters.Or}">
-                                <Binding Converter="{x:Static ObjectConverters.IsNotNull}"
-                                         Path="FooterLeftItemsSource"
-                                         RelativeSource="{RelativeSource TemplatedParent}" />
-                                <Binding Converter="{x:Static ObjectConverters.IsNotNull}"
-                                         Path="ActionButtonsSource"
-                                         RelativeSource="{RelativeSource TemplatedParent}" />
+                                <Binding Path="!!FooterLeftItemsSource.Count" RelativeSource="{RelativeSource TemplatedParent}" />
+                                <Binding Path="!!ActionButtonsSource.Count" RelativeSource="{RelativeSource TemplatedParent}" />
                             </MultiBinding>
                         </Grid.IsVisible>
                         <ItemsControl Name="PART_LeftContentItems"
@@ -118,12 +120,14 @@
                                       ItemsSource="{TemplateBinding FooterLeftItemsSource}">
                             <ItemsControl.ItemsPanel>
                                 <ItemsPanelTemplate>
-                                    <StackPanel HorizontalAlignment="Right"
-                                                Orientation="Horizontal"
-                                                Spacing="10" />
+                                    <StackPanel Orientation="Horizontal" Spacing="{Binding ItemsSpacing, RelativeSource={RelativeSource FindAncestor, AncestorType=suki:SukiMessageBoxHost}}" />
                                 </ItemsPanelTemplate>
                             </ItemsControl.ItemsPanel>
                         </ItemsControl>
+
+                        <Border Grid.Row="0"
+                                Grid.Column="1"
+                                Margin="{TemplateBinding ItemsSpacing, Converter={StaticResource FooterBetweenMarginConverter}}" />
 
                         <ItemsControl Name="PART_ActionButtons"
                                       Grid.Row="0"
@@ -133,7 +137,7 @@
                                 <ItemsPanelTemplate>
                                     <StackPanel HorizontalAlignment="Right"
                                                 Orientation="Horizontal"
-                                                Spacing="10" />
+                                                Spacing="{Binding ItemsSpacing, RelativeSource={RelativeSource FindAncestor, AncestorType=suki:SukiMessageBoxHost}}" />
                                 </ItemsPanelTemplate>
                             </ItemsControl.ItemsPanel>
                         </ItemsControl>
@@ -157,20 +161,21 @@
                                 </Grid.IsVisible>
                                 <Grid Grid.Row="0"
                                       Grid.Column="0"
+                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                       ColumnDefinitions="Auto,*"
                                       RowDefinitions="Auto">
-                                    <ContentControl Grid.Row="0"
-                                                    Grid.Column="0"
-                                                    Margin="0,0,10,0"
-                                                    Content="{TemplateBinding Icon}"
-                                                    FontWeight="DemiBold"
-                                                    IsVisible="{Binding Icon, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static ObjectConverters.IsNotNull}}" />
-                                    <ContentControl Grid.Row="0"
-                                                    Grid.Column="1"
-                                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                    Content="{TemplateBinding Header}"
-                                                    ContentTemplate="{TemplateBinding HeaderTemplate}"
-                                                    FontWeight="DemiBold" />
+                                    <ContentPresenter Name="PART_Icon"
+                                                      Grid.Row="0"
+                                                      Grid.Column="0"
+                                                      Margin="0,0,10,0"
+                                                      Content="{TemplateBinding Icon}"
+                                                      IsVisible="{Binding Icon, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static ObjectConverters.IsNotNull}}" />
+                                    <ContentPresenter Name="PART_Header"
+                                                      Grid.Row="0"
+                                                      Grid.Column="1"
+                                                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                      Content="{TemplateBinding Header}"
+                                                      ContentTemplate="{TemplateBinding HeaderTemplate}" />
                                 </Grid>
 
                                 <Border Grid.Row="1"
@@ -183,14 +188,15 @@
 
                             <Grid Grid.Row="1"
                                   Grid.Column="0"
+                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                   ColumnDefinitions="Auto,*"
                                   RowDefinitions="*">
-                                <ContentControl Grid.Row="0"
-                                                Grid.Column="0"
-                                                Margin="0,0,15,0"
-                                                Content="{TemplateBinding Icon}"
-                                                FontWeight="DemiBold">
-                                    <ContentControl.IsVisible>
+                                <ContentPresenter Grid.Row="0"
+                                                  Grid.Column="0"
+                                                  Margin="{StaticResource IconTitleMargin}"
+                                                  Content="{TemplateBinding Icon}"
+                                                  FontWeight="DemiBold">
+                                    <ContentPresenter.IsVisible>
                                         <MultiBinding Converter="{x:Static BoolConverters.And}">
                                             <Binding Converter="{x:Static ObjectConverters.IsNotNull}"
                                                      Path="Icon"
@@ -199,8 +205,8 @@
                                                      Path="Header"
                                                      RelativeSource="{RelativeSource TemplatedParent}" />
                                         </MultiBinding>
-                                    </ContentControl.IsVisible>
-                                </ContentControl>
+                                    </ContentPresenter.IsVisible>
+                                </ContentPresenter>
 
                                 <ScrollViewer Name="PART_Content"
                                               Grid.Row="0"
@@ -215,5 +221,13 @@
                 </DockPanel>
             </ControlTemplate>
         </Setter>
+
+        <Style Selector="^ /template/ ContentPresenter#PART_AlternativeIcon, ^ /template/ ContentPresenter#PART_Icon, ^ /template/ ContentPresenter#PART_AlternativeHeader, ^ /template/ ContentPresenter#PART_Header">
+            <Setter Property="FontSize" Value="16" />
+            <Setter Property="FontWeight" Value="DemiBold" />
+        </Style>
+
+
+
     </ControlTheme>
 </ResourceDictionary>

--- a/SukiUI/Controls/Hosts/SukiMessageBoxHost.axaml.cs
+++ b/SukiUI/Controls/Hosts/SukiMessageBoxHost.axaml.cs
@@ -1,20 +1,32 @@
-using System.Collections;
 using Avalonia;
+using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
+using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using SukiUI.MessageBox;
 
 namespace SukiUI.Controls;
 
 [TemplatePart("PART_AlternativeHeaderGrid", typeof(Grid))]
+[TemplatePart("PART_AlternativeIcon", typeof(ContentPresenter))]
+[TemplatePart("PART_AlternativeHeader", typeof(ContentPresenter))]
 [TemplatePart("PART_HeaderGrid", typeof(Grid))]
+[TemplatePart("PART_Icon", typeof(ContentPresenter))]
+[TemplatePart("PART_Header", typeof(ContentPresenter))]
 [TemplatePart("PART_Content", typeof(ScrollViewer))]
 [TemplatePart("PART_FooterGrid", typeof(Grid))]
 [TemplatePart("PART_LeftContentItems", typeof(ItemsControl))]
 [TemplatePart("PART_ActionButtons", typeof(ItemsControl))]
 public class SukiMessageBoxHost : HeaderedContentControl
 {
+    private const int DefaultItemsSpacing = 10;
+    private const double DefaultIconPresetSize = 24;
+
+
+    /// <summary>
+    /// Defines the <see cref="UseAlternativeHeaderStyle"/> property.
+    /// </summary>
     public static readonly StyledProperty<bool> UseAlternativeHeaderStyleProperty = AvaloniaProperty.Register<SukiMessageBoxHost, bool>(nameof(UseAlternativeHeaderStyle));
 
     /// <summary>
@@ -56,7 +68,7 @@ public class SukiMessageBoxHost : HeaderedContentControl
     /// Defines the <see cref="IconPresetSize"/> property.
     /// </summary>
     public static readonly StyledProperty<double> IconPresetSizeProperty =
-        AvaloniaProperty.Register<SukiMessageBoxHost, double>(nameof(IconPresetSize), 24);
+        AvaloniaProperty.Register<SukiMessageBoxHost, double>(nameof(IconPresetSize), DefaultIconPresetSize);
 
     /// <summary>
     /// Gets or sets the size of the preset icon.
@@ -86,13 +98,13 @@ public class SukiMessageBoxHost : HeaderedContentControl
     /// <summary>
     /// Defines the <see cref="FooterLeftItemsSource"/> property.
     /// </summary>
-    public static readonly StyledProperty<IEnumerable?> FooterLeftItemsSourceProperty =
-        AvaloniaProperty.Register<SukiMessageBoxHost, IEnumerable?>(nameof(FooterLeftItemsSource));
+    public static readonly StyledProperty<Avalonia.Controls.Controls?> FooterLeftItemsSourceProperty =
+        AvaloniaProperty.Register<SukiMessageBoxHost, Avalonia.Controls.Controls?>(nameof(FooterLeftItemsSource));
 
     /// <summary>
     /// Gets or sets the items source to display in the footer left of the message box
     /// </summary>
-    public IEnumerable? FooterLeftItemsSource
+    public Avalonia.Controls.Controls? FooterLeftItemsSource
     {
         get => GetValue(FooterLeftItemsSourceProperty);
         set => SetValue(FooterLeftItemsSourceProperty, value);
@@ -101,13 +113,13 @@ public class SukiMessageBoxHost : HeaderedContentControl
     /// <summary>
     /// Defines the <see cref="ActionButtonsSource"/> property.
     /// </summary>
-    public static readonly StyledProperty<IEnumerable<Button>?> ActionButtonsSourceProperty =
-        AvaloniaProperty.Register<SukiMessageBoxHost, IEnumerable<Button>?>(nameof(ActionButtonsSource));
+    public static readonly StyledProperty<AvaloniaList<Button>?> ActionButtonsSourceProperty =
+        AvaloniaProperty.Register<SukiMessageBoxHost, AvaloniaList<Button>?>(nameof(ActionButtonsSource));
 
     /// <summary>
     /// Gets or sets the action buttons to display in bottom right of the message box.
     /// </summary>
-    public IEnumerable<Button>? ActionButtonsSource
+    public AvaloniaList<Button>? ActionButtonsSource
     {
         get => GetValue(ActionButtonsSourceProperty);
         set => SetValue(ActionButtonsSourceProperty, value);
@@ -128,6 +140,28 @@ public class SukiMessageBoxHost : HeaderedContentControl
         set => SetValue(ActionButtonsPresetProperty, value);
     }
 
+    /// <summary>
+    /// Defines the <see cref="ItemsSpacing"/> property.
+    /// </summary>
+    public static readonly StyledProperty<int> ItemsSpacingProperty =
+        AvaloniaProperty.Register<SukiMessageBoxHost, int>(nameof(ItemsSpacing), DefaultItemsSpacing);
+
+    /// <summary>
+    /// Gets or sets the spacing between the items (<see cref="FooterLeftItemsSource"/> and <see cref="ActionButtonsSource"/>) in the message box.
+    /// </summary>
+    public int ItemsSpacing
+    {
+        get => GetValue(ItemsSpacingProperty);
+        set => SetValue(ItemsSpacingProperty, value);
+    }
+
+    public SukiMessageBoxHost()
+    {
+        FooterLeftItemsSource = [];
+        ActionButtonsSource = [];
+    }
+
+
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs e)
     {
         base.OnPropertyChanged(e);
@@ -145,12 +179,12 @@ public class SukiMessageBoxHost : HeaderedContentControl
             var preset = ActionButtonsPreset;
             if (preset is null) return;
 
-            ActionButtonsSource = preset switch
+            Button[] buttons = preset switch
             {
-                SukiMessageBoxButtons.OK => new[]
-                {
+                SukiMessageBoxButtons.OK =>
+                [
                     SukiMessageBoxButtonsFactory.CreateButton(SukiMessageBoxResult.OK)
-                },
+                ],
                 SukiMessageBoxButtons.OKCancel =>
                 [
                     SukiMessageBoxButtonsFactory.CreateButton(SukiMessageBoxResult.OK),
@@ -200,8 +234,33 @@ public class SukiMessageBoxHost : HeaderedContentControl
                 ],
                 _ => throw new ArgumentOutOfRangeException(nameof(preset), preset, null)
             };
+
+            if (ActionButtonsSource is null)
+            {
+                ActionButtonsSource = new AvaloniaList<Button>(buttons);
+            }
+            else
+            {
+                ActionButtonsSource.Clear();
+                ActionButtonsSource.AddRange(buttons);
+            }
         }
     }
 
+    public void ResetToDefaults()
+    {
+        UseAlternativeHeaderStyle = false;
+        ShowHeaderContentSeparator = false;
 
+        Icon = null;
+        IconPreset = null;
+        IconPresetSize = DefaultIconPresetSize;
+        Content = null;
+
+        FooterLeftItemsSource?.Clear();
+        ActionButtonsSource?.Clear();
+        ActionButtonsPreset = null;
+
+        ItemsSpacing = DefaultItemsSpacing;
+    }
 }

--- a/SukiUI/Extensions/WindowExtensions.cs
+++ b/SukiUI/Extensions/WindowExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System.Runtime.CompilerServices;
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Platform;
 
@@ -41,5 +40,54 @@ public static class WindowExtensions
 
         window.Position = new PixelPoint((int)(screen.Bounds.X + screen.WorkingArea.Width / 2.0 - window.Bounds.Width / (2.0 / window.RenderScaling)),
                                         (int)(screen.Bounds.Y + screen.WorkingArea.Height / 2.0 - window.Bounds.Height / (2.0 / window.RenderScaling)));
+    }
+
+    /// <summary>
+    /// Constrain the maximum size of the window to a ratio of the screen size.
+    /// </summary>
+    /// <param name="window"></param>
+    /// <param name="maxWidthScreenRatio">The max width ratio from [0.0 to 1.0].</param>
+    /// <param name="maxHeightScreenRatio">The max height ratio from [0.0 to 1.0].</param>
+    /// <remarks><p>A ratio &lt;= 0 or a window state of [<see cref="WindowState.FullScreen"/> / <see cref="WindowState.Maximized"/>] will remove the max limit.</p>
+    /// <p>A ratio of <see cref="double.NaN"/> will cause that setter size to be ignored.</p>
+    /// <p>The resulting size can never be smaller than the MinWidth/MinHeight properties.</p></remarks>
+    public static void ConstrainMaxSizeToScreenRatio(this Window window, double maxWidthScreenRatio, double maxHeightScreenRatio)
+    {
+        Screen? screen = null;
+        WindowState? windowState = null;
+
+        if (!double.IsNaN(maxWidthScreenRatio))
+        {
+            windowState = window.WindowState;
+            if (maxWidthScreenRatio <= 0 || windowState is WindowState.FullScreen or WindowState.Maximized)
+            {
+                window.MaxWidth = double.PositiveInfinity;
+            }
+            else
+            {
+                screen = window.GetHostScreen();
+                if (screen is null) return;
+
+                var desiredMaxWidth = screen.WorkingArea.Width / window.RenderScaling * maxWidthScreenRatio;
+                window.MaxWidth = Math.Max(window.MinWidth, desiredMaxWidth);
+            }
+        }
+
+        if (!double.IsNaN(maxHeightScreenRatio))
+        {
+            windowState ??= window.WindowState;
+            if (maxHeightScreenRatio <= 0 || windowState is WindowState.FullScreen or WindowState.Maximized)
+            {
+                window.MaxHeight = double.PositiveInfinity;
+            }
+            else
+            {
+                screen ??= window.GetHostScreen();
+                if (screen is null) return;
+
+                var desiredMaxHeight = screen.WorkingArea.Height / window.RenderScaling * maxHeightScreenRatio;
+                window.MaxHeight = Math.Max(window.MinHeight, desiredMaxHeight);
+            }
+        }
     }
 }

--- a/SukiUI/MessageBox/SukiMessageBox.cs
+++ b/SukiUI/MessageBox/SukiMessageBox.cs
@@ -5,6 +5,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using SukiUI.Controls;
+using SukiUI.Extensions;
 
 namespace SukiUI.MessageBox;
 
@@ -19,28 +20,56 @@ public static class SukiMessageBox
     /// </summary>
     /// <param name="options"></param>
     /// <returns></returns>
-    public static SukiWindow CreateMessageBoxWindow(SukiMessageBoxOptions? options = null)
+    public static Window CreateMessageBoxWindow(SukiMessageBoxOptions? options = null)
     {
         options ??= new SukiMessageBoxOptions();
-        return new SukiWindow
+
+        Window window;
+
+        if (options.UseNativeWindow)
         {
-            CanResize = options.CanResize,
-            CanMinimize = options.CanMinimize,
-            CanMaximize = options.CanMaximize,
-            CanFullScreen = false,
-            IsTitleBarVisible = options.IsTitleBarVisible,
-            Title = options.Title,
-            LogoContent = options.LogoContent,
-            ShowInTaskbar = options.ShowInTaskbar,
-            WindowStartupLocation = options.WindowStartupLocation,
-            SizeToContent = options.SizeToContent,
-            Width = options.Width,
-            Height = options.Height,
-            MinWidth = options.MinWidth,
-            MinHeight = options.MinHeight,
-            MaxWidthScreenRatio = options.MaxWidthScreenRatio,
-            MaxHeightScreenRatio = options.MaxHeightScreenRatio,
-        };
+            window = new Window
+            {
+                SystemDecorations = options.IsTitleBarVisible ? SystemDecorations.Full : SystemDecorations.BorderOnly,
+            };
+            window.ConstrainMaxSizeToScreenRatio(options.MaxWidthScreenRatio, options.MaxHeightScreenRatio);
+        }
+        else
+        {
+            var sukiWindow = new SukiWindow
+            {
+                CanMinimize = options.CanMinimize,
+                CanMaximize = options.CanMaximize,
+                CanFullScreen = false,
+                IsTitleBarVisible = options.IsTitleBarVisible,
+                LogoContent = options.LogoContent,
+                MaxWidthScreenRatio = options.MaxWidthScreenRatio,
+                MaxHeightScreenRatio = options.MaxHeightScreenRatio,
+            };
+
+            if (options.BackgroundAnimationEnabled is not null) sukiWindow.BackgroundAnimationEnabled = options.BackgroundAnimationEnabled.Value;
+            if (options.BackgroundForceSoftwareRendering is not null) sukiWindow.BackgroundForceSoftwareRendering = options.BackgroundForceSoftwareRendering.Value;
+            if (options.BackgroundShaderFile is not null) sukiWindow.BackgroundShaderFile = options.BackgroundShaderFile;
+            if (options.BackgroundShaderCode is not null) sukiWindow.BackgroundShaderCode = options.BackgroundShaderCode;
+            if (options.BackgroundStyle is not null) sukiWindow.BackgroundStyle = options.BackgroundStyle.Value;
+            if (options.BackgroundTransitionTime is not null) sukiWindow.BackgroundTransitionTime = options.BackgroundTransitionTime.Value;
+            if (options.BackgroundTransitionsEnabled is not null) sukiWindow.BackgroundTransitionsEnabled = options.BackgroundTransitionsEnabled.Value;
+
+            window = sukiWindow;
+        }
+
+        // Shared properties
+        window.CanResize = options.CanResize;
+        window.Title = options.Title;
+        window.ShowInTaskbar = options.ShowInTaskbar;
+        window.WindowStartupLocation = options.WindowStartupLocation;
+        window.SizeToContent = options.SizeToContent;
+        window.Width = options.Width;
+        window.Height = options.Height;
+        window.MinWidth = options.MinWidth;
+        window.MinHeight = options.MinHeight;
+
+        return window;
     }
     #endregion
 
@@ -58,6 +87,19 @@ public static class SukiMessageBox
     /// </returns>
     public static Task<object?> ShowDialog(Window owner, SukiMessageBoxHost messageBox, SukiMessageBoxOptions? windowOptions = null)
     {
+        windowOptions ??= new SukiMessageBoxOptions();
+
+        if (owner is SukiWindow sukiWindow)
+        {
+            if (windowOptions.BackgroundAnimationEnabled is null) windowOptions = windowOptions with { BackgroundAnimationEnabled = sukiWindow.BackgroundAnimationEnabled };
+            if (windowOptions.BackgroundForceSoftwareRendering is null) windowOptions = windowOptions with { BackgroundForceSoftwareRendering = sukiWindow.BackgroundForceSoftwareRendering };
+            if (windowOptions.BackgroundShaderCode is null) windowOptions = windowOptions with { BackgroundShaderCode = sukiWindow.BackgroundShaderCode };
+            if (windowOptions.BackgroundShaderFile is null) windowOptions = windowOptions with { BackgroundShaderFile = sukiWindow.BackgroundShaderFile };
+            if (windowOptions.BackgroundStyle is null) windowOptions = windowOptions with { BackgroundStyle = sukiWindow.BackgroundStyle };
+            if (windowOptions.BackgroundTransitionTime is null) windowOptions = windowOptions with { BackgroundTransitionTime = sukiWindow.BackgroundTransitionTime };
+            if (windowOptions.BackgroundTransitionsEnabled is null) windowOptions = windowOptions with { BackgroundTransitionsEnabled = sukiWindow.BackgroundTransitionsEnabled };
+        }
+
         var window = CreateMessageBoxWindow(windowOptions);
         window.Icon ??= owner.Icon;
         if (string.IsNullOrWhiteSpace(window.Title)) window.Title = $"{owner.Title} Message";
@@ -69,7 +111,7 @@ public static class SukiMessageBox
             messageBox.Header = new SelectableTextBlock
             {
                 Text = headerText,
-                FontSize = 16,
+                Classes = { "h5" },
                 TextWrapping = TextWrapping.Wrap
             };
         }
@@ -86,21 +128,20 @@ public static class SukiMessageBox
         var actionButtons = messageBox.ActionButtonsSource;
         if (actionButtons is not null)
         {
-            var buttonArray = actionButtons as Button[] ?? actionButtons.ToArray();
-            foreach (var button in buttonArray)
+            foreach (var button in actionButtons)
             {
                 button.Tag = (button.Tag, window);
                 button.Click += ActionButtonOnClick;
             }
 
-            if (buttonArray.Length <= 1)
+            if (actionButtons.Count <= 1)
             {
                 window.KeyUp += WindowOnKeyUp;
             }
 
-            if (buttonArray.Length == 1)
+            if (actionButtons.Count == 1)
             {
-                buttonArray[0].IsCancel = true;
+                actionButtons[0].IsCancel = true;
             }
         }
         else
@@ -108,7 +149,28 @@ public static class SukiMessageBox
             window.KeyUp += WindowOnKeyUp;
         }
 
-        window.Content = messageBox;
+        if (windowOptions.UseNativeWindow)
+        {
+            var sukiHost = new SukiMainHost
+            {
+                Content = messageBox,
+            };
+
+            if (windowOptions.BackgroundAnimationEnabled is not null) sukiHost.BackgroundAnimationEnabled = windowOptions.BackgroundAnimationEnabled.Value;
+            if (windowOptions.BackgroundForceSoftwareRendering is not null) sukiHost.BackgroundForceSoftwareRendering = windowOptions.BackgroundForceSoftwareRendering.Value;
+            if (windowOptions.BackgroundShaderFile is not null) sukiHost.BackgroundShaderFile = windowOptions.BackgroundShaderFile;
+            if (windowOptions.BackgroundShaderCode is not null) sukiHost.BackgroundShaderCode = windowOptions.BackgroundShaderCode;
+            if (windowOptions.BackgroundStyle is not null) sukiHost.BackgroundStyle = windowOptions.BackgroundStyle.Value;
+            if (windowOptions.BackgroundTransitionTime is not null) sukiHost.BackgroundTransitionTime = windowOptions.BackgroundTransitionTime.Value;
+            if (windowOptions.BackgroundTransitionsEnabled is not null) sukiHost.BackgroundTransitionsEnabled = windowOptions.BackgroundTransitionsEnabled.Value;
+
+            window.Content = sukiHost;
+        }
+        else
+        {
+            window.Content = messageBox;
+        }
+
         return window.ShowDialog<object?>(owner);
     }
 
@@ -169,6 +231,9 @@ public static class SukiMessageBox
                 button.Click -= ActionButtonOnClick;
             }
         }
+
+        // Unload the content to free resources and allow reuse of the host control
+        window.Content = null;
     }
 
     /// <summary>
@@ -179,12 +244,12 @@ public static class SukiMessageBox
     private static void ActionButtonOnClick(object sender, RoutedEventArgs e)
     {
         if (sender is not Button button) return;
-        if (button.Tag is SukiWindow window)
+        if (button.Tag is Window window)
         {
             window.Close();
             return;
         }
-        if (button.Tag is not ValueTuple<object?, SukiWindow> tuple) return;
+        if (button.Tag is not ValueTuple<object?, Window> tuple) return;
 
         if (tuple.Item1 is SukiMessageBoxResult result)
         {

--- a/SukiUI/MessageBox/SukiMessageBoxIconsFactory.cs
+++ b/SukiUI/MessageBox/SukiMessageBoxIconsFactory.cs
@@ -9,7 +9,7 @@ namespace SukiUI.MessageBox;
 /// </summary>
 public static class SukiMessageBoxIconsFactory
 {
-    public static PathIcon CreateIcon(double size = 24)
+    public static PathIcon CreateIcon(double size = double.NaN)
     {
         return new PathIcon
         {
@@ -18,7 +18,7 @@ public static class SukiMessageBoxIconsFactory
         };
     }
 
-    public static PathIcon CreateIcon(SukiMessageBoxIcons icon, double size = 24)
+    public static PathIcon CreateIcon(SukiMessageBoxIcons icon, double size = double.NaN)
     {
         var pathIcon = CreateIcon(size);
         pathIcon.Tag = icon;
@@ -26,9 +26,19 @@ public static class SukiMessageBoxIconsFactory
         switch (icon)
         {
             case SukiMessageBoxIcons.Question:
+            {
                 pathIcon.Data = Icons.CircleHelp;
+                /*if (Application.Current!.TryGetResource("SukiInformationColor", Application.Current.ActualThemeVariant, out var value))
+                {
+                    pathIcon.Foreground = value is Color color ? new ImmutableSolidColorBrush(color) : Brushes.CornflowerBlue;
+                }
+                else
+                {
+                    pathIcon.Foreground = Brushes.CornflowerBlue;
+                }*/
                 pathIcon.Foreground = Brushes.CornflowerBlue;
                 break;
+            }
             case SukiMessageBoxIcons.Information:
                 pathIcon.Data = Icons.CircleInformation;
                 pathIcon.Foreground = Brushes.CornflowerBlue;
@@ -38,22 +48,35 @@ public static class SukiMessageBoxIconsFactory
                 pathIcon.Foreground = Brushes.Gold;
                 break;
             case SukiMessageBoxIcons.Warning:
+            {
                 pathIcon.Data = Icons.TriangleAlert;
                 pathIcon.Foreground = Brushes.Gold;
+                /*if (Application.Current!.TryGetResource("SukiWarningColor", Application.Current.ActualThemeVariant, out var value))
+                {
+                    pathIcon.Foreground = value is Color color ? new ImmutableSolidColorBrush(color) : Brushes.Gold;
+                }
+                else
+                {
+                    pathIcon.Foreground = Brushes.Gold;
+                }*/
                 break;
+            }
             case SukiMessageBoxIcons.Error:
                 pathIcon.Data = Icons.CircleClose;
-                pathIcon.Foreground = Brushes.DarkRed;
                 pathIcon.Foreground = Brushes.Firebrick;
                 break;
             case SukiMessageBoxIcons.Success:
+            {
                 pathIcon.Data = Icons.CircleCheck;
                 pathIcon.Foreground = Brushes.ForestGreen;
                 break;
+            }
             case SukiMessageBoxIcons.Star:
+            {
                 pathIcon.Data = Icons.Star;
                 pathIcon.Foreground = Brushes.Gold;
                 break;
+            }
             default:
                 throw new ArgumentOutOfRangeException(nameof(icon), icon, null);
         }

--- a/SukiUI/MessageBox/SukiMessageBoxOptions.cs
+++ b/SukiUI/MessageBox/SukiMessageBoxOptions.cs
@@ -1,4 +1,7 @@
 ﻿using Avalonia.Controls;
+using Avalonia.Media;
+using SukiUI.Controls;
+using SukiUI.Enums;
 
 namespace SukiUI.MessageBox;
 
@@ -7,6 +10,11 @@ namespace SukiUI.MessageBox;
 /// </summary>
 public record SukiMessageBoxOptions
 {
+    /// <summary>
+    /// Gets if the window should use the native <see cref="Window"/>, otherwise it will use the <see cref="SukiWindow"/>.
+    /// </summary>
+    public bool UseNativeWindow { get; init; }
+
     /// <summary>
     /// Gets if the window can resize.
     /// </summary>
@@ -36,6 +44,11 @@ public record SukiMessageBoxOptions
     /// Gets if the window can show in the taskbar.
     /// </summary>
     public bool ShowInTaskbar { get; init; } = false;
+
+    /// <summary>
+    /// Gets the flow direction of the window.
+    /// </summary>
+    public FlowDirection FlowDirection { get; init; }
 
     /// <summary>
     /// Gets the minimum width of the window.
@@ -81,4 +94,30 @@ public record SukiMessageBoxOptions
     /// Gets the window title to display in the title har.
     /// </summary>
     public string Title { get; init; } = string.Empty;
+
+
+    /// <inheritdoc cref="SukiBackground.AnimationEnabled"/>
+    public bool? BackgroundAnimationEnabled { get; init; }
+
+
+    /// <inheritdoc cref="SukiBackground.Style"/>
+    public SukiBackgroundStyle? BackgroundStyle { get; init; }
+
+
+    /// <inheritdoc cref="SukiBackground.ShaderFile"/>
+    public string? BackgroundShaderFile { get; init; }
+
+
+    /// <inheritdoc cref="SukiBackground.ShaderCode"/>
+    public string? BackgroundShaderCode { get; init; }
+
+
+    /// <inheritdoc cref="SukiBackground.TransitionsEnabled"/>
+    public bool? BackgroundTransitionsEnabled { get; init; }
+
+    /// <inheritdoc cref="SukiBackground.TransitionsEnabled"/>
+    public double? BackgroundTransitionTime { get; init; }
+
+    /// <inheritdoc cref="SukiBackground.ForceSoftwareRendering"/>
+    public bool? BackgroundForceSoftwareRendering { get; init; }
 }

--- a/SukiUI/Theme/TextBlock.xaml
+++ b/SukiUI/Theme/TextBlock.xaml
@@ -19,6 +19,7 @@
                     <TextBlock Classes="h2" Text="h2 TextBlock" />
                     <TextBlock Classes="h3" Text="h3 TextBlock" />
                     <TextBlock Classes="h4" Text="h4 TextBlock" />
+                    <TextBlock Classes="h5" Text="h5 TextBlock" />
                     <TextBlock Classes="Caption" Text="Caption TextBlock" />
                     <TextBlock Classes="Primary" Text="Primary TextBlock" />
                     <TextBlock Classes="Accent" Text="Accent TextBlock" />
@@ -36,6 +37,7 @@
                     <SelectableTextBlock Classes="h2" Text="h2 SelectableTextBlock" />
                     <SelectableTextBlock Classes="h3" Text="h3 SelectableTextBlock" />
                     <SelectableTextBlock Classes="h4" Text="h4 SelectableTextBlock" />
+                    <SelectableTextBlock Classes="h5" Text="h5 SelectableTextBlock" />
                     <SelectableTextBlock Classes="Caption" Text="Caption SelectableTextBlock" />
                     <SelectableTextBlock Classes="Primary" Text="Primary SelectableTextBlock" />
                     <SelectableTextBlock Classes="Accent" Text="Accent SelectableTextBlock" />
@@ -52,6 +54,9 @@
     <ControlTheme x:Key="SukiTextBlockStyle" TargetType="TextBlock">
         <Setter Property="FontSize" Value="14" />
 
+        <Style Selector="^.h5">
+            <Setter Property="FontSize" Value="16" />
+        </Style>
         <Style Selector="^.h4">
             <Setter Property="Margin" Value="0 7 0 10" />
             <Setter Property="FontSize" Value="20" />
@@ -59,17 +64,17 @@
         <Style Selector="^.h3">
 
             <Setter Property="Margin" Value="0 10 0 15" />
-            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="FontWeight" Value="DemiBold" />
             <Setter Property="FontSize" Value="25" />
         </Style>
         <Style Selector="^.h2">
             <Setter Property="Margin" Value="0 12 0 20" />
-            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="FontWeight" Value="DemiBold" />
             <Setter Property="FontSize" Value="30" />
         </Style>
         <Style Selector="^.h1">
             <Setter Property="Margin" Value="0 20 0 30" />
-            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="FontWeight" Value="DemiBold" />
             <Setter Property="FontSize" Value="40" />
         </Style>
         <Style Selector="^.Caption">


### PR DESCRIPTION
- Add `UseNativeWindow` property to `SukiMessageBoxOptions`
- Add SukiBackground properties to `SukiMessageBoxOptions`
- SukiMessageBoxHost now uses Controls and AvaloniaList<Buttons> instead of IEnumerable for easier set on xaml without the need of creating a list type
- Add `ItemsSpacing` Property on `SukiMessageBoxHost `
- `Null` window content after close a `SukiMessageBox` to be able to reuse `SukiMessageBoxHost` in another `SukiMessageBox.ShowDialog`
- `HorizontalContentAlignment` can now be used on `SukiMessageBoxHost`
- Move `ConstrainMaxSizeToScreenRatio` from `SukiWindow` to `WindowExtensions`
- Add `h5` style for text, SukiMessageBox title now set h5 class instead of fixed `FontSize=16`

![image](https://github.com/user-attachments/assets/8b12a24c-5ee3-4c03-8172-52bc12ca1aca)
