### PR TITLE
Update package references and formatting in project files

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -36,6 +36,7 @@
     <PackageVersion Include="SkiaSharp" Version="3.119.0-preview.1.2" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.0-preview.1.2" />
 
+    <PackageVersion Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-rc5.4" />
 
     <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.6.0.2" />
     <PackageVersion Include="System.Text.Json" Version="9.0.4" />

--- a/SukiUI.Demo/SukiUI.Demo.csproj
+++ b/SukiUI.Demo/SukiUI.Demo.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia" />
-    <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.2.0"/>
+    <PackageReference Include="Avalonia.AvaloniaEdit"/>
     <PackageReference Include="Avalonia.Controls.ColorPicker" />
     <PackageReference Include="Avalonia.Desktop" />
     <PackageReference Include="Avalonia.Fonts.Inter" />
@@ -27,7 +27,7 @@
     <PackageReference Include="Dock.Model.Avalonia" />
     <PackageReference Include="Dock.Model.Mvvm" />
     <PackageReference Include="Dock.Serializer" />
-    <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-rc5.4"  />
+    <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia"/>
     <PackageReference Include="Material.Icons.Avalonia" />
     <PackageReference Include="Markdown.Avalonia" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
@@ -93,7 +93,5 @@
       <SubType>Code</SubType>
     </Compile>
   </ItemGroup>
-
-
 
 </Project>


### PR DESCRIPTION
- Added `LiveChartsCore.SkiaSharpView.Avalonia` as a versionless reference in `Directory.Packages.props` and `SukiUI.Demo.csproj`.
- Updated `Avalonia.AvaloniaEdit` to a versionless reference for flexibility.
- Removed an empty line at the end of `SukiUI.Demo.csproj` for cleaner formatting.