### PR TITLE
About Textbox Height

### DIFF
--- a/SukiUI/Theme/TextBoxStyles.xaml
+++ b/SukiUI/Theme/TextBoxStyles.xaml
@@ -134,7 +134,7 @@
 
             <ControlTemplate>
 
-                <Grid RowDefinitions="Auto Auto">
+                <Grid RowDefinitions="Auto *">
 
                     <TextBlock Name="floatingWatermark"
                                Grid.Row="0"


### PR DESCRIPTION
Setting 'RowDefinitions="Auto Auto"' will make it impossible to set the height of the TextBox. Moreover, the TextBox won't be able to expand within the Grid, and the scrollbar of the TextBox will also stop functioning.