### PR TITLE
TextBox fine-tune

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,13 +14,11 @@
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Controls.DataGrid" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Controls.ColorPicker" Version="$(AvaloniaVersion)" />
-
     <PackageVersion Include="Dock.Avalonia" Version="11.3.0.2" />
     <PackageVersion Include="Dock.Model" Version="11.3.0.2" />
     <PackageVersion Include="Dock.Model.Avalonia" Version="11.3.0.2" />
     <PackageVersion Include="Dock.Model.Mvvm" Version="11.3.0.2" />
     <PackageVersion Include="Dock.Serializer" Version="11.3.0.2" />
-
     <PackageVersion Include="Avalonia.AvaloniaEdit" Version="11.3.0" />
     <PackageVersion Include="AvaloniaEdit.TextMate" Version="11.3.0" />
     <PackageVersion Include="Markdown.Avalonia" Version="11.0.2" />
@@ -32,10 +30,9 @@
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.0" />
     <PackageVersion Include="SkiaSharp.NativeAssets.macOS" Version="3.119.0" />
     <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="3.119.0" />
-
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
     <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.6.5" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.5" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.6" />
   </ItemGroup>
 </Project>

--- a/SukiUI.Demo/Features/Dashboard/DashboardView.axaml
+++ b/SukiUI.Demo/Features/Dashboard/DashboardView.axaml
@@ -1,9 +1,9 @@
 <UserControl x:Class="SukiUI.Demo.Features.Dashboard.DashboardView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:dashboard="clr-namespace:SukiUI.Demo.Features.Dashboard"
+             xmlns:icon="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:suki="https://github.com/kikipoulet/SukiUI"
              d:DesignHeight="650"
@@ -24,12 +24,12 @@
                                    BusyText="Signing In..."
                                    IsBusy="{Binding IsLoggingIn}">
                         <StackPanel>
-                            <avalonia:MaterialIcon Width="30"
-                                                   Height="30"
-                                                   Margin="10"
-                                                   HorizontalAlignment="Center"
-                                                   Foreground="{DynamicResource SukiPrimaryColor}"
-                                                   Kind="MicrosoftEdge" />
+                            <icon:MaterialIcon Width="30"
+                                               Height="30"
+                                               Margin="10"
+                                               HorizontalAlignment="Center"
+                                               Foreground="{DynamicResource SukiPrimaryColor}"
+                                               Kind="MicrosoftEdge" />
                             <TextBlock Margin="0,5,0,27"
                                        HorizontalAlignment="Center"
                                        FontSize="18"
@@ -39,8 +39,9 @@
                                        FontWeight="DemiBold"
                                        Foreground="{DynamicResource SukiLowText}"
                                        Text="Username" />
-                            <TextBox suki:TextBoxExtensions.Prefix=""
+                            <TextBox suki:TextBoxExtensions.Prefix="{icon:MaterialIconExt Kind=User}"
                                      Classes="clearButton"
+                                     Text="{Binding Username}"
                                      Watermark="John" />
                             <TextBlock Margin="6,18,0,3"
                                        FontWeight="DemiBold"
@@ -48,9 +49,11 @@
                                        Text="Password" />
                             <TextBox Name="PasswordTextBox"
                                      Margin="0,0,0,25"
-                                     suki:TextBoxExtensions.AddDeleteButton="False"
+                                     suki:TextBoxExtensions.AddDeleteButton="True"
+                                     suki:TextBoxExtensions.Prefix="{icon:MaterialIconExt Kind=Password}"
                                      Classes="revealPasswordButton"
                                      PasswordChar="*"
+                                     Text="{Binding Password}"
                                      Watermark="*******" />
                         </StackPanel>
                     </suki:BusyArea>
@@ -120,9 +123,9 @@
                                 <TextBlock FontSize="13"
                                            Foreground="Green"
                                            Text="32.21%" />
-                                <avalonia:MaterialIcon Margin="5,0,0,0"
-                                                       Foreground="Green"
-                                                       Kind="ArrowUp" />
+                                <icon:MaterialIcon Margin="5,0,0,0"
+                                                   Foreground="Green"
+                                                   Kind="ArrowUp" />
                             </StackPanel>
                         </Grid>
                         <ProgressBar Margin="0,1,0,0" Value="16" />
@@ -136,9 +139,9 @@
                                 <TextBlock FontSize="13"
                                            Foreground="Red"
                                            Text="7.18%" />
-                                <avalonia:MaterialIcon Margin="5,0,0,0"
-                                                       Foreground="Red"
-                                                       Kind="ArrowDown" />
+                                <icon:MaterialIcon Margin="5,0,0,0"
+                                                   Foreground="Red"
+                                                   Kind="ArrowDown" />
                             </StackPanel>
                         </Grid>
                         <ProgressBar Margin="0,1,0,0" Value="62" />
@@ -153,9 +156,9 @@
                                 <TextBlock FontSize="13"
                                            Foreground="Green"
                                            Text="16.89%" />
-                                <avalonia:MaterialIcon Margin="5,0,0,0"
-                                                       Foreground="Green"
-                                                       Kind="ArrowUp" />
+                                <icon:MaterialIcon Margin="5,0,0,0"
+                                                   Foreground="Green"
+                                                   Kind="ArrowUp" />
                             </StackPanel>
                         </Grid>
                         <ProgressBar Margin="0,1,0,0" Value="34" />
@@ -181,16 +184,16 @@
                         <suki:WaveProgress Value="{Binding Value, ElementName=SliderT}" />
                     </Viewbox>
                     <DockPanel VerticalAlignment="Bottom">
-                        <avalonia:MaterialIcon Width="20"
-                                               Height="20"
-                                               DockPanel.Dock="Left"
-                                               Foreground="#666666"
-                                               Kind="TemperatureLow" />
-                        <avalonia:MaterialIcon Width="20"
-                                               Height="20"
-                                               DockPanel.Dock="Right"
-                                               Foreground="#666666"
-                                               Kind="TemperatureHigh" />
+                        <icon:MaterialIcon Width="20"
+                                           Height="20"
+                                           DockPanel.Dock="Left"
+                                           Foreground="#666666"
+                                           Kind="TemperatureLow" />
+                        <icon:MaterialIcon Width="20"
+                                           Height="20"
+                                           DockPanel.Dock="Right"
+                                           Foreground="#666666"
+                                           Kind="TemperatureHigh" />
                         <Slider Name="SliderT"
                                 Margin="8,0"
                                 Maximum="100"
@@ -345,7 +348,7 @@
                                 <Expander>
                                     <Expander.Header>
                                         <StackPanel Orientation="Horizontal">
-                                            <avalonia:MaterialIcon Foreground="{DynamicResource SukiText}" Kind="Lock" />
+                                            <icon:MaterialIcon Foreground="{DynamicResource SukiText}" Kind="Lock" />
                                             <TextBlock Text="Test Lock" />
                                         </StackPanel>
                                     </Expander.Header>
@@ -387,7 +390,7 @@
                 <suki:GroupBox>
                     <suki:GroupBox.Header>
                         <StackPanel Orientation="Horizontal">
-                            <avalonia:MaterialIcon Foreground="{DynamicResource SukiLowText}" Kind="Dollar" />
+                            <icon:MaterialIcon Foreground="{DynamicResource SukiLowText}" Kind="Dollar" />
                             <TextBlock Margin="5,0,0,0" Text="Change Plan" />
                         </StackPanel>
                     </suki:GroupBox.Header>

--- a/SukiUI.Demo/Features/Dashboard/DashboardViewModel.cs
+++ b/SukiUI.Demo/Features/Dashboard/DashboardViewModel.cs
@@ -1,9 +1,8 @@
+using System.ComponentModel.DataAnnotations;
 using Avalonia.Collections;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Material.Icons;
-using SukiUI.Controls;
-using System.Threading.Tasks;
 using SukiUI.Dialogs;
 
 namespace SukiUI.Demo.Features.Dashboard;
@@ -11,6 +10,8 @@ namespace SukiUI.Demo.Features.Dashboard;
 public partial class DashboardViewModel : DemoPageBase
 {
     [ObservableProperty] private bool _isLoggingIn;
+    [ObservableProperty][Required] [MinLength(5)] [MaxLength(20)] private string? _username;
+    [ObservableProperty][Required] [MinLength(6)] [MaxLength(20)] private string? _password;
     [ObservableProperty] private int _stepperIndex;
 
     public IAvaloniaReadOnlyList<InvoiceViewModel> Invoices { get; } = new AvaloniaList<InvoiceViewModel>()
@@ -27,7 +28,7 @@ public partial class DashboardViewModel : DemoPageBase
     {
         "Dispatched", "En-Route", "Delivered"
     };
-    
+
     private readonly ISukiDialogManager _dialogManager;
 
     public DashboardViewModel(ISukiDialogManager dialogManager) : base("Dashboard", MaterialIconKind.CircleOutline, -100)

--- a/SukiUI.Demo/SukiUIDemoView.axaml
+++ b/SukiUI.Demo/SukiUIDemoView.axaml
@@ -277,8 +277,7 @@
     </suki:SukiWindow.MenuItems>
     <suki:SukiSideMenu IsSearchEnabled="True"
                        ItemsSource="{Binding DemoPages}"
-                       SelectedItem="{Binding ActivePage}"
-                       >
+                       SelectedItem="{Binding ActivePage}">
         <suki:SukiSideMenu.Styles>
             <Style Selector="Image.AppIcon">
                 <Setter Property="Transitions">
@@ -287,7 +286,7 @@
                     </Transitions>
                 </Setter>
                 <Style Selector="^:pointerover">
-                    <Setter Property="Opacity" Value="0.5" />
+                    <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}" />
                 </Style>
             </Style>
         </suki:SukiSideMenu.Styles>

--- a/SukiUI/Theme/Button.axaml
+++ b/SukiUI/Theme/Button.axaml
@@ -238,7 +238,7 @@
 
         <!--  Nested Selectors For Basic Button  -->
         <Style Selector="^:disabled">
-            <Setter Property="Opacity" Value="0.5" />
+            <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}" />
         </Style>
 
         <!--  Events For Basic Button  -->

--- a/SukiUI/Theme/DataGridStyle.axaml
+++ b/SukiUI/Theme/DataGridStyle.axaml
@@ -1,15 +1,19 @@
-<Styles xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:objectModel="clr-namespace:System.Collections.ObjectModel;assembly=netstandard">
     <Design.PreviewWith>
-        <Border Background="White" Padding="20">
-            <DataGrid GridLinesVisibility="All" CanUserResizeColumns="True" Height="200" AutoGenerateColumns="True">
-               <DataGrid.ItemsSource>
-                   <objectModel:ObservableCollection x:TypeArguments="DataGridCell">
-                       <DataGridCell HorizontalAlignment="Left"></DataGridCell>
-                       <DataGridCell HorizontalAlignment="Left"></DataGridCell>
-                       <DataGridCell HorizontalAlignment="Left"></DataGridCell>
-                   </objectModel:ObservableCollection>
-               </DataGrid.ItemsSource>
+        <Border Padding="20" Background="White">
+            <DataGrid Height="200"
+                      AutoGenerateColumns="True"
+                      CanUserResizeColumns="True"
+                      GridLinesVisibility="All">
+                <DataGrid.ItemsSource>
+                    <objectModel:ObservableCollection x:TypeArguments="DataGridCell">
+                        <DataGridCell HorizontalAlignment="Left" />
+                        <DataGridCell HorizontalAlignment="Left" />
+                        <DataGridCell HorizontalAlignment="Left" />
+                    </objectModel:ObservableCollection>
+                </DataGrid.ItemsSource>
             </DataGrid>
         </Border>
     </Design.PreviewWith>
@@ -22,7 +26,7 @@
             <ControlTemplate>
                 <Grid Background="{TemplateBinding Background}" ColumnDefinitions="*,Auto">
                     <ContentPresenter Margin="{TemplateBinding Padding}"
-                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                       VerticalAlignment="Center"
                                       Content="{TemplateBinding Content}"
                                       ContentTemplate="{TemplateBinding ContentTemplate}"
@@ -32,7 +36,7 @@
                                Grid.Column="1"
                                HorizontalAlignment="Stretch"
                                VerticalAlignment="Stretch"
-                               Stroke="{DynamicResource SukiBorderBrush}" 
+                               Stroke="{DynamicResource SukiBorderBrush}"
                                StrokeThickness="1" />
                 </Grid>
             </ControlTemplate>
@@ -100,7 +104,7 @@
     </Style>
 
     <Style Selector="DataGridColumnHeader:dragIndicator">
-        <Setter Property="Opacity" Value="0.5" />
+        <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}" />
     </Style>
 
     <Style Selector="DataGridColumnHeader /template/ Path#SortIcon">
@@ -137,7 +141,8 @@
                     <Border Name="BackgroundRectangle"
                             Grid.RowSpan="2"
                             Grid.ColumnSpan="2"
-                            Padding="18" Background="{TemplateBinding Background}"
+                            Padding="18"
+                            Background="{TemplateBinding Background}"
                             BorderBrush="{DynamicResource SukiBorderBrush}"
                             BorderThickness="0,0,0,1"
                             CornerRadius="0" />
@@ -149,7 +154,7 @@
                                        DataGridFrozenGrid.IsFrozen="True" />
                     <DataGridCellsPresenter Name="PART_CellsPresenter"
                                             Grid.Row="0"
-                                            Grid.Column="1" 
+                                            Grid.Column="1"
                                             Margin="6,0"
                                             DataGridFrozenGrid.IsFrozen="True" />
                     <DataGridDetailsPresenter Name="PART_DetailsPresenter"
@@ -225,7 +230,7 @@
         <Setter Property="Height" Value="32" />
         <Setter Property="Template">
             <ControlTemplate>
-                <DataGridFrozenGrid Name="Root" 
+                <DataGridFrozenGrid Name="Root"
                                     Background="{TemplateBinding Background}"
                                     ColumnDefinitions="Auto,Auto,Auto,Auto"
                                     RowDefinitions="Auto,*,Auto">
@@ -236,9 +241,9 @@
                     <ToggleButton Name="PART_ExpanderButton"
                                   Grid.Row="1"
                                   Grid.Column="2"
+                                  Margin="2,11,0,0"
                                   FontWeight="DemiBold"
-                                  Foreground="{DynamicResource SukiText}"
-                                  Margin="2,11,0,0" />
+                                  Foreground="{DynamicResource SukiText}" />
 
                     <StackPanel Grid.Row="1"
                                 Grid.Column="3"
@@ -249,20 +254,24 @@
                                    Margin="4,0,0,0"
                                    FontWeight="DemiBold"
                                    IsVisible="{TemplateBinding IsPropertyNameVisible}" />
-                        <TextBlock Margin="4,0,0,0" 
-                                   FontWeight="DemiBold" FontSize="16"
-                                   Text="{Binding Key}" />
-                        <TextBlock Name="PART_ItemCountElement" FontSize="14" Foreground="{DynamicResource SukiLowText}"
-                                   Margin="8,2,0,0"
+                        <TextBlock Margin="4,0,0,0"
+                                   FontSize="16"
                                    FontWeight="DemiBold"
+                                   Text="{Binding Key}" />
+                        <TextBlock Name="PART_ItemCountElement"
+                                   Margin="8,2,0,0"
+                                   FontSize="14"
+                                   FontWeight="DemiBold"
+                                   Foreground="{DynamicResource SukiLowText}"
                                    IsVisible="{TemplateBinding IsItemCountVisible}" />
                     </StackPanel>
 
                     <DataGridRowHeader Name="RowHeader"
                                        Grid.Row="0"
-                                       Grid.RowSpan="3" Margin="-25,25,0,0"
+                                       Grid.RowSpan="3"
                                        Grid.Column="0"
-                                       DataGridFrozenGrid.IsFrozen="True"/>
+                                       Margin="-25,25,0,0"
+                                       DataGridFrozenGrid.IsFrozen="True" />
 
                 </DataGridFrozenGrid>
             </ControlTemplate>
@@ -316,13 +325,13 @@
                     <Grid ColumnDefinitions="Auto,*,Auto" RowDefinitions="Auto,*,Auto,Auto">
                         <Grid.Styles>
                             <Style Selector="DataGrid /template/ Border > Grid:pointerover ScrollBar#PART_VerticalScrollbar">
-                                <Setter Property="AllowAutoHide" Value="True"></Setter>
+                                <Setter Property="AllowAutoHide" Value="True" />
                             </Style>
                             <Style Selector="DataGrid /template/ Border > Grid:pointerover ScrollBar#PART_HorizontalScrollbar">
-                                <Setter Property="AllowAutoHide" Value="True"></Setter>
+                                <Setter Property="AllowAutoHide" Value="True" />
                             </Style>
                         </Grid.Styles>
-                        
+
                         <DataGridColumnHeader Name="PART_TopLeftCornerHeader"
                                               Grid.Row="0"
                                               Grid.Column="0"
@@ -343,24 +352,24 @@
                                    StrokeThickness="1" />
 
                         <DataGridRowsPresenter Name="PART_RowsPresenter"
-                                    ClipToBounds="True"
-                                    Grid.Row="1"
-                                    Grid.Column="0"
-                                    Grid.ColumnSpan="3">
+                                               Grid.Row="1"
+                                               Grid.Column="0"
+                                               Grid.ColumnSpan="3"
+                                               ClipToBounds="True">
                             <DataGridRowsPresenter.GestureRecognizers>
                                 <ScrollGestureRecognizer CanHorizontallyScroll="True" CanVerticallyScroll="True" />
                             </DataGridRowsPresenter.GestureRecognizers>
                         </DataGridRowsPresenter>
 
                         <ScrollBar Name="PART_VerticalScrollbar"
-                                   Orientation="Vertical"
-                                   Grid.Column="2"
                                    Grid.Row="1"
-                                   HorizontalAlignment="Right" />
+                                   Grid.Column="2"
+                                   HorizontalAlignment="Right"
+                                   Orientation="Vertical" />
 
-                        <Grid Grid.Column="1"
+                        <Grid Grid.Row="2"
+                              Grid.Column="1"
                               Grid.ColumnSpan="2"
-                              Grid.Row="2"
                               ColumnDefinitions="Auto,*">
                             <Rectangle Name="PART_FrozenColumnScrollBarSpacer" />
                             <ScrollBar Name="PART_HorizontalScrollbar"

--- a/SukiUI/Theme/MenuItem.axaml
+++ b/SukiUI/Theme/MenuItem.axaml
@@ -80,8 +80,7 @@
                                                   Content="{TemplateBinding Icon}" />
                                 <CheckBox Name="PART_Check"
                                           Margin="2,0,0,0"
-                                          IsChecked="{TemplateBinding IsChecked,
-                                                                      Mode=TwoWay}"
+                                          IsChecked="{TemplateBinding IsChecked, Mode=TwoWay}"
                                           IsVisible="False" />
                             </Panel>
                             <Rectangle Width="1"
@@ -107,8 +106,7 @@
                                        DockPanel.Dock="Right"
                                        Foreground="{DynamicResource SukiMuteText}"
                                        IsVisible="{Binding InputGesture, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static ObjectConverters.IsNotNull}}"
-                                       Text="{TemplateBinding InputGesture,
-                                                              Converter={StaticResource KeyGestureConverter}}" />
+                                       Text="{TemplateBinding InputGesture, Converter={StaticResource KeyGestureConverter}}" />
 
 
                             <ContentPresenter Name="PART_HeaderPresenter"
@@ -128,8 +126,7 @@
                                ClipToBounds="True"
                                HorizontalOffset="-25"
                                IsLightDismissEnabled="False"
-                               IsOpen="{TemplateBinding IsSubMenuOpen,
-                                                        Mode=TwoWay}"
+                               IsOpen="{TemplateBinding IsSubMenuOpen, Mode=TwoWay}"
                                Opacity="0"
                                OverlayInputPassThroughElement="{Binding $parent[MenuItem]}"
                                Placement="RightEdgeAlignedTop"
@@ -208,7 +205,7 @@
         </Style>
 
         <Style Selector="^:not(.Menu):disabled">
-            <Setter Property="Opacity" Value="0.56" />
+            <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}" />
         </Style>
 
         <Style Selector="^:empty /template/ PathIcon#PART_RightArrow">

--- a/SukiUI/Theme/NumericUpDown.axaml
+++ b/SukiUI/Theme/NumericUpDown.axaml
@@ -1,12 +1,13 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:suki="https://github.com/kikipoulet/SukiUI">
+                    xmlns:suki="https://github.com/kikipoulet/SukiUI"
+                    xmlns:system="clr-namespace:System;assembly=netstandard">
     <!--  Add Resources Here  -->
     <Design.PreviewWith>
         <Border Padding="20">
             <Border.Styles>
                 <Style Selector="NumericUpDown">
-                    <Setter Property="Width" Value="120" />
+                    <Setter Property="Width" Value="300" />
                 </Style>
             </Border.Styles>
             <StackPanel Orientation="Vertical" Spacing="5">
@@ -16,7 +17,11 @@
                                Value="120" />
                 <NumericUpDown IsEnabled="False" Value="120" />
                 <NumericUpDown AllowSpin="False" Value="120" />
-                <NumericUpDown Increment="0.05" Value="120" />
+                <NumericUpDown Height="64"
+                               suki:NumericUpDownExtensions.UseFloatingWatermark="True"
+                               Increment="0.05"
+                               Watermark="Large height"
+                               Value="120" />
                 <NumericUpDown suki:NumericUpDownExtensions.Unit="mm"
                                FormatString="F0"
                                Value="120" />
@@ -24,6 +29,39 @@
                                ButtonSpinnerLocation="Left"
                                FormatString="F0"
                                Value="120" />
+                <NumericUpDown FormatString="F0"
+                               InnerLeftContent="[L]"
+                               InnerRightContent="[R]"
+                               Value="120" />
+                <NumericUpDown suki:NumericUpDownExtensions.Unit="mm"
+                               FormatString="F0"
+                               InnerLeftContent="[L]"
+                               InnerRightContent="[R]"
+                               Watermark="Validation"
+                               Value="120">
+                    <DataValidationErrors.Error>
+                        <system:Exception>
+                            <x:Arguments>
+                                <x:String>Validation error</x:String>
+                            </x:Arguments>
+                        </system:Exception>
+                    </DataValidationErrors.Error>
+                </NumericUpDown>
+                <NumericUpDown suki:NumericUpDownExtensions.Unit="mm"
+                               suki:NumericUpDownExtensions.UseFloatingWatermark="True"
+                               FormatString="F0"
+                               InnerLeftContent="[L]"
+                               InnerRightContent="[R]"
+                               Watermark="Validation"
+                               Value="120">
+                    <DataValidationErrors.Error>
+                        <system:Exception>
+                            <x:Arguments>
+                                <x:String>Validation error</x:String>
+                            </x:Arguments>
+                        </system:Exception>
+                    </DataValidationErrors.Error>
+                </NumericUpDown>
             </StackPanel>
         </Border>
     </Design.PreviewWith>
@@ -37,52 +75,50 @@
         <Setter Property="Focusable" Value="True" />
         <Setter Property="Template">
             <ControlTemplate>
-                <DataValidationErrors>
-                    <Border Name="border"
-                            Margin="{TemplateBinding Padding}"
-                            HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
-                            VerticalAlignment="{TemplateBinding VerticalAlignment}"
-                            Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            CornerRadius="{TemplateBinding CornerRadius}">
-                        <DockPanel>
-                            <UniformGrid Name="PART_SpinnerPanel"
-                                         DockPanel.Dock="Right"
-                                         IsVisible="{TemplateBinding ShowButtonSpinner}"
-                                         Rows="2">
-                                <RepeatButton Name="PART_IncreaseButton"
-                                              BorderThickness="0"
-                                              Theme="{StaticResource SimpleButtonSpinnerRepeatButton}">
-                                    <Path Width="8"
-                                          Height="4"
-                                          HorizontalAlignment="Center"
-                                          VerticalAlignment="Center"
-                                          Data="M0,5 L4.5,.5 9,5 6,5 4.5,3.5 3,5 z"
-                                          Fill="{DynamicResource SukiText}"
-                                          Stretch="Uniform" />
-                                </RepeatButton>
-                                <RepeatButton Name="PART_DecreaseButton"
-                                              BorderThickness="0"
-                                              Theme="{StaticResource SimpleButtonSpinnerRepeatButton}">
-                                    <Path Width="8"
-                                          Height="4"
-                                          HorizontalAlignment="Center"
-                                          VerticalAlignment="Center"
-                                          Data="M0,0 L3,0 4.5,1.5 6,0 9,0 4.5,4.5 z"
-                                          Fill="{DynamicResource SukiText}"
-                                          Stretch="Uniform" />
-                                </RepeatButton>
-                            </UniformGrid>
-                            <ContentPresenter Name="PART_ContentPresenter"
-                                              Padding="{TemplateBinding Padding}"
-                                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                              Content="{TemplateBinding Content}"
-                                              ContentTemplate="{TemplateBinding ContentTemplate}" />
-                        </DockPanel>
-                    </Border>
-                </DataValidationErrors>
+                <Border Name="border"
+                        Margin="{TemplateBinding Padding}"
+                        HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                        VerticalAlignment="{TemplateBinding VerticalAlignment}"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        CornerRadius="{TemplateBinding CornerRadius}">
+                    <DockPanel>
+                        <UniformGrid Name="PART_SpinnerPanel"
+                                     DockPanel.Dock="Right"
+                                     IsVisible="{TemplateBinding ShowButtonSpinner}"
+                                     Rows="2">
+                            <RepeatButton Name="PART_IncreaseButton"
+                                          BorderThickness="0"
+                                          Theme="{StaticResource SimpleButtonSpinnerRepeatButton}">
+                                <Path Width="8"
+                                      Height="4"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"
+                                      Data="M0,5 L4.5,.5 9,5 6,5 4.5,3.5 3,5 z"
+                                      Fill="{DynamicResource SukiText}"
+                                      Stretch="Uniform" />
+                            </RepeatButton>
+                            <RepeatButton Name="PART_DecreaseButton"
+                                          BorderThickness="0"
+                                          Theme="{StaticResource SimpleButtonSpinnerRepeatButton}">
+                                <Path Width="8"
+                                      Height="4"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"
+                                      Data="M0,0 L3,0 4.5,1.5 6,0 9,0 4.5,4.5 z"
+                                      Fill="{DynamicResource SukiText}"
+                                      Stretch="Uniform" />
+                            </RepeatButton>
+                        </UniformGrid>
+                        <ContentPresenter Name="PART_ContentPresenter"
+                                          Padding="{TemplateBinding Padding}"
+                                          HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}" />
+                    </DockPanel>
+                </Border>
             </ControlTemplate>
         </Setter>
 
@@ -104,90 +140,91 @@
     </ControlTheme>
 
     <ControlTheme x:Key="SukiNumericUpDown" TargetType="NumericUpDown">
-        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Foreground" Value="{DynamicResource SukiText}" />
         <Setter Property="BorderBrush" Value="{DynamicResource SukiControlBorderBrush}" />
         <Setter Property="CornerRadius" Value="{DynamicResource SmallCornerRadius}" />
-        <Setter Property="Background" Value="{DynamicResource SukiBackground}" />
+        <Setter Property="Background" Value="{DynamicResource SukiGlassCardBackground}" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
-        <Setter Property="HorizontalContentAlignment" Value="Left" />
-        <Setter Property="Padding" Value="5" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="Padding" Value="5,5,0,5" />
+        <Setter Property="MinHeight" Value="36" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Border Background="{TemplateBinding Background}"
-                        BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="{TemplateBinding BorderThickness}"
-                        CornerRadius="{TemplateBinding CornerRadius}">
-                    <suki:GlassCard Padding="0"
-                                    VerticalAlignment="Center"
-                                    Classes="Discrete"
-                                    CornerRadius="{TemplateBinding CornerRadius}">
-                        <ButtonSpinner Name="PART_Spinner"
-                                       Height="26"
-                                       Margin="5,4"
-                                       HorizontalContentAlignment="Stretch"
-                                       VerticalContentAlignment="Stretch"
-                                       AllowSpin="{TemplateBinding AllowSpin}"
-                                       BorderThickness="0"
-                                       ButtonSpinnerLocation="{TemplateBinding ButtonSpinnerLocation}"
-                                       CornerRadius="{TemplateBinding CornerRadius}"
-                                       ShowButtonSpinner="{TemplateBinding ShowButtonSpinner}"
-                                       Theme="{StaticResource SukiNumericUpDownButtonSpinner}">
-                            <Grid ColumnDefinitions="*,Auto">
+                <suki:GlassCard Name="PART_GlassCard"
+                                Padding="0"
+                                HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                                VerticalAlignment="{TemplateBinding VerticalAlignment}"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{TemplateBinding CornerRadius}">
+                    <suki:GlassCard.Transitions>
+                        <Transitions>
+                            <BrushTransition Property="BorderBrush" Duration="0:0:0.15" />
+                        </Transitions>
+                    </suki:GlassCard.Transitions>
+                    <ButtonSpinner Name="PART_Spinner"
+                                   Margin="5,0"
+                                   HorizontalContentAlignment="Stretch"
+                                   VerticalContentAlignment="Stretch"
+                                   AllowSpin="{TemplateBinding AllowSpin}"
+                                   Background="Transparent"
+                                   BorderThickness="0"
+                                   ButtonSpinnerLocation="{TemplateBinding ButtonSpinnerLocation}"
+                                   CornerRadius="{TemplateBinding CornerRadius}"
+                                   ShowButtonSpinner="{TemplateBinding ShowButtonSpinner}"
+                                   Theme="{StaticResource SukiNumericUpDownButtonSpinner}">
+                        <Grid ColumnDefinitions="*,Auto"
+                              ColumnSpacing="5"
+                              RowDefinitions="*">
+                            <DataValidationErrors Grid.Column="0">
                                 <TextBox Name="PART_TextBox"
-                                         Grid.Column="0"
                                          MinWidth="20"
+                                         MinHeight="34"
                                          Padding="{TemplateBinding Padding}"
                                          HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                         suki:TextBoxExtensions.AddDeleteButton="False"
                                          AcceptsReturn="False"
                                          Background="Transparent"
+                                         BorderBrush="Transparent"
                                          BorderThickness="0"
-                                         Classes="NoShadow"
                                          CornerRadius="0"
-                                         DataValidationErrors.Errors="{TemplateBinding (DataValidationErrors.Errors)}"
                                          FontSize="{TemplateBinding FontSize}"
                                          FontWeight="{TemplateBinding FontWeight}"
                                          Foreground="{TemplateBinding Foreground}"
+                                         InnerLeftContent="{TemplateBinding InnerLeftContent}"
+                                         InnerRightContent="{TemplateBinding InnerRightContent}"
                                          IsReadOnly="{TemplateBinding IsReadOnly}"
                                          Text="{TemplateBinding Text}"
                                          TextWrapping="NoWrap"
+                                         UseFloatingWatermark="{TemplateBinding suki:NumericUpDownExtensions.UseFloatingWatermark}"
                                          Watermark="{TemplateBinding Watermark}" />
-                                <ContentPresenter Grid.Column="1"
-                                                  Margin="5,0,5,0"
-                                                  VerticalAlignment="Center"
-                                                  Content="{TemplateBinding suki:NumericUpDownExtensions.Unit}"
-                                                  FontSize="{TemplateBinding FontSize}"
-                                                  Foreground="{DynamicResource SukiLowText}"
-                                                  IsVisible="{TemplateBinding suki:NumericUpDownExtensions.Unit, Converter={x:Static ObjectConverters.IsNotNull}}" />
-                            </Grid>
+                            </DataValidationErrors>
+                            <ContentPresenter Grid.Column="1"
+                                              Margin="0,0,5,0"
+                                              VerticalAlignment="Center"
+                                              Content="{TemplateBinding suki:NumericUpDownExtensions.Unit}"
+                                              FontSize="{TemplateBinding FontSize}"
+                                              Foreground="{DynamicResource SukiLowText}"
+                                              IsVisible="{TemplateBinding suki:NumericUpDownExtensions.Unit, Converter={x:Static ObjectConverters.IsNotNull}}" />
+                        </Grid>
 
-                        </ButtonSpinner>
-                    </suki:GlassCard>
-                </Border>
+                    </ButtonSpinner>
+                </suki:GlassCard>
             </ControlTemplate>
         </Setter>
 
-        <Style Selector="^ /template/ Border">
-            <Setter Property="BorderThickness" Value="0" />
-
-        </Style>
-        <Style Selector="^:pointerover /template/ TextBox">
-            <Setter Property="Background" Value="Transparent" />
-            <Setter Property="BorderThickness" Value="0" />
-            <Setter Property="BorderBrush" Value="{DynamicResource SukiControlBorderBrush}" />
-        </Style>
-        <Style Selector="^:pressed /template/ TextBox">
-            <Setter Property="Background" Value="Transparent" />
-            <Setter Property="BorderBrush" Value="{DynamicResource SukiControlBorderBrush}" />
-        </Style>
         <Style Selector="^:disabled">
-            <Setter Property="Foreground" Value="{DynamicResource SukiDisabledText}" />
+            <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}" />
         </Style>
 
-        <Style Selector="^:pointerover">
-            <Setter Property="BorderBrush" Value="{DynamicResource SukiBorderBrush}" />
+        <Style Selector="^:pointerover, ^:focus">
+            <Setter Property="BorderBrush" Value="{DynamicResource SukiPrimaryColor}" />
+        </Style>
+
+        <Style Selector="^:error">
+            <Setter Property="BorderBrush" Value="{DynamicResource ErrorBrush}" />
         </Style>
 
     </ControlTheme>

--- a/SukiUI/Theme/NumericUpDownExtensions.cs
+++ b/SukiUI/Theme/NumericUpDownExtensions.cs
@@ -17,4 +17,17 @@ public class NumericUpDownExtensions
     {
         textBox.SetValue(UnitProperty, value);
     }
+
+    public static readonly AttachedProperty<bool> UseFloatingWatermarkProperty =
+        AvaloniaProperty.RegisterAttached<NumericUpDown, bool>("UseFloatingWatermark", typeof(NumericUpDown));
+
+    public static bool GetUseFloatingWatermark(NumericUpDown textBox)
+    {
+        return textBox.GetValue(UseFloatingWatermarkProperty);
+    }
+
+    public static void SetUseFloatingWatermark(NumericUpDown textBox, bool value)
+    {
+        textBox.SetValue(UseFloatingWatermarkProperty, value);
+    }
 }

--- a/SukiUI/Theme/SplitButton.axaml
+++ b/SukiUI/Theme/SplitButton.axaml
@@ -179,14 +179,12 @@
                             suki:ButtonExtensions.ShowProgress="{TemplateBinding suki:SplitButtonExtensions.ShowProgress}"
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness,
-                                                              Converter={StaticResource PrimaryButtonBorderMultiplier}}"
+                            BorderThickness="{TemplateBinding BorderThickness, Converter={StaticResource PrimaryButtonBorderMultiplier}}"
                             Command="{TemplateBinding Command}"
                             CommandParameter="{TemplateBinding CommandParameter}"
                             Content="{TemplateBinding Content}"
                             ContentTemplate="{TemplateBinding ContentTemplate}"
-                            CornerRadius="{TemplateBinding CornerRadius,
-                                                           Converter={StaticResource LeftCornerRadiusFilterConverter}}"
+                            CornerRadius="{TemplateBinding CornerRadius, Converter={StaticResource LeftCornerRadiusFilterConverter}}"
                             Focusable="False"
                             FontFamily="{TemplateBinding FontFamily}"
                             FontSize="{TemplateBinding FontSize}"
@@ -206,10 +204,8 @@
                             VerticalContentAlignment="Center"
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness,
-                                                              Converter={StaticResource SecondaryButtonBorderMultiplier}}"
-                            CornerRadius="{TemplateBinding CornerRadius,
-                                                           Converter={StaticResource RightCornerRadiusFilterConverter}}"
+                            BorderThickness="{TemplateBinding BorderThickness, Converter={StaticResource SecondaryButtonBorderMultiplier}}"
+                            CornerRadius="{TemplateBinding CornerRadius, Converter={StaticResource RightCornerRadiusFilterConverter}}"
                             Focusable="False"
                             Foreground="{TemplateBinding Foreground}"
                             KeyboardNavigation.IsTabStop="False"
@@ -233,7 +229,7 @@
         </Setter>
 
         <Style Selector="^:disabled">
-            <Setter Property="Opacity" Value="0.5" />
+            <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}" />
         </Style>
 
         <Style Selector="^:flyout-open /template/ Button">

--- a/SukiUI/Theme/TextBox.axaml
+++ b/SukiUI/Theme/TextBox.axaml
@@ -6,7 +6,7 @@
     <!--  Add Resources Here  -->
     <Design.PreviewWith>
         <Border Width="800"
-                Height="450"
+                Height="580"
                 Padding="20"
                 Background="{DynamicResource SukiBackground}">
             <Grid ColumnDefinitions="Auto,*,Auto"
@@ -18,19 +18,46 @@
                             Width="250"
                             Spacing="5">
 
-                    <TextBox Width="200"
-                             Text=""
-                             Watermark="Elem" />
+                    <TextBox IsEnabled="False"
+                             Text="Disabled text"
+                             Watermark="TextBox" />
 
-                    <TextBox Width="200"
-                             suki:TextBoxExtensions.Prefix="https://"
-                             Text="test"
+                    <TextBox suki:TextBoxExtensions.AddDeleteButton="True"
+                             BorderBrush="Red"
+                             BorderThickness="10"
+                             Text="Thick border"
+                             UseFloatingWatermark="True" />
+
+                    <TextBox suki:TextBoxExtensions.AddDeleteButton="True" Text="Error validation">
+                        <DataValidationErrors.Error>
+                            <system:Exception>
+                                <x:Arguments>
+                                    <x:String>Validation error</x:String>
+                                </x:Arguments>
+                            </system:Exception>
+                        </DataValidationErrors.Error>
+                    </TextBox>
+
+                    <TextBox suki:TextBoxExtensions.Prefix="https://"
+                             Text="test.com"
                              UseFloatingWatermark="True"
-                             Watermark="Elem" />
+                             Watermark="Url" />
 
-                    <TextBox Classes="NoShadow" Text="Elem" />
+                    <TextBox InnerLeftContent="[L]"
+                             InnerRightContent="[R]"
+                             Text="InnerContent" />
 
-                    <NumericUpDown Value="1" />
+                    <TextBox Classes="NoShadow" Watermark="NoShadow" />
+
+                    <NumericUpDown Value="1">
+                        <DataValidationErrors.Error>
+                            <system:Exception>
+                                <x:Arguments>
+                                    <x:String>Validation error</x:String>
+                                </x:Arguments>
+                            </system:Exception>
+                        </DataValidationErrors.Error>
+                    </NumericUpDown>
 
                     <Panel>
                         <Border Margin="0,0,0,25" Classes="Card">
@@ -152,15 +179,12 @@
                                           Top="False" />
 
     <ControlTheme x:Key="SukiTextBoxButton" TargetType="Button">
-        <Setter Property="Cursor" Value="Arrow" />
+        <Setter Property="Cursor" Value="Hand" />
         <Setter Property="Focusable" Value="False" />
         <Setter Property="Template">
             <ControlTemplate TargetType="Button">
-                <Border x:Name="PART_ButtonLayoutBorder"
-                        Background="Transparent"
-                        BorderThickness="{TemplateBinding BorderThickness}">
+                <Border Name="PART_ButtonLayoutBorder" Background="Transparent">
                     <Path x:Name="PART_GlyphElement"
-                          Width="10"
                           Height="10"
                           HorizontalAlignment="Center"
                           VerticalAlignment="Center"
@@ -175,36 +199,28 @@
     <ControlTheme x:Key="SukiTextBoxToggleButton"
                   BasedOn="{StaticResource SukiTextBoxButton}"
                   TargetType="ToggleButton">
-        <Setter Property="Cursor" Value="Arrow" />
+        <Setter Property="Cursor" Value="Hand" />
         <Setter Property="Focusable" Value="False" />
         <Setter Property="Template">
             <ControlTemplate TargetType="ToggleButton">
-                <Border x:Name="PART_ButtonLayoutBorder"
-                        Width="12"
+                <Border Name="PART_ButtonLayoutBorder"
+                        Height="16"
                         Background="Transparent">
-                    <Panel>
-                        <Path x:Name="PART_GlyphElement_Reveal"
-                              Width="12"
-                              Height="8"
-                              HorizontalAlignment="Center"
-                              VerticalAlignment="Center"
-                              Data="{DynamicResource PasswordBoxRevealButtonData}"
-                              Fill="{DynamicResource SukiLowText}"
-                              IsVisible="{Binding !IsChecked, RelativeSource={RelativeSource TemplatedParent}}"
-                              Stretch="Uniform" />
-                        <Path x:Name="PART_GlyphElement_Hide"
-                              Width="12"
-                              Height="12"
-                              HorizontalAlignment="Center"
-                              VerticalAlignment="Center"
-                              Data="{DynamicResource PasswordBoxHideButtonData}"
-                              Fill="{DynamicResource SukiLowText}"
-                              IsVisible="{TemplateBinding IsChecked}"
-                              Stretch="Uniform" />
-                    </Panel>
+                    <Path x:Name="PART_GlyphElement"
+                          Height="10"
+                          HorizontalAlignment="Center"
+                          VerticalAlignment="Center"
+                          Data="{DynamicResource PasswordBoxRevealButtonData}"
+                          Fill="{DynamicResource SukiLowText}"
+                          Stretch="Uniform" />
                 </Border>
             </ControlTemplate>
         </Setter>
+
+        <Style Selector="^:checked /template/ Path">
+            <Setter Property="Data" Value="{DynamicResource PasswordBoxHideButtonData}" />
+            <Setter Property="Height" Value="16" />
+        </Style>
     </ControlTheme>
 
     <ControlTheme x:Key="SukiTextBox" TargetType="TextBox">
@@ -213,129 +229,143 @@
         <Setter Property="FontSize" Value="14" />
         <Setter Property="BorderBrush" Value="{DynamicResource SukiControlBorderBrush}" />
         <Setter Property="CornerRadius" Value="{DynamicResource SmallCornerRadius}" />
-        <Setter Property="Background" Value="{DynamicResource SukiBackground}" />
+        <Setter Property="Background" Value="{DynamicResource SukiGlassCardBackground}" />
         <Setter Property="Foreground" Value="{DynamicResource SukiText}" />
         <Setter Property="SelectionBrush" Value="{DynamicResource SukiPrimaryColor75}" />
         <Setter Property="MinHeight" Value="36" />
-        <Setter Property="Padding" Value="10,9" />
+        <Setter Property="Padding" Value="10,8" />
         <Setter Property="ContextFlyout" Value="{StaticResource DefaultTextBoxContextFlyout}" />
         <Setter Property="Template">
             <ControlTemplate>
-                <DataValidationErrors>
-                    <Panel Name="PART_RootPanel">
-                        <suki:GlassCard Name="PART_GlassBorder"
-                                        Padding="0"
-                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                        BorderThickness="{TemplateBinding BorderThickness}"
-                                        CornerRadius="{TemplateBinding CornerRadius}">
-                            <suki:GlassCard.Transitions>
-                                <Transitions>
-                                    <BrushTransition Property="BorderBrush" Duration="0:0:0.2" />
-                                </Transitions>
-                            </suki:GlassCard.Transitions>
-                        </suki:GlassCard>
+                <suki:GlassCard Name="PART_GlassBorder"
+                                Padding="{TemplateBinding Padding}"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{TemplateBinding CornerRadius}">
+                    <suki:GlassCard.Transitions>
+                        <Transitions>
+                            <BrushTransition Property="BorderBrush" Duration="0:0:0.15" />
+                        </Transitions>
+                    </suki:GlassCard.Transitions>
+                    <DockPanel x:Name="PART_InnerDockPanel"
+                               LastChildFill="True"
+                               VerticalSpacing="3">
+
+                        <TextBlock Name="PART_FloatingWatermark"
+                                   DockPanel.Dock="Top"
+                                   Foreground="{DynamicResource SukiPrimaryColor}"
+                                   Text="{TemplateBinding Watermark}">
+                            <TextBox.IsVisible>
+                                <MultiBinding Converter="{x:Static BoolConverters.And}">
+                                    <TemplateBinding Converter="{x:Static StringConverters.IsNotNullOrEmpty}" Property="Watermark" />
+                                    <TemplateBinding Property="UseFloatingWatermark" />
+                                </MultiBinding>
+                            </TextBox.IsVisible>
+                        </TextBlock>
 
 
-                        <DockPanel x:Name="PART_InnerDockPanel"
-                                   Margin="{TemplateBinding Padding}"
-                                   LastChildFill="True"
-                                   VerticalSpacing="3">
-
-                            <TextBlock Name="PART_FloatingWatermark"
-                                       DockPanel.Dock="Top"
-                                       Foreground="{DynamicResource SukiPrimaryColor}"
-                                       IsVisible="{TemplateBinding UseFloatingWatermark}"
-                                       Text="{TemplateBinding Watermark}" />
-
-
-                            <Grid HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                  ColumnDefinitions="Auto,*,Auto"
-                                  ColumnSpacing="{StaticResource SukiTextBoxElementSpacing}">
-                                <StackPanel Grid.Column="0"
-                                            Orientation="Horizontal"
-                                            Spacing="{StaticResource SukiTextBoxElementSpacing}">
-                                    <ContentPresenter VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                      Content="{TemplateBinding InnerLeftContent}"
-                                                      IsVisible="{TemplateBinding InnerLeftContent, Converter={x:Static ObjectConverters.IsNotNull}}" />
-                                    <ContentPresenter VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                      Content="{TemplateBinding suki:TextBoxExtensions.Prefix}"
-                                                      FontSize="{TemplateBinding FontSize}"
-                                                      Foreground="{DynamicResource SukiLowText}"
-                                                      IsVisible="{TemplateBinding suki:TextBoxExtensions.Prefix, Converter={x:Static ObjectConverters.IsNotNull}}" />
-                                </StackPanel>
+                        <Grid HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                              ColumnDefinitions="Auto,*,Auto"
+                              ColumnSpacing="{StaticResource SukiTextBoxElementSpacing}">
+                            <StackPanel Grid.Column="0"
+                                        Orientation="Horizontal"
+                                        Spacing="{StaticResource SukiTextBoxElementSpacing}">
+                                <StackPanel.IsVisible>
+                                    <MultiBinding Converter="{x:Static BoolConverters.Or}">
+                                        <TemplateBinding Converter="{x:Static ObjectConverters.IsNotNull}" Property="InnerLeftContent" />
+                                        <TemplateBinding Converter="{x:Static ObjectConverters.IsNotNull}" Property="suki:TextBoxExtensions.Prefix" />
+                                    </MultiBinding>
+                                </StackPanel.IsVisible>
+                                <ContentPresenter VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                  Content="{TemplateBinding InnerLeftContent}"
+                                                  IsVisible="{TemplateBinding InnerLeftContent, Converter={x:Static ObjectConverters.IsNotNull}}" />
+                                <ContentPresenter VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                  Content="{TemplateBinding suki:TextBoxExtensions.Prefix}"
+                                                  FontSize="{TemplateBinding FontSize}"
+                                                  Foreground="{DynamicResource SukiLowText}"
+                                                  IsVisible="{TemplateBinding suki:TextBoxExtensions.Prefix, Converter={x:Static ObjectConverters.IsNotNull}}" />
+                            </StackPanel>
 
 
-                                <ScrollViewer Grid.Column="1"
-                                              HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
-                                              VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}">
-                                    <ScrollViewer.Styles>
-                                        <Style Selector="ScrollContentPresenter#PART_ContentPresenter">
-                                            <Setter Property="Cursor" Value="IBeam" />
-                                        </Style>
-                                    </ScrollViewer.Styles>
-                                    <Panel>
-                                        <TextBlock Name="PART_Watermark"
+                            <ScrollViewer Grid.Column="1"
+                                          HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
+                                          VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}">
+                                <ScrollViewer.Styles>
+                                    <Style Selector="ScrollContentPresenter#PART_ContentPresenter">
+                                        <Setter Property="Cursor" Value="IBeam" />
+                                    </Style>
+                                </ScrollViewer.Styles>
+                                <Panel>
+                                    <TextBlock Name="PART_Watermark"
+                                               HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                               Opacity="0.5"
+                                               Text="{TemplateBinding Watermark}"
+                                               TextAlignment="{TemplateBinding TextAlignment}"
+                                               TextWrapping="{TemplateBinding TextWrapping}">
+                                        <TextBlock.IsVisible>
+                                            <MultiBinding Converter="{x:Static BoolConverters.And}">
+                                                <Binding Converter="{x:Static StringConverters.IsNullOrEmpty}"
+                                                         ElementName="PART_TextPresenter"
+                                                         Path="PreeditText" />
+                                                <TemplateBinding Converter="{x:Static StringConverters.IsNullOrEmpty}" Property="Text" />
+                                                <TemplateBinding Converter="{x:Static BoolConverters.Not}" Property="UseFloatingWatermark" />
+                                            </MultiBinding>
+                                        </TextBlock.IsVisible>
+                                    </TextBlock>
+                                    <TextPresenter Name="PART_TextPresenter"
                                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                   Opacity="0.5"
-                                                   Text="{TemplateBinding Watermark}"
+                                                   CaretBlinkInterval="{TemplateBinding CaretBlinkInterval}"
+                                                   CaretBrush="{DynamicResource SukiLowText}"
+                                                   CaretIndex="{TemplateBinding CaretIndex}"
+                                                   LetterSpacing="{TemplateBinding LetterSpacing}"
+                                                   LineHeight="{TemplateBinding LineHeight}"
+                                                   PasswordChar="{TemplateBinding PasswordChar}"
+                                                   RevealPassword="{TemplateBinding RevealPassword}"
+                                                   SelectionBrush="{TemplateBinding SelectionBrush}"
+                                                   SelectionEnd="{TemplateBinding SelectionEnd}"
+                                                   SelectionForegroundBrush="{TemplateBinding SelectionForegroundBrush}"
+                                                   SelectionStart="{TemplateBinding SelectionStart}"
+                                                   Text="{TemplateBinding Text, Mode=TwoWay}"
                                                    TextAlignment="{TemplateBinding TextAlignment}"
-                                                   TextWrapping="{TemplateBinding TextWrapping}">
-                                            <TextBlock.IsVisible>
-                                                <MultiBinding Converter="{x:Static BoolConverters.And}">
-                                                    <Binding Converter="{x:Static StringConverters.IsNullOrEmpty}"
-                                                             ElementName="PART_TextPresenter"
-                                                             Path="PreeditText" />
-                                                    <Binding Converter="{x:Static StringConverters.IsNullOrEmpty}"
-                                                             Path="Text"
-                                                             RelativeSource="{RelativeSource TemplatedParent}" />
-                                                    <Binding Path="!UseFloatingWatermark" RelativeSource="{RelativeSource TemplatedParent}" />
-                                                </MultiBinding>
-                                            </TextBlock.IsVisible>
-                                        </TextBlock>
-                                        <TextPresenter Name="PART_TextPresenter"
-                                                       HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                       VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                       CaretBlinkInterval="{TemplateBinding CaretBlinkInterval}"
-                                                       CaretBrush="{DynamicResource SukiLowText}"
-                                                       CaretIndex="{TemplateBinding CaretIndex}"
-                                                       LetterSpacing="{TemplateBinding LetterSpacing}"
-                                                       LineHeight="{TemplateBinding LineHeight}"
-                                                       PasswordChar="{TemplateBinding PasswordChar}"
-                                                       RevealPassword="{TemplateBinding RevealPassword}"
-                                                       SelectionBrush="{TemplateBinding SelectionBrush}"
-                                                       SelectionEnd="{TemplateBinding SelectionEnd}"
-                                                       SelectionForegroundBrush="{TemplateBinding SelectionForegroundBrush}"
-                                                       SelectionStart="{TemplateBinding SelectionStart}"
-                                                       Text="{TemplateBinding Text, Mode=TwoWay}"
-                                                       TextAlignment="{TemplateBinding TextAlignment}"
-                                                       TextWrapping="{TemplateBinding TextWrapping}" />
-                                    </Panel>
-                                </ScrollViewer>
+                                                   TextWrapping="{TemplateBinding TextWrapping}" />
+                                </Panel>
+                            </ScrollViewer>
 
-                                <StackPanel Grid.Column="2"
-                                            Orientation="Horizontal"
-                                            Spacing="{StaticResource SukiTextBoxElementSpacing}">
-                                    <suki:TextEraserButton VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                           Cursor="Hand"
-                                                           IsVisible="{TemplateBinding suki:TextBoxExtensions.AddDeleteButton}"
-                                                           Opacity="{TemplateBinding Text, Converter={StaticResource StringToDoubleC}}"
-                                                           Text="{TemplateBinding Text, Mode=TwoWay}">
-                                        <suki:TextEraserButton.Transitions>
-                                            <Transitions>
-                                                <DoubleTransition Property="Opacity" Duration="0:0:0.35" />
-                                            </Transitions>
-                                        </suki:TextEraserButton.Transitions>
-                                    </suki:TextEraserButton>
-                                    <ContentPresenter VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                      Content="{TemplateBinding InnerRightContent}"
-                                                      IsVisible="{TemplateBinding InnerRightContent, Converter={x:Static ObjectConverters.IsNotNull}}" />
-                                </StackPanel>
-                            </Grid>
-                        </DockPanel>
-                    </Panel>
-                </DataValidationErrors>
+                            <StackPanel Grid.Column="2"
+                                        Orientation="Horizontal"
+                                        Spacing="{StaticResource SukiTextBoxElementSpacing}">
+                                <StackPanel.IsVisible>
+                                    <MultiBinding Converter="{x:Static BoolConverters.Or}">
+                                        <TemplateBinding Property="suki:TextBoxExtensions.AddDeleteButton" />
+                                        <TemplateBinding Converter="{x:Static ObjectConverters.IsNotNull}" Property="InnerRightContent" />
+                                        <TemplateBinding Property="DataValidationErrors.HasErrors" />
+                                    </MultiBinding>
+                                </StackPanel.IsVisible>
+                                <ContentPresenter VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                  Content="{TemplateBinding InnerRightContent}"
+                                                  IsVisible="{TemplateBinding InnerRightContent, Converter={x:Static ObjectConverters.IsNotNull}}" />
+
+                                <suki:TextEraserButton VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                       Cursor="Hand"
+                                                       IsVisible="{TemplateBinding suki:TextBoxExtensions.AddDeleteButton}"
+                                                       Opacity="{TemplateBinding Text, Converter={StaticResource StringToDoubleC}}"
+                                                       Text="{TemplateBinding Text, Mode=TwoWay}">
+                                    <suki:TextEraserButton.Transitions>
+                                        <Transitions>
+                                            <DoubleTransition Property="Opacity" Duration="0:0:0.35" />
+                                        </Transitions>
+                                    </suki:TextEraserButton.Transitions>
+                                </suki:TextEraserButton>
+
+                                <DataValidationErrors />
+                            </StackPanel>
+                        </Grid>
+                    </DockPanel>
+                </suki:GlassCard>
             </ControlTemplate>
         </Setter>
 
@@ -345,60 +375,36 @@
             <Style Selector="^ /template/ suki|GlassCard#border">
                 <Setter Property="BorderThickness" Value="0" />
             </Style>
-            <Style Selector="^ /template/ Panel#PART_RootPanel">
+            <Style Selector="^ /template/ Panel#PART_GlassBorder">
                 <Setter Property="ClipToBounds" Value="True" />
             </Style>
         </Style>
 
-        <Style Selector="^:pointerover /template/ suki|GlassCard#border">
-            <Setter Property="BorderBrush" Value="{DynamicResource SukiBorderBrush}" />
-        </Style>
-
-
-        <Style Selector="^:pointerover /template/ Border#borderbottom">
-            <Setter Property="BorderBrush" Value="{DynamicResource SukiBorderBrush}" />
-        </Style>
-
-
-        <Style Selector="^.BottomBar /template/ Border#borderbottom">
+        <Style Selector="^.BottomBar">
             <Setter Property="BorderThickness" Value="0,0,0,1.5" />
         </Style>
 
-
-        <Style Selector="^:focus /template/ Border#borderbottom">
-            <Setter Property="BorderBrush" Value="{DynamicResource SukiPrimaryColor}" />
-        </Style>
-
-        <Style Selector="^:focus /template/ suki|GlassCard#border">
-            <Setter Property="BorderBrush" Value="{DynamicResource SukiPrimaryColor}" />
-            <Setter Property="BorderThickness" Value="1.2" />
-        </Style>
-
-        <Style Selector="^:error /template/ suki|GlassCard#border">
-            <Setter Property="BorderBrush" Value="{DynamicResource ErrorBrush}" />
-        </Style>
-
-        <Style Selector="^:disabled /template/ suki|GlassCard#border">
+        <Style Selector="^:disabled">
             <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}" />
         </Style>
 
-        <Style Selector="^:disabled">
-            <Setter Property="Foreground" Value="{DynamicResource SukiDisabledText}" />
+        <Style Selector="^:pointerover, ^:focus">
+            <Setter Property="BorderBrush" Value="{DynamicResource SukiPrimaryColor}" />
         </Style>
 
-        <Style Selector="^.NoShadow /template/ Border">
-            <Setter Property="BoxShadow" Value="0 0 0 0 Gray" />
+        <Style Selector="^:error">
+            <Setter Property="BorderBrush" Value="{DynamicResource ErrorBrush}" />
         </Style>
 
-        <Style Selector="^.NoShadow /template/ suki|GlassCard#PART_GlassBorder">
+        <Style Selector="^.NoShadow">
             <Setter Property="Background" Value="Transparent" />
             <Setter Property="BorderThickness" Value="0" />
-            <Setter Property="Margin" Value="0,9,0,0" />
-        </Style>
 
-        <Style Selector="^.NoShadow:focus /template/ suki|GlassCard#PART_GlassBorder">
-            <Setter Property="Background" Value="Transparent" />
-            <Setter Property="BorderThickness" Value="0" />
+            <Style Selector="^:pointerover, ^:focus">
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="BorderBrush" Value="Transparent" />
+                <Setter Property="BorderThickness" Value="0" />
+            </Style>
         </Style>
 
         <Style Selector="^.clearButton[AcceptsReturn=False][IsReadOnly=False]:focus:not(TextBox:empty)">

--- a/SukiUI/Theme/ToggleButton.axaml
+++ b/SukiUI/Theme/ToggleButton.axaml
@@ -43,7 +43,7 @@
         </Setter>
 
         <Style Selector="^:disabled">
-            <Setter Property="Opacity" Value="0.5" />
+            <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}" />
         </Style>
 
         <Style Selector="^:pointerover">


### PR DESCRIPTION
- Clean TextBox, remove root panel and put content inside GlassCard, this way thicker borders will not overlap content
- Allow set TextBox Background
- Resize and optimize the reveal password toogle button
- Set Hand cursor for the clear and reveal password toogle button
- Do not show floating watermark when true but watermark text is null or empty
- Allow set InnerLeft/RightContent for NumericUpDown
- Allow set height for NumericUpDown
- Add NumericUpDownExtensions.UseFloatingWatermark Property to have floating watermarks in numeric boxes
- Allow set background for NumericUpDown
- Allow set Horizontal/VerticalAlignment for NumericUpDown
- Set BorderThickness to 1 for NumericUpDown
- Fix validation and state styles
- Fix NoShadow class
- Use {DynamicResource ThemeDisabledOpacity} instead of fixed 0.5 value for disabled components

PS: Sizing was kept untouched.

![image](https://github.com/user-attachments/assets/90327136-610d-4024-a909-6378a92618dc)
![image](https://github.com/user-attachments/assets/7f41407d-6606-41e3-8ce9-fd0f4f3edbb6)
