### PR TITLE
Fix NumericUpDown FontSize

### DIFF
--- a/SukiUI.Demo/Features/ControlsLibrary/CollectionsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/CollectionsView.axaml
@@ -1,14 +1,14 @@
 <UserControl x:Class="SukiUI.Demo.Features.ControlsLibrary.CollectionsView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:suki="https://github.com/kikipoulet/SukiUI"
              xmlns:controlsLibrary="clr-namespace:SukiUI.Demo.Features.ControlsLibrary"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:objectModel="clr-namespace:System.Collections.ObjectModel;assembly=System.ObjectModel"
              xmlns:showMeTheXaml="clr-namespace:ShowMeTheXaml;assembly=ShowMeTheXaml.Avalonia"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
              xmlns:system="clr-namespace:System;assembly=System.Runtime"
-             d:DesignHeight="450"
+             d:DesignHeight="650"
              d:DesignWidth="800"
              x:DataType="controlsLibrary:CollectionsViewModel"
              mc:Ignorable="d">
@@ -39,7 +39,9 @@
                 <suki:GlassCard>
                     <suki:GroupBox Header="ComboBox">
                         <showMeTheXaml:XamlDisplay UniqueId="ComboBox">
-                            <ComboBox VerticalAlignment="Top" ItemsSource="{Binding SimpleContent}" SelectedItem="{Binding SelectedSimpleContent}" />
+                            <ComboBox VerticalAlignment="Top"
+                                      ItemsSource="{Binding SimpleContent}"
+                                      SelectedItem="{Binding SelectedSimpleContent}" />
                         </showMeTheXaml:XamlDisplay>
                     </suki:GroupBox>
                 </suki:GlassCard>
@@ -68,7 +70,7 @@
                     <suki:GroupBox Header="DataGrid">
                         <StackPanel>
                             <showMeTheXaml:XamlDisplay UniqueId="DataGrid">
-                                <DataGrid  MinWidth="350"
+                                <DataGrid MinWidth="350"
                                           MaxHeight="200"
                                           CanUserResizeColumns="{Binding IsDataGridColumnsResizable}"
                                           ItemsSource="{Binding DataGridContent}">
@@ -79,7 +81,11 @@
                                     </DataGrid.Styles>
                                     <DataGrid.Columns>
                                         <DataGridTextColumn Binding="{Binding StringColumn, DataType=controlsLibrary:DataGridContentViewModel}" Header="String" />
-                                        <DataGridTextColumn Binding="{Binding IntColumn, DataType=controlsLibrary:DataGridContentViewModel}" Header="Int" />
+                                        <DataGridTemplateColumn Header="Int" SortMemberPath="IntColumn">
+                                            <DataTemplate>
+                                                <NumericUpDown FormatString="F0" Value="{Binding IntColumn, DataType=controlsLibrary:DataGridContentViewModel}" />
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn>
                                         <DataGridCheckBoxColumn Binding="{Binding BoolColumn, DataType=controlsLibrary:DataGridContentViewModel}" Header="Bool" />
                                         <DataGridTextColumn Binding="{Binding Group, DataType=controlsLibrary:DataGridContentViewModel}" Header="Group" />
                                     </DataGrid.Columns>

--- a/SukiUI/Theme/NumericUpDown.axaml
+++ b/SukiUI/Theme/NumericUpDown.axaml
@@ -149,6 +149,7 @@
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="Padding" Value="5,5,0,5" />
         <Setter Property="MinHeight" Value="36" />
+        <Setter Property="FontSize" Value="14" />
         <Setter Property="Template">
             <ControlTemplate>
                 <suki:GlassCard Name="PART_GlassCard"


### PR DESCRIPTION
With recent `NumericUpDown` changes the `FontSize` was not set, leading to bigger font when using inside a parent, eg: DataGrid.

- Added to NumericUpDown: `<Setter Property="FontSize" Value="14" />` 

Before:
![SukiUI Demo_2025-06-27_00-42-19](https://github.com/user-attachments/assets/7670dedc-c9c2-47d1-ac56-49cbb39531f3)

After:
![SukiUI Demo_2025-06-27_00-43-41](https://github.com/user-attachments/assets/56518692-b561-4c6d-993c-017a15c2d6d3)
