### PR TITLE
Fixed a small regression in `CircleProgressBar`.

### DIFF
--- a/SukiUI/Controls/CircleProgressBar.axaml
+++ b/SukiUI/Controls/CircleProgressBar.axaml
@@ -41,8 +41,7 @@
                                 </Transitions>
                             </Arc.Transitions>
                         </Arc>
-                        <ContentControl Margin="{TemplateBinding StrokeWidth}"
-                                        HorizontalContentAlignment="Center"
+                        <ContentControl HorizontalContentAlignment="Center"
                                         VerticalContentAlignment="Center"
                                         Content="{TemplateBinding Content}" />
                     </Panel>

--- a/SukiUI/Controls/CircleProgressBar.axaml.cs
+++ b/SukiUI/Controls/CircleProgressBar.axaml.cs
@@ -41,10 +41,10 @@ namespace SukiUI.Controls
         public static readonly StyledProperty<double> ValueProperty =
             AvaloniaProperty.Register<CircleProgressBar, double>(nameof(Value), defaultValue: 50, coerce: (o, d) => d * 3.6);
 
-        public static readonly StyledProperty<int> StrokeWidthProperty =
-            AvaloniaProperty.Register<CircleProgressBar, int>(nameof(StrokeWidth), defaultValue: 10);
+        public static readonly StyledProperty<double> StrokeWidthProperty =
+            AvaloniaProperty.Register<CircleProgressBar, double>(nameof(StrokeWidth), defaultValue: 10);
 
-        public int StrokeWidth
+        public double StrokeWidth
         {
             get { return GetValue(StrokeWidthProperty); }
             set { SetValue(StrokeWidthProperty, value); }


### PR DESCRIPTION
### Fixes
- The `ContentControl` was using `StrokeWidth` as it's margin, which up until now was valid. This now causes an invalid cast exception and so was removed.