### PR TITLE
Added SukiSideMenu customization features

### DIFF
--- a/SukiUI/Controls/SukiSideMenuItem.axaml
+++ b/SukiUI/Controls/SukiSideMenuItem.axaml
@@ -95,6 +95,15 @@
                                         </Transitions>
                                     </ContentControl.Transitions>
                                 </ContentControl>
+                                <Grid Name="PART_SideDisplay"
+                                      DockPanel.Dock="Right"
+                                      Margin="5,0"
+                                      IsVisible="{Binding IsMenuExpanded, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type suki:SukiSideMenu}}}">
+                                    <ContentPresenter Name="PART_SideDisplayContent"
+                                                      Content="{Binding}"
+                                                      ContentTemplate="{TemplateBinding SideDisplayTemplate}"
+                                                      IsVisible="{Binding SideDisplayTemplate, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static ObjectConverters.IsNotNull}}" />
+                                </Grid>
                                 <Viewbox HorizontalAlignment="Left" StretchDirection="DownOnly">
                                     <TextBlock Name="PART_Header"
                                                Margin="15,0"

--- a/SukiUI/Controls/SukiSideMenuItem.axaml.cs
+++ b/SukiUI/Controls/SukiSideMenuItem.axaml.cs
@@ -1,8 +1,9 @@
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
 using Avalonia.Input;
+using Avalonia.LogicalTree;
 
 namespace SukiUI.Controls;
 
@@ -38,6 +39,15 @@ public class SukiSideMenuItem : TreeViewItem
     {
         get => GetValue(PageContentProperty);
         set => SetValue(PageContentProperty, value);
+    }
+
+    public static readonly StyledProperty<IDataTemplate?> SideDisplayTemplateProperty =
+        AvaloniaProperty.Register<SukiSideMenuItem, IDataTemplate?>(nameof(SideDisplayTemplate));
+
+    public IDataTemplate? SideDisplayTemplate
+    {
+        get => GetValue(SideDisplayTemplateProperty);
+        set => SetValue(SideDisplayTemplateProperty, value);
     }
 
     public void Show()


### PR DESCRIPTION
Added some things to make customizing the SukiSideMenu easier:

- Manually set content on SukiSideMenu

For those that prefer using a more standard data binding approach to displaying the content. By setting the `UseCustomContent` property to True and providing view data to the `Content` property, SukiSideMenu will override the default behavior and instead use said content instead of looking to the `PageContent` property of the SukiSideMenuItem.

Resolves #496 

- Provide an additional display area on menu items

Since the menu item header bind texts directly to a TextBlock I felt that adding in a new spot for customization would be the simplest backwards-compatible way to offer some addition functionality. Just provide a data template in the `SideDisplayTemplate` property. See test examples with an icon, a context menu, text.

<img width="221" height="222" alt="menu-sides" src="https://github.com/user-attachments/assets/2a276a23-c7e4-46d3-a574-d87031b32e0b" />
<img width="280" height="222" alt="menu-sides-ctx" src="https://github.com/user-attachments/assets/a214e3bb-e94a-4e74-b853-9d3dd7bf4f17" />
<img width="221" height="222" alt="menu-sides-submenus" src="https://github.com/user-attachments/assets/7d73a8c3-014e-4a47-a20c-13c387a1536c" />
<img width="49" height="222" alt="menu-collapsed" src="https://github.com/user-attachments/assets/dd0c2459-bd57-4a3e-a25b-ab865229b4b2" />

- Made logic methods protected virtual

Allows easy overriding of logic in derived classes. e.g. Adding search operators to the filter, changing how displaying content works, etc.
