### PR TITLE
feat: Unify foreground color for RadioButton.Chips on checked state

### DIFF
--- a/SukiUI/Theme/ListBoxStyles.xaml
+++ b/SukiUI/Theme/ListBoxStyles.xaml
@@ -26,7 +26,6 @@
         </Border>
     </Design.PreviewWith>
     <Style Selector="ListBox">
-        <Setter Property="TextBlock.Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
         <Setter Property="BorderThickness" Value="{DynamicResource ListBoxBorderThemeThickness}" />

--- a/SukiUI/Theme/RadioButtonStyles.xaml
+++ b/SukiUI/Theme/RadioButtonStyles.xaml
@@ -67,15 +67,17 @@
 
         <Style Selector="RadioButton.Chips TextBlock">
             <Setter Property="Foreground" Value="{DynamicResource SukiLowText}" />
-            
-        </Style>
 
+        </Style>
+    <Style Selector="RadioButton.Chips:checked">
+        <Setter Property="Foreground" Value="White" />
+    </Style>
 
         <Style Selector="RadioButton.Chips:checked  TextBlock">
             <Setter Property="Foreground" Value="White" />
             <Setter Property="FontWeight" Value="Bold"></Setter>
         </Style>
-        
+
     <Style Selector="RadioButton.Chips:checked  AccessText">
         <Setter Property="Foreground" Value="White" />
         <Setter Property="FontWeight" Value="DemiBold"></Setter>
@@ -99,13 +101,13 @@
             <ControlTemplate>
                 <Panel>
                     <suki:GlassCard  Name="BigBorder" IsInteractive="True"
-                                   
+
                             Margin="4"
                             Padding="15,15,30,15"
-                            
+
                             ClipToBounds="True"
                             CornerRadius="{TemplateBinding CornerRadius}">
-                      
+
 
 
                         <ContentPresenter Name="PART_ContentPresenter"
@@ -148,7 +150,7 @@
         </Setter>
     </Style>
 
-    
+
     <Style Selector="RadioButton.GigaChips:checked  Border#SelectedBorder">
         <Setter Property="Opacity" Value="1" />
     </Style>
@@ -216,7 +218,7 @@
                     <suki:GlassCard Width="20" Height="20" CornerRadius="50" Classes="Control"
                                     Classes.PrimaryOpaque="{TemplateBinding IsChecked}"
                                     />
-                    
+
                     <Ellipse Height="8" Width="8" HorizontalAlignment="Center" VerticalAlignment="Center" IsVisible="{TemplateBinding IsChecked}"  Fill="White"/>
                     <ContentPresenter Name="PART_ContentPresenter"
                                       Grid.Column="1"


### PR DESCRIPTION
This pull request introduces a new style for checked radio buttons with the `Chips` style, improving UI consistency by ensuring the foreground color is set to white when selected.

RadioButton style updates:

* Added a style for `RadioButton.Chips:checked` to set the `Foreground` property to white, ensuring selected chips are visually distinct.

<img width="208" height="66" alt="image" src="https://github.com/user-attachments/assets/641338a8-f48e-40b9-8631-7f40cd3d1906" />
