### PR TITLE
fix: Adjust margin for ComboBox styles to improve layout

### DIFF
--- a/SukiUI/Theme/ComboBoxStyles.xaml
+++ b/SukiUI/Theme/ComboBoxStyles.xaml
@@ -143,7 +143,7 @@
 
                                     <Border Name="B1" Padding="5,10,5,5">
                                         <Panel>
-                                            <Border Margin="10,-10,0,0"
+                                            <Border Margin="10,-10,0,10"
                                                     Background="{DynamicResource SukiPopupBackground}"
                                                     BorderBrush="{DynamicResource SukiMenuBorderBrush}"
                                                     BorderThickness="1,1,1,1"


### PR DESCRIPTION
This is a bug.
Before:
<img width="492" height="616" alt="image" src="https://github.com/user-attachments/assets/f850ba8e-03f8-4106-b1b8-556fc13f1f22" />


After:
<img width="502" height="636" alt="image" src="https://github.com/user-attachments/assets/73f77ae5-7fd0-42c9-adf7-81d2a36c3dd1" />
