### PR TITLE
SukiWindow: Use Avalonia CanMinimize and CanMaximize properties

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <AvaloniaVersion>11.3.1</AvaloniaVersion>
+    <AvaloniaVersion>11.3.4</AvaloniaVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />

--- a/SukiUI/Controls/SukiWindow.axaml.cs
+++ b/SukiUI/Controls/SukiWindow.axaml.cs
@@ -270,17 +270,6 @@ public class SukiWindow : Window, IDisposable
         set => SetValue(RootCornerRadiusProperty, value);
     }
 
-    public static readonly StyledProperty<bool> CanMinimizeProperty =
-        AvaloniaProperty.Register<SukiWindow, bool>(nameof(CanMinimize), defaultValue: true);
-
-    /// <summary>
-    /// Gets or sets a value indicating whether the window can be minimized.
-    /// </summary>
-    public bool CanMinimize
-    {
-        get => GetValue(CanMinimizeProperty);
-        set => SetValue(CanMinimizeProperty, value);
-    }
 
     public static readonly StyledProperty<bool> ShowTitlebarBackgroundProperty =
         AvaloniaProperty.Register<SukiWindow, bool>(nameof(ShowTitlebarBackground), defaultValue: true);
@@ -318,17 +307,6 @@ public class SukiWindow : Window, IDisposable
         set => SetValue(CanPinProperty, value);
     }
 
-    public static readonly StyledProperty<bool> CanMaximizeProperty =
-        AvaloniaProperty.Register<SukiWindow, bool>(nameof(CanMaximize), defaultValue: true);
-
-    /// <summary>
-    /// Gets or sets a value indicating whether the window can be maximized.
-    /// </summary>
-    public bool CanMaximize
-    {
-        get => GetValue(CanMaximizeProperty);
-        set => SetValue(CanMaximizeProperty, value);
-    }
 
     public static readonly StyledProperty<bool> CanMoveProperty =
         AvaloniaProperty.Register<SukiWindow, bool>(nameof(CanMove), defaultValue: true);


### PR DESCRIPTION
- Bump Avalonia to 11.3.4
- Drop CanMinimize and CanMaximize in favor of new Avalonia built in properties