### PR TITLE
Fix blur background memory leaks

### DIFF
--- a/SukiUI/Controls/GlassMorphism/BlurBackground.cs
+++ b/SukiUI/Controls/GlassMorphism/BlurBackground.cs
@@ -144,14 +144,13 @@ half4 main(float2 coord) {
                sigma = sigma *  BlurFactor;
 
                 using (var filter = SKImageFilter.CreateBlur((float)sigma, (float)sigma))
-                using (var blurPaint = new SKPaint
-                       {
-                           Shader = backdropShader,
-                           ImageFilter = filter
-                       })
+                using (var blurPaint = new SKPaint())
+                {
+                    blurPaint.Shader = backdropShader;
+                    blurPaint.ImageFilter = filter;
                     blurred.Canvas.DrawRect(0, 0, (float)_bounds.Width, (float)_bounds.Height, blurPaint);
+                }
 
-  
                 using (var blurSnap = blurred.Snapshot())
                     
                 using (var blurSnapShader = SKShader.CreateImage(blurSnap))
@@ -178,11 +177,9 @@ half4 main(float2 coord) {
                     };
                     using var clampShader = _effect.ToShader(uniforms, children, SKMatrix.CreateIdentity());
 
-                    using var paint = new SKPaint
-                    {
-                        Shader = clampShader,
-                        IsAntialias = false
-                    };
+                    using var paint = new SKPaint();
+                    paint.Shader = clampShader;
+                    paint.IsAntialias = false;
 
                     canvas.DrawRect(0, 0, (float)_bounds.Width, (float)_bounds.Height, paint);
                 }


### PR DESCRIPTION
The current implementation of `BlurBehindRenderOperation` causes a significant unmanaged memory leak when repeatedly opening and closing dialogs.

This PR fixes this by:
- Disposing the cached background.
- Caching and disposing the runtime effect.
- Properly unsubscribing from `OnBaseThemeChanged`.
- Making sure some objects are disposed on exceptions.

Before:
<img width="1156" height="347" alt="image" src="https://github.com/user-attachments/assets/30276497-22a9-42e8-89cc-de9352b956e9" />

After:
<img width="1157" height="344" alt="image" src="https://github.com/user-attachments/assets/9e05aa25-d9a5-4d8a-a681-a162d2c174aa" />

It might be even better to cache the runtime effect statically.