### PR TITLE
ProgressBar rework

### DIFF
--- a/SukiUI.Demo/Features/ControlsLibrary/ProgressView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/ProgressView.axaml
@@ -120,7 +120,7 @@
                             </showMeTheXaml:XamlDisplay>
                             
                             <Expander Header="Advanced">
-                                <StackPanel Spacing="12">
+                                <StackPanel Spacing="12" >
                                      <showMeTheXaml:XamlDisplay UniqueId="Progress2">
                                 <ProgressBar Classes="Accent" IsIndeterminate="{Binding IsIndeterminate}" />
                             </showMeTheXaml:XamlDisplay>
@@ -138,7 +138,8 @@
                             </showMeTheXaml:XamlDisplay>
                             <StackPanel VerticalAlignment="Stretch"
                                         Orientation="Horizontal"
-                                        Spacing="15">
+                                        Spacing="10"
+                                        Height="150">
                                 <showMeTheXaml:XamlDisplay UniqueId="Progress3">
                                     <ProgressBar IsIndeterminate="{Binding IsIndeterminate}" Orientation="Vertical" />
                                 </showMeTheXaml:XamlDisplay>

--- a/SukiUI/Theme/ProgressBar.axaml
+++ b/SukiUI/Theme/ProgressBar.axaml
@@ -1,68 +1,113 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:suki="https://github.com/kikipoulet/SukiUI">
+                    xmlns:suki="https://github.com/kikipoulet/SukiUI"
+                    xmlns:converters="clr-namespace:Avalonia.Controls.Converters;assembly=Avalonia.Controls">
     <!--  Add Resources Here  -->
     <Design.PreviewWith>
-        <StackPanel Margin="20" Spacing="10">
-            <ProgressBar Width="100" Value="50" />
-            <ProgressBar Width="100" IsIndeterminate="True" />
-            <ProgressBar Width="100"
-                         Classes="Accent"
-                         Value="50" />
-            <ProgressBar Width="100"
-                         Classes="Success"
-                         Value="50" />
-            <ProgressBar Width="100"
-                         Classes="Information"
-                         Value="50" />
-            <ProgressBar Width="100"
-                         Classes="Warning"
-                         Value="50" />
-            <ProgressBar Width="100"
-                         Classes="Danger"
-                         ShowProgressText="True"
-                         Value="50" />
+        <StackPanel Margin="30"
+                    Orientation="Horizontal"
+                    Spacing="10">
+            <StackPanel Spacing="10">
+                <ProgressBar Value="50" />
+                <ProgressBar Width="100" IsIndeterminate="True" />
+                <ProgressBar Width="50"
+                             Classes="Accent"
+                             Value="50" />
+                <Border Height="100">
+                    <ProgressBar Width="100"
+                                 Classes="Success"
+                                 Value="50" />
+                </Border>
 
-            <StackPanel Orientation="Horizontal">
+                <ProgressBar Width="50"
+                             Classes="Information"
+                             Value="50" />
                 <ProgressBar Width="100"
-                             Orientation="Vertical"
+                             Classes="Warning"
+                             Value="50" />
+                <ProgressBar Width="100"
+                             Classes="Danger"
                              ShowProgressText="True"
                              Value="50" />
 
-                <ProgressBar Width="100"
-                             Classes="Danger"
-                             IsIndeterminate="True"
-                             Orientation="Vertical"
-                             ShowProgressText="True" />
+                <ProgressBar Classes="Danger"
+                             ShowProgressText="True"
+                             Value="100" />
+
+                <StackPanel Orientation="Horizontal" Spacing="20" Height="200">
+                    <ProgressBar Orientation="Vertical"
+                                 Value="50" />
+
+                    <ProgressBar Orientation="Vertical"
+                                 Classes="Warning"
+                                 ShowProgressText="True"
+                                 ProgressTextFormat="{}{0} percent"
+                                 Value="50" />
+
+                    <ProgressBar Classes="Danger"
+                                 IsIndeterminate="True"
+                                 Orientation="Vertical"
+                                 ShowProgressText="True" />
+                </StackPanel>
+
+
             </StackPanel>
 
+            <Grid RowDefinitions="100,200" ColumnDefinitions="100,100"
+                  RowSpacing="10" ColumnSpacing="10">
+                <ProgressBar Grid.Row="0" Grid.Column="0"
+                             Value="50" />
+                <ProgressBar Grid.Row="0" Grid.Column="1"
+                             Classes="Accent"
+                             Value="50" />
 
+                <ProgressBar Grid.Row="1" Grid.Column="0"
+                             Orientation="Vertical"
+                             Classes="Information"
+                             Value="50" />
+                <ProgressBar Grid.Row="1" Grid.Column="1"
+                             Orientation="Vertical"
+                             Classes="Warning"
+                             Value="50" />
+
+            </Grid>
         </StackPanel>
+
     </Design.PreviewWith>
+
+    <converters:StringFormatConverter x:Key="StringFormatConverter"/>
 
     <ControlTheme x:Key="SukiProgressBarStyle" TargetType="ProgressBar">
         <Setter Property="CornerRadius" Value="{DynamicResource SmallCornerRadius}" />
+        <Setter Property="MinHeight" Value="8" />
+        <Setter Property="MinWidth" Value="8" />
+        <Setter Property="VerticalAlignment" Value="Stretch" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="Background" Value="{DynamicResource SukiBorderBrush}" />
         <Setter Property="Foreground" Value="{DynamicResource SukiPrimaryColor}" />
 
         <Setter Property="Template">
             <ControlTemplate>
                 <DockPanel Name="PART_Dock">
-                    <DockPanel.Resources />
                     <TextBlock Name="PART_Text"
                                Width="0"
                                Height="0"
-                               Margin="0,0,0,1"
-                               HorizontalAlignment="Right"
-                               VerticalAlignment="Center"
                                DockPanel.Dock="Right"
                                FontWeight="{DynamicResource DefaultDemiBold}"
                                Foreground="{DynamicResource SukiText}"
-                               Text="{Binding Value, RelativeSource={RelativeSource TemplatedParent}, StringFormat={}{0:0}%}"
-                               TextAlignment="Right" />
+                               IsVisible="{TemplateBinding ShowProgressText}">
+                        <TextBlock.Text>
+                            <MultiBinding Converter="{StaticResource StringFormatConverter}">
+                                <TemplateBinding Property="ProgressTextFormat"/>
+                                <TemplateBinding Property="Value"/>
+                                <TemplateBinding Property="Percentage"/>
+                                <TemplateBinding Property="Minimum"/>
+                                <TemplateBinding Property="Maximum"/>
+                            </MultiBinding>
+                        </TextBlock.Text>
+                    </TextBlock>
 
                     <suki:GlassCard Name="PART_RootBorder"
-                                    MinWidth="{TemplateBinding MinWidth}"
                                     Padding="0"
                                     BorderBrush="{TemplateBinding BorderBrush}"
                                     BorderThickness="{TemplateBinding BorderThickness}"
@@ -77,8 +122,6 @@
                                     </Transitions>
                                 </Panel.Transitions>
                                 <Border Name="PART_Indicator"
-                                        Width="8"
-                                        Height="8"
                                         Background="{TemplateBinding Foreground}"
                                         CornerRadius="{TemplateBinding CornerRadius}"
                                         IsVisible="{Binding !IsIndeterminate, RelativeSource={RelativeSource TemplatedParent}}">
@@ -119,10 +162,6 @@
             </ControlTemplate>
         </Setter>
 
-        <Style Selector="^[FlowDirection=RightToLeft] /template/ TextBlock#PART_Text">
-            <Setter Property="TextAlignment" Value="Left" />
-        </Style>
-
         <Style Selector="^:indeterminate /template/ Panel#DeterminateRoot">
             <Setter Property="Opacity" Value="0" />
         </Style>
@@ -130,48 +169,51 @@
             <Setter Property="Opacity" Value="1" />
         </Style>
 
+        <Style Selector="^:horizontal">
+            <Setter Property="MinWidth" Value="100" />
+        </Style>
+        <Style Selector="^:vertical">
+            <Setter Property="MinHeight" Value="100" />
+        </Style>
+
         <Style Selector="^:horizontal /template/ Border#PART_Indicator">
             <Setter Property="HorizontalAlignment" Value="Left" />
             <Setter Property="VerticalAlignment" Value="Stretch" />
         </Style>
-        <Style Selector="^:vertical /template/ DockPanel#PART_Dock">
-            <Setter Property="Width" Value="35" />
-        </Style>
+
         <Style Selector="^:vertical /template/ Border#PART_Indicator">
             <Setter Property="HorizontalAlignment" Value="Stretch" />
             <Setter Property="VerticalAlignment" Value="Bottom" />
         </Style>
 
-        <Style Selector="^:horizontal">
-            <Setter Property="MinWidth" Value="200" />
-
-        </Style>
-
-        <Style Selector="^:vertical">
-
-            <Setter Property="MinHeight" Value="200" />
+        <Style Selector="^:horizontal[FlowDirection=RightToLeft] /template/ TextBlock#PART_Text">
+            <Setter Property="TextAlignment" Value="Left" />
         </Style>
 
         <Style Selector="^:horizontal /template/ TextBlock#PART_Text">
             <Setter Property="DockPanel.Dock" Value="Right" />
-            <Setter Property="Height" Value="15" />
+            <Setter Property="TextAlignment" Value="Right" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+            <Setter Property="HorizontalAlignment" Value="Right" />
         </Style>
 
         <Style Selector="^:vertical /template/ TextBlock#PART_Text">
             <Setter Property="DockPanel.Dock" Value="Bottom" />
-            <Setter Property="Margin" Value="10,10,0,0" />
             <Setter Property="TextAlignment" Value="Center" />
-            <Setter Property="Width" Value="35" />
+            <Setter Property="VerticalAlignment" Value="Bottom" />
+            <Setter Property="HorizontalAlignment" Value="Center" />
         </Style>
 
         <Style Selector="^:horizontal[ShowProgressText=True] /template/ TextBlock#PART_Text">
+            <Setter Property="Margin" Value="5,0,0,0" />
+            <Setter Property="Height" Value="NaN" />
             <Style.Animations>
                 <Animation FillMode="Forward" Duration="0:0:0.35">
                     <KeyFrame Cue="0%">
                         <Setter Property="Width" Value="0" />
                     </KeyFrame>
                     <KeyFrame Cue="100%">
-                        <Setter Property="Width" Value="40" />
+                        <Setter Property="Width" Value="35" />
                     </KeyFrame>
                 </Animation>
             </Style.Animations>
@@ -181,7 +223,7 @@
             <Style.Animations>
                 <Animation FillMode="Forward" Duration="0:0:0.35">
                     <KeyFrame Cue="0%">
-                        <Setter Property="Width" Value="40" />
+                        <Setter Property="Width" Value="35" />
                     </KeyFrame>
                     <KeyFrame Cue="100%">
                         <Setter Property="Width" Value="0" />
@@ -191,13 +233,15 @@
         </Style>
 
         <Style Selector="^:vertical[ShowProgressText=True] /template/ TextBlock#PART_Text">
+            <Setter Property="Width" Value="NaN" />
+            <Setter Property="Margin" Value="0,8,0,0" />
             <Style.Animations>
                 <Animation FillMode="Forward" Duration="0:0:0.35">
                     <KeyFrame Cue="0%">
                         <Setter Property="Height" Value="0" />
                     </KeyFrame>
                     <KeyFrame Cue="100%">
-                        <Setter Property="Height" Value="35" />
+                        <Setter Property="Height" Value="15" />
                     </KeyFrame>
                 </Animation>
             </Style.Animations>
@@ -207,25 +251,13 @@
             <Style.Animations>
                 <Animation FillMode="Forward" Duration="0:0:0.35">
                     <KeyFrame Cue="0%">
-                        <Setter Property="Height" Value="35" />
+                        <Setter Property="Height" Value="15" />
                     </KeyFrame>
                     <KeyFrame Cue="100%">
                         <Setter Property="Height" Value="0" />
                     </KeyFrame>
                 </Animation>
             </Style.Animations>
-        </Style>
-
-        <Style Selector="^:horizontal /template/ suki|GlassCard#PART_RootBorder">
-            <Setter Property="MinHeight" Value="8" />
-            <Setter Property="Height" Value="8" />
-            <Setter Property="MaxHeight" Value="8" />
-        </Style>
-
-        <Style Selector="^:vertical /template/ suki|GlassCard#PART_RootBorder">
-            <Setter Property="MinWidth" Value="8" />
-            <Setter Property="Width" Value="8" />
-            <Setter Property="MaxWidth" Value="8" />
         </Style>
 
         <Style Selector="^:vertical /template/ LayoutTransformControl#PART_LayoutTransformControl">


### PR DESCRIPTION
- Add `ProgressTextFormat` support
- Allow set bar size (It was fixed to 8px)
- Change the default style to stretch and take all space on the parent, (it still defaults to 8px on parents with infinite space)
- Fix vertical text height

<img width="420" height="516" alt="image" src="https://github.com/user-attachments/assets/f451dca3-cb1c-489f-9d35-e09f2aff2d62" />
