### PR TITLE
Rework MenuItem - Allow checkbox and radio to live with icons

### DIFF
--- a/SukiUI/Theme/MenuItem.axaml
+++ b/SukiUI/Theme/MenuItem.axaml
@@ -127,13 +127,10 @@
                                     <MultiBinding Converter="{x:Static BoolConverters.Or}">
                                         <Binding Path="#PART_IconPresenter.IsVisible"
                                                  RelativeSource="{RelativeSource TemplatedParent}" />
-                                        <MultiBinding Converter="{x:Static BoolConverters.Or}">
-                                            <Binding Path="#PART_CheckBox.IsVisible"
-                                                     RelativeSource="{RelativeSource TemplatedParent}" />
-                                            <Binding Path="#PART_RadioButton.IsVisible"
-                                                     RelativeSource="{RelativeSource TemplatedParent}" />
-                                        </MultiBinding>
-
+                                        <Binding Path="#PART_CheckBox.IsVisible"
+                                                 RelativeSource="{RelativeSource TemplatedParent}" />
+                                        <Binding Path="#PART_RadioButton.IsVisible"
+                                                 RelativeSource="{RelativeSource TemplatedParent}" />
                                     </MultiBinding>
                                 </Rectangle.IsVisible>
                             </Rectangle>


### PR DESCRIPTION
Until now is not possible to have checkbox and icon together, when having checkbox it always overlap to icon.
Some adjustments were made to make this possible, and also make use of shared grid so all sizes aligns.
Added ToggleButton compability.
The separator is now hidden when nothing to show on left side.
The icon can now have sizes, by default starts at 16px but user can pass larger icons

<img width="262" height="232" alt="image" src="https://github.com/user-attachments/assets/1c08ce62-4575-4c2e-b42d-18c61f84b75a" />
<img width="311" height="222" alt="devenv_2025-12-24_21-52-02" src="https://github.com/user-attachments/assets/1a6d4938-0b58-4146-be8c-63bad09f5069" />
<img width="373" height="293" alt="devenv_2025-12-24_21-51-58" src="https://github.com/user-attachments/assets/274b3abe-c305-4a13-a505-bcffe36e844a" />
<img width="339" height="221" alt="image" src="https://github.com/user-attachments/assets/a073f049-eb65-4cd1-b6d5-c69dab29e764" />

