### PR TITLE
Fix Slider Focusable

### DIFF
--- a/SukiUI/Theme/SliderStyles.xaml
+++ b/SukiUI/Theme/SliderStyles.xaml
@@ -84,7 +84,8 @@
                                           HorizontalAlignment="Stretch"
                                           Background="{DynamicResource SukiPrimaryColor}"
                                           BorderThickness="0"
-                                          CornerRadius="20,0,0,20" />
+                                          CornerRadius="20,0,0,20"
+                                          Focusable="False" />
                         </Track.DecreaseButton>
                         <Track.IncreaseButton>
                             <RepeatButton Name="PART_IncreaseButton" Classes="repeattrack" />
@@ -137,7 +138,8 @@
                                           HorizontalAlignment="Stretch"
                                           Background="{DynamicResource SukiPrimaryColor}"
                                           BorderThickness="0"
-                                          CornerRadius="20" />
+                                          CornerRadius="20"
+                                          Focusable="False" />
                         </Track.DecreaseButton>
                         <Track.IncreaseButton>
                             <RepeatButton Name="PART_IncreaseButton" Classes="repeattrack" />


### PR DESCRIPTION
- Because the `PART_DecreaseButton` does not set the `Focusable` property.

- When the `Focusable` of `Slider` is set to false,the child component `PART_DecreaseButton` will capture keyboard operations and gain focus

- Add `Focusable="False"` to `PART_DecreaseButton`
- fix #558