### PR TITLE
fix: SetColorTheme method is not executed when switching to light/dark mode at the system level

### DIFF
--- a/SukiUI/Theme/Index.axaml.cs
+++ b/SukiUI/Theme/Index.axaml.cs
@@ -80,7 +80,12 @@ public partial class SukiTheme : Styles
     {
         AvaloniaXamlLoader.Load(this);
         _app = Application.Current!;
-        _app.ActualThemeVariantChanged += (_, e) => OnBaseThemeChanged?.Invoke(_app.ActualThemeVariant);
+        _app.ActualThemeVariantChanged += (_, e) =>
+        {
+            OnBaseThemeChanged?.Invoke(_app.ActualThemeVariant);
+
+            SetColorThemeResourcesOnColorThemeChanged();
+        };
         foreach (var theme in DefaultColorThemes)
             AddColorTheme(theme.Value);
 
@@ -159,8 +164,6 @@ public partial class SukiTheme : Styles
     {
         if (_app.ActualThemeVariant == baseTheme) return;
         _app.RequestedThemeVariant = baseTheme;
-        
-        SetColorThemeResourcesOnColorThemeChanged();
     }
 
     /// <summary>
@@ -168,13 +171,10 @@ public partial class SukiTheme : Styles
     /// </summary>
     public void SwitchBaseTheme()
     {
-        if (Application.Current is null) return;
-        var newBase = Application.Current.ActualThemeVariant == ThemeVariant.Dark
+        var newBase = _app.ActualThemeVariant == ThemeVariant.Dark
             ? ThemeVariant.Light
             : ThemeVariant.Dark;
-        Application.Current.RequestedThemeVariant = newBase;
-        
-        SetColorThemeResourcesOnColorThemeChanged();
+        _app.RequestedThemeVariant = newBase;
     }
 
     private void UpdateFlowDirectionResources(bool rightToLeft)


### PR DESCRIPTION
1. Optimize the color resource update logic during theme switching.Remove the call to SetColorThemeResourcesOnColorThemeChanged from the ChangeBaseTheme and SwitchBaseTheme methods, and instead handle it uniformly in the ActualThemeVariantChanged event to ensure resources are always correctly updated when the theme changes, improving code robustness. 
2. This also fixes the bug where the SetColorTheme method is not executed when switching to dark mode at the system level, causing color resource mismatches.

优化主题切换时的资源更新逻辑。
将 SetColorThemeResourcesOnColorThemeChanged 的调用从 ChangeBaseTheme 和 SwitchBaseTheme 方法中移除，改为在 ActualThemeVariantChanged 事件中统一处理，确保主题变更时资源始终正确更新，提升代码健壮性。这样做同时也修复了：当在系统层面切换暗色模式时程序并不会执行SetColorTheme方法，因此导致色彩资源不匹配的bug。