### PR TITLE
Fix race condition in dialog manager

### DIFF
--- a/SukiUI/Dialogs/SukiDialogManager.cs
+++ b/SukiUI/Dialogs/SukiDialogManager.cs
@@ -21,11 +21,12 @@ namespace SukiUI.Dialogs
         {
             if (_activeDialog == null || _activeDialog != dialog) 
                 return false;
-            
-            OnDialogDismissed?.Invoke(this, new SukiDialogManagerEventArgs(_activeDialog));
-            _activeDialog.OnDismissed?.Invoke(_activeDialog);
+
+            var dismissedDialog = _activeDialog;
             _activeDialog = null;
-            
+            OnDialogDismissed?.Invoke(this, new SukiDialogManagerEventArgs(dismissedDialog));
+            dismissedDialog.OnDismissed?.Invoke(dismissedDialog);
+
             return true;
         }
 
@@ -33,10 +34,11 @@ namespace SukiUI.Dialogs
         {
             if (_activeDialog == null) 
                 return;
-            
-            OnDialogDismissed?.Invoke(this, new SukiDialogManagerEventArgs(_activeDialog));
-            _activeDialog.OnDismissed?.Invoke(_activeDialog);
+
+            var dismissedDialog = _activeDialog;
             _activeDialog = null;
+            OnDialogDismissed?.Invoke(this, new SukiDialogManagerEventArgs(dismissedDialog));
+            dismissedDialog.OnDismissed?.Invoke(dismissedDialog);
         }
     }
 }


### PR DESCRIPTION
This PR fixes a race condition that can happen when showing dialogs using `TryShowAsync()`.
Currently, the continuation of `await TryShowAsync()` can run before ` _activeDialog = null;` is set in `SukiDialogManager` on dismissal.

For example, below, the second `TryShowAsync()` will called before the active dialog has been cleared in the dialog manager, leading to an exception.
```csharp
var completion = new TaskCompletionSource<bool>();
var dialog = dialogManager.CreateDialog().OnDismissed(_ => completion.TrySetResult(true));
dialog.Completion = completion;
await dialog.TryShowAsync();

await dialogManager.CreateDialog().TryShowAsync();
```

This PR fixes this by clearing `_activeDialog` before invoking the dismissal event and action.