### PR TITLE
Add SukiMessageBox overloads

### DIFF
--- a/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsViewModel.MessageBoxes.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsViewModel.MessageBoxes.cs
@@ -1,6 +1,5 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Layout;
 using Avalonia.Media;
 using CommunityToolkit.Mvvm.Input;
@@ -63,12 +62,11 @@ namespace SukiUI.Demo.Features.ControlsLibrary.Dialogs
         [RelayCommand]
         private async Task OpenSimpleQuestionMessageBox()
         {
-            var result = await SukiMessageBox.ShowDialog(new SukiMessageBoxHost
-            {
-                IconPreset = SukiMessageBoxIcons.Question,
-                Content = "Are you sure you want to process this action?",
-                ActionButtonsPreset = SukiMessageBoxButtons.YesNo
-            });
+            var result = await SukiMessageBox.ShowDialogResult("Are you sure you want to process this action?",
+                SukiMessageBoxButtons.YesNo,
+                title:"Basic question dialog",
+                header: "Please confirm",
+                icon:SukiMessageBoxIcons.Question);
 
             toastManager.CreateToast()
                     .WithTitle("Dialog Option Clicked")

--- a/SukiUI/MessageBox/SukiMessageBoxOptions.cs
+++ b/SukiUI/MessageBox/SukiMessageBoxOptions.cs
@@ -103,7 +103,7 @@ public record SukiMessageBoxOptions
     /// <summary>
     /// Gets the window title to display in the title har.
     /// </summary>
-    public string Title { get; init; } = string.Empty;
+    public string? Title { get; init; }
 
 
     /// <inheritdoc cref="SukiBackground.AnimationEnabled"/>


### PR DESCRIPTION
- Allow `SukiMessageBoxOptions.Title` to be nullable 
- Add overloads to `SukiMessageBox` (For simplicity and to mimic windows [MessageBox.Show](https://learn.microsoft.com/en-us/dotnet/api/system.windows.forms.messagebox.show?view=windowsdesktop-10.0))
  - `ShowDialog(Window owner, SukiMessageBoxHost messageBox, string? title, SukiMessageBoxOptions? windowOptions = null)`
  - `ShowDialog(Window owner, SukiMessageBoxHost messageBox, SukiMessageBoxOptions? windowOptions = null)`
  - `ShowDialog(SukiMessageBoxHost messageBox, string? title, SukiMessageBoxOptions? windowOptions = null)`
  - `ShowDialog(SukiMessageBoxHost messageBox, SukiMessageBoxOptions? windowOptions = null)`
  - `ShowDialogResult(Window owner, SukiMessageBoxHost messageBox, string? title, SukiMessageBoxOptions? windowOptions = null)`
  - `ShowDialogResult(Window owner, SukiMessageBoxHost messageBox, SukiMessageBoxOptions? windowOptions = null)`
  - `ShowDialogResult(Window owner, string message, SukiMessageBoxButtons buttons, string? title = null, string? header = null, SukiMessageBoxIcons? icon = null, SukiMessageBoxOptions? windowOptions = null)`
  - `ShowDialogResult(SukiMessageBoxHost messageBox, string? title, SukiMessageBoxOptions? windowOptions = null)`
  - `ShowDialogResult(SukiMessageBoxHost messageBox, SukiMessageBoxOptions? windowOptions = null)`
  - `ShowDialogResult(string message, SukiMessageBoxButtons buttons, string? title = null, string? header = null, SukiMessageBoxIcons? icon = null, SukiMessageBoxOptions? windowOptions = null)`

## Example:

```C#
var result = await SukiMessageBox.ShowDialogResult("Are you sure you want to process this action?",
                SukiMessageBoxButtons.YesNo,
                title:"Basic question dialog", // Optional
                header:"Please confirm", // Optional
                icon:SukiMessageBoxIcons.Question  // Optional
              );
```