### PR TITLE
Clean up `TryShowAsync` in dialog builder

### DIFF
--- a/SukiUI/Dialogs/SukiDialogBuilder.cs
+++ b/SukiUI/Dialogs/SukiDialogBuilder.cs
@@ -36,7 +36,7 @@ namespace SukiUI.Dialogs
 #if DEBUG
                 System.Diagnostics.Debugger.Break();
 #endif
-                throw new InvalidOperationException($"{nameof(SukiDialogBuilder)} is not configured corretly. Its missing a valid value for {nameof(Completion)}.");
+                throw new InvalidOperationException($"{nameof(SukiDialogBuilder)} is not configured correctly. Its missing a valid value for {nameof(Completion)}.");
             }
 
             using var _ = cancellationToken.Register(() => completion.TrySetCanceled(cancellationToken));


### PR DESCRIPTION
- Properly dispose `CancellationTokenRegistration`.
- Use `TrySetCanceled` instead of `TrySetResult(false)` on cancellation.
- Call `TryDismissDialog` before continuing. This handles e.g. action buttons setting completion result before dialog has been dismissed (see `AddActionButton` where `onClicked` is invoked before `TryDismissDialog`).
- Wrap in try-finally to properly handle cancellation.