### PR TITLE
Synchronize title bar visibility when applying template

### DIFF
--- a/SukiUI/Controls/SukiWindow.axaml.cs
+++ b/SukiUI/Controls/SukiWindow.axaml.cs
@@ -506,6 +506,8 @@ public class SukiWindow : Window, IDisposable
         _titleBarControl = e.NameScope.Find<LayoutTransformControl>("PART_TitleBar");
         if (_titleBarControl is not null)
         {
+            _titleBarControl.IsVisible = IsTitleBarVisible;
+
             _titleBarControl.PointerPressed += OnTitleBarPointerPressed;
             _titleBarControl.PointerReleased += OnTitleBarPointerReleased;
             _titleBarControl.DoubleTapped += OnMaximizeButtonClicked;


### PR DESCRIPTION
Setting `IsTitleBarVisible` to false no longer hides the title bar in `SukiWindow` unless a property change is triggered. If `IsTitleBarVisible` is already set to false (by e.g. a binding) when `OnApplyTemplate` runs, then the title bar is created with `IsVisible` set to true even though it should be hidden.
Issue comes from moving away from style selectors in 50d39c7f.