### PR TITLE
Switch Demo to use more recent Dock.Serializer.SystemTextJson

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,21 +20,21 @@
     <PackageVersion Include="Dock.Model" Version="11.3.11.22" />
     <PackageVersion Include="Dock.Model.Avalonia" Version="11.3.11.22" />
     <PackageVersion Include="Dock.Model.Mvvm" Version="11.3.11.22" />
-    <PackageVersion Include="Dock.Serializer" Version="11.3.0.12" />
+    <PackageVersion Include="Dock.Serializer.SystemTextJson" Version="11.3.11.22" />
     <PackageVersion Include="Avalonia.AvaloniaEdit" Version="11.4.1" />
     <PackageVersion Include="AvaloniaEdit.TextMate" Version="11.4.1" />
     <PackageVersion Include="Markdown.Avalonia" Version="11.0.2" />
     <PackageVersion Include="Material.Icons.Avalonia" Version="3.0.0" />
-    <PackageVersion Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-rc5.4" />
+    <PackageVersion Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0" />
     <PackageVersion Include="ShowMeTheXaml.Avalonia" Version="1.5.2" />
     <PackageVersion Include="ShowMeTheXaml.Avalonia.Generator" Version="1.5.2" />
     <PackageVersion Include="SkiaSharp" Version="3.119.2" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.2" />
     <PackageVersion Include="SkiaSharp.NativeAssets.macOS" Version="3.119.2" />
     <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="3.119.2" />
-    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.1" />
+    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
-    <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.7.1" />
+    <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.7.2" />
     <PackageVersion Include="System.Text.Json" Version="10.0.5" />
   </ItemGroup>
 </Project>

--- a/SukiUI.Demo/Features/ControlsLibrary/DockMvvmViewModel.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/DockMvvmViewModel.cs
@@ -5,7 +5,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Dock.Model.Controls;
 using Dock.Model.Core;
-using Dock.Serializer;
+using Dock.Serializer.SystemTextJson;
 using Material.Icons;
 using SukiUI.Demo.Common;
 using SukiUI.Demo.Features.ControlsLibrary.DockControls;

--- a/SukiUI.Demo/SukiUI.Demo.csproj
+++ b/SukiUI.Demo/SukiUI.Demo.csproj
@@ -7,11 +7,9 @@
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>
 
-
-
   <ItemGroup>
     <PackageReference Include="Avalonia" />
-    <PackageReference Include="Avalonia.AvaloniaEdit"/>
+    <PackageReference Include="Avalonia.AvaloniaEdit" />
     <PackageReference Include="Avalonia.Controls.ColorPicker" />
     <PackageReference Include="Avalonia.Desktop" />
     <PackageReference Include="Avalonia.Fonts.Inter" />
@@ -25,8 +23,8 @@
     <PackageReference Include="Dock.Model" />
     <PackageReference Include="Dock.Model.Avalonia" />
     <PackageReference Include="Dock.Model.Mvvm" />
-    <PackageReference Include="Dock.Serializer" />
-    <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia"/>
+    <PackageReference Include="Dock.Serializer.SystemTextJson" />
+    <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" />
     <PackageReference Include="Material.Icons.Avalonia" />
     <PackageReference Include="Markdown.Avalonia" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />


### PR DESCRIPTION
Hi,

I love this library and with Avalonia 12 releasing yesterday, I wanted to get started on porting this to use it. From what I've experimented with so far it doesn't seem like too many changes, but thought I would break them into some small chunks if that's okay.

So this bumps dependencies for 
- LiveChartsCore.SkiaSharpView.Avalonia from 2.0.0-rc5.4 to 2.0.0
- CommunityToolkit.Mvvm from 8.4.1 to 8.4.2
- System.Linq.Dynamic.Core from 1.7.1 to 1.7.2

It also replaces the Dock.Serializer dependency at version 11.3.0.12 with Dock.Serializer.SystemTextJson and brings it in line with the other Dock dependendencies at version 11.3.11.22.