### PR TITLE
Fix settings item not appearing on bound header.

### DIFF
--- a/SukiUI.Demo/Features/Theming/ThemingViewModel.cs
+++ b/SukiUI.Demo/Features/Theming/ThemingViewModel.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Avalonia.Collections;
+﻿using Avalonia.Collections;
 using Avalonia.Styling;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -23,9 +22,10 @@ public partial class ThemingViewModel : DemoPageBase
     private readonly SukiTheme _theme = SukiTheme.GetInstance();
 
     [ObservableProperty] private bool _isLightTheme;
-    [ObservableProperty] private SukiBackgroundStyle _backgroundStyle ;
+    [ObservableProperty] private SukiBackgroundStyle _backgroundStyle;
     [ObservableProperty] private bool _backgroundAnimations;
     [ObservableProperty] private bool _backgroundTransitions;
+    [ObservableProperty] private string _themingHeader = "Base Theme";
 
     private string? _customShader = null;
     
@@ -34,10 +34,10 @@ public partial class ThemingViewModel : DemoPageBase
         AvailableBackgroundStyles = new AvaloniaList<SukiBackgroundStyle>(Enum.GetValues<SukiBackgroundStyle>());
         AvailableColors = _theme.ColorThemes;
         IsLightTheme = _theme.ActiveBaseTheme == ThemeVariant.Light;
-        _theme.OnBaseThemeChanged += variant =>
+        _theme.OnBaseThemeChanged += variant => {
             IsLightTheme = variant == ThemeVariant.Light;
-        _theme.OnColorThemeChanged += theme =>
-        {
+        };
+        _theme.OnColorThemeChanged += theme => {
             // TODO: Implement a way to make this correct, might need to wrap the thing in a VM, this isn't ideal.
         };
     }

--- a/SukiUI/Controls/Settings/SettingsLayout.axaml
+++ b/SukiUI/Controls/Settings/SettingsLayout.axaml
@@ -8,10 +8,7 @@
              d:DesignHeight="450"
              d:DesignWidth="800"
              mc:Ignorable="d">
-
     <UserControl.Styles>
-      
-
         <Style Selector="controls|SettingsLayout">
             <Setter Property="Template">
                 <ControlTemplate>

--- a/SukiUI/Controls/Settings/SettingsLayoutItem.cs
+++ b/SukiUI/Controls/Settings/SettingsLayoutItem.cs
@@ -1,35 +1,31 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
 
-namespace SukiUI.Controls;
-
-public class SettingsLayoutItem : Control
+namespace SukiUI.Controls
 {
-    public static readonly DirectProperty<SettingsLayoutItem, string?> HeaderProperty =
-        AvaloniaProperty.RegisterDirect<SettingsLayoutItem, string?>(
-            nameof(Header),
-            o => o.Header,
-            (o, v) => o.Header = v);
-
-    public string? Header
+    public class SettingsLayoutItem : Control
     {
-        get { return _header; }
-        set { SetAndRaise(HeaderProperty, ref _header, value); }
+        public static readonly StyledProperty<string?> HeaderProperty =
+            AvaloniaProperty.Register<SettingsLayoutItem, string?>(nameof(Header));
+
+        public static readonly DirectProperty<SettingsLayoutItem, Control?> ContentProperty =
+            AvaloniaProperty.RegisterDirect<SettingsLayoutItem, Control?>(
+                nameof(Content),
+                o => o.Content,
+                (o, v) => o.Content = v);
+
+        private Control? _content;
+
+        public string? Header
+        {
+            get => GetValue(HeaderProperty);
+            set => SetValue(HeaderProperty, value);
+        }
+
+        public Control? Content
+        {
+            get => _content;
+            set => SetAndRaise(ContentProperty, ref _content, value);
+        }
     }
-
-    private string? _header;
-
-    public static readonly DirectProperty<SettingsLayoutItem, Control?> ContentProperty =
-    AvaloniaProperty.RegisterDirect<SettingsLayoutItem, Control?>(
-        nameof(Content),
-        o => o.Content,
-        (o, v) => o.Content = v);
-
-    public Control? Content
-    {
-        get { return _content; }
-        set { SetAndRaise(ContentProperty, ref _content, value); }
-    }
-
-    private Control? _content;
 }


### PR DESCRIPTION
Resolves #543 by changing the Settings header from a DirectProperty to a StyledProperty which should update properly when using bindings.