### PR TITLE
Fix appearance binding for info badge

### DIFF
--- a/SukiUI/Controls/InfoBadge.axaml.cs
+++ b/SukiUI/Controls/InfoBadge.axaml.cs
@@ -9,43 +9,24 @@ using SukiUI.Enums;
 
 namespace SukiUI.Controls;
 
-public class InfoBadge: HeaderedContentControl
+public class InfoBadge : HeaderedContentControl
 {
     private Border? _badgeContainer;
-    
-    public static readonly StyledProperty<NotificationType> AppearanceProperty =
-        AvaloniaProperty.Register<InfoBadge, NotificationType>(nameof(Appearance), NotificationType.Information);
 
-    public NotificationType Appearance
-    {
+    public static readonly StyledProperty<NotificationType> AppearanceProperty = AvaloniaProperty.Register<InfoBadge, NotificationType>(nameof(Appearance), NotificationType.Information);
+    public NotificationType Appearance {
         get => GetValue(AppearanceProperty);
-        set
-        {
-            Background = value switch
-            {
-                NotificationType.Information => NotificationColor.InfoIconForeground,
-                NotificationType.Success => NotificationColor.SuccessIconForeground,
-                NotificationType.Warning => NotificationColor.WarningIconForeground,
-                NotificationType.Error => NotificationColor.ErrorIconForeground,
-                _ => NotificationColor.InfoIconForeground
-            };
-            
-            SetValue(AppearanceProperty, value);
-        }
+        set => SetValue(AppearanceProperty, value);
     }
 
-    public static readonly StyledProperty<CornerPosition> CornerPositionProperty = AvaloniaProperty.Register<InfoBadge, CornerPosition>(
-        nameof(CornerPosition));
-    public CornerPosition CornerPosition
-    {
+    public static readonly StyledProperty<CornerPosition> CornerPositionProperty = AvaloniaProperty.Register<InfoBadge, CornerPosition>(nameof(CornerPosition));
+    public CornerPosition CornerPosition {
         get => GetValue(CornerPositionProperty);
         set => SetValue(CornerPositionProperty, value);
     }
-    
-    public static readonly StyledProperty<bool> IsDotProperty = AvaloniaProperty.Register<InfoBadge, bool>(
-        nameof(IsDot), false);
-    public bool IsDot
-    {
+
+    public static readonly StyledProperty<bool> IsDotProperty = AvaloniaProperty.Register<InfoBadge, bool>(nameof(IsDot), false);
+    public bool IsDot {
         get => GetValue(IsDotProperty);
         set {
             UpdateBadgePosition();
@@ -53,16 +34,17 @@ public class InfoBadge: HeaderedContentControl
         }
     }
 
-    public static readonly StyledProperty<int> OverflowProperty = AvaloniaProperty.Register<InfoBadge, int>(
-        nameof(Overflow));
-    public int Overflow
-    {
+    public static readonly StyledProperty<int> OverflowProperty = AvaloniaProperty.Register<InfoBadge, int>(nameof(Overflow));
+    public int Overflow {
         get => GetValue(OverflowProperty);
         set => SetValue(OverflowProperty, value);
     }
 
     static InfoBadge()
     {
+        AppearanceProperty.Changed.AddClassHandler<InfoBadge>((badge, e) => {
+            badge.UpdateAppearance((NotificationType)e.NewValue!);
+        });
         HeaderProperty.Changed.AddClassHandler<InfoBadge>((badge, _) => badge.UpdateBadgePosition());
     }
 
@@ -84,28 +66,37 @@ public class InfoBadge: HeaderedContentControl
         return base.ArrangeOverride(finalSize);
     }
 
+    private void UpdateAppearance(NotificationType value)
+    {
+        Background = value switch {
+            NotificationType.Information => NotificationColor.InfoIconForeground,
+            NotificationType.Success => NotificationColor.SuccessIconForeground,
+            NotificationType.Warning => NotificationColor.WarningIconForeground,
+            NotificationType.Error => NotificationColor.ErrorIconForeground,
+            _ => NotificationColor.InfoIconForeground
+        };
+    }
+
     private void UpdateBadgePosition()
     {
         var verticalOffset = -1;
-        if (CornerPosition is CornerPosition.BottomLeft or CornerPosition.BottomRight)
-        {
+        if (CornerPosition is CornerPosition.BottomLeft or CornerPosition.BottomRight) {
             verticalOffset = 1;
         }
 
         var horizontalOffset = -1;
-        if (CornerPosition is CornerPosition.TopRight or CornerPosition.BottomRight)
-        {
+        if (CornerPosition is CornerPosition.TopRight or CornerPosition.BottomRight) {
             horizontalOffset = 1;
         }
-        
-        if (_badgeContainer is not null && Presenter?.Child is not null)
-        {
-            _badgeContainer.RenderTransform = new TransformGroup
-            {
-                Children = new Transforms
-                {
-                    new TranslateTransform(horizontalOffset*_badgeContainer.Bounds.Width / 2,verticalOffset*_badgeContainer.Bounds.Height / 2)
-                }
+
+        if (_badgeContainer is not null && Presenter?.Child is not null) {
+            _badgeContainer.RenderTransform = new TransformGroup {
+                Children = [
+                    new TranslateTransform(
+                        horizontalOffset * _badgeContainer.Bounds.Width / 2,
+                        verticalOffset * _badgeContainer.Bounds.Height / 2
+                    )
+                ]
             };
         }
     }


### PR DESCRIPTION
Resolve #534 by removing appearance update from setter and implementing a changed event instead to update background correctly.