### PR TITLE
Warning fixes

### DIFF
--- a/SukiUI.Demo/Features/ControlsLibrary/FormViewModel.cs
+++ b/SukiUI.Demo/Features/ControlsLibrary/FormViewModel.cs
@@ -91,4 +91,4 @@ public partial class ChildFormViewModel : ObservableObject
     private DateTimeOffset _dateTimeOffset = DateTimeOffset.MinValue;
 }
 
-#pragma warning enable CS0657 // Not a valid attribute location for this declaration
+#pragma warning restore CS0657 // Not a valid attribute location for this declaration

--- a/SukiUI/Controls/Gauges/RadialGauge/RadialGaugeStyles.axaml
+++ b/SukiUI/Controls/Gauges/RadialGauge/RadialGaugeStyles.axaml
@@ -74,7 +74,7 @@
         
         <Setter Property="NeedleBrush" >
             <Setter.Value>
-                <RadialGradientBrush Center="0%,0%" GradientOrigin="0%,0%" Radius="1.5">
+                <RadialGradientBrush Center="0%,0%" GradientOrigin="0%,0%" RadiusX="150%" RadiusY="150%">
                     <GradientStop Offset="0" Color="{DynamicResource SukiLowText}" />
                     <GradientStop Offset="1" Color="{DynamicResource SukiPrimaryColor120}" />
                 </RadialGradientBrush>

--- a/SukiUI/Converters/ProgressToContentConverter.cs
+++ b/SukiUI/Converters/ProgressToContentConverter.cs
@@ -1,27 +1,23 @@
-﻿using System;
-using System.Globalization;
-using Avalonia.Controls;
-using Avalonia.Data;
+﻿using Avalonia.Controls;
 using Avalonia.Data.Converters;
 using SukiUI.Controls;
+using System.Globalization;
 
 namespace SukiUI.Converters
 {
     public class ProgressToContentConverter : IValueConverter
     {
         public static readonly ProgressToContentConverter Instance = new ProgressToContentConverter();
-        
-        
-        public object? Convert(object? value, Type targetType, object? parameter, 
-            CultureInfo culture)
-        {
-            if ((bool)value)
-                return new Loading() { LoadingStyle = LoadingStyle.Simple };
 
+        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value is bool booleanValue && booleanValue == true) {
+                return new Loading() { LoadingStyle = LoadingStyle.Simple };
+            }
             return new Panel();
         }
-        
-        public object ConvertBack(object? value, Type targetType, 
+
+        public object ConvertBack(object? value, Type targetType,
             object? parameter, CultureInfo culture)
         {
             throw new NotSupportedException();

--- a/SukiUI/Theme/BorderStyles.xaml
+++ b/SukiUI/Theme/BorderStyles.xaml
@@ -25,7 +25,7 @@
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="BorderBrush" Value="{DynamicResource SukiBorderBrush}" />
         <Setter Property="Background">
-            <RadialGradientBrush Center="120%,-220%" GradientOrigin="120%,-220%" Radius="3">
+            <RadialGradientBrush Center="120%,-220%" GradientOrigin="120%,-220%" RadiusX="300%" RadiusY="300%">
                 <GradientStop Offset="0.4" Color="{DynamicResource SukiPrimaryColor}" />
                 <GradientStop Offset="1" Color="Transparent" />
             </RadialGradientBrush>

--- a/SukiUI/Theme/ComboboxConverter.cs
+++ b/SukiUI/Theme/ComboboxConverter.cs
@@ -1,5 +1,4 @@
 using Avalonia.Data.Converters;
-using System;
 using System.Collections;
 using System.Globalization;
 
@@ -11,12 +10,14 @@ namespace SukiUI.Theme
 
         public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
-            double x = (double)value;
-            if (x == 0)
-                return 0;
+            if (value is double x) {
+                if (x == 0)
+                    return 0;
 
-            x += 9;
-            return x;
+                x += 9;
+                return x;
+            }
+            return 0;
         }
 
         public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
@@ -36,8 +37,7 @@ namespace SukiUI.Theme
                 return "";
 
             var s = "";
-            foreach (var o in x)
-            {
+            foreach (var o in x) {
                 if (o?.ToString()?.Length > s.ToString().Length)
                     s = o.ToString();
             }
@@ -62,8 +62,7 @@ namespace SukiUI.Theme
                 return "";
 
             var s = "";
-            foreach (var o in x)
-            {
+            foreach (var o in x) {
                 if (o?.ToString()?.Length > s.ToString().Length)
                     s = o.ToString();
             }

--- a/SukiUI/Theme/DatePicker.axaml
+++ b/SukiUI/Theme/DatePicker.axaml
@@ -114,7 +114,7 @@
 
                         <Popup Name="PART_Popup"
                                IsLightDismissEnabled="True"
-                               PlacementMode="Bottom"
+                               Placement="Bottom"
                                PlacementTarget="{TemplateBinding}"
                                WindowManagerAddShadowHint="False">
                             <DatePickerPresenter Name="PART_PickerPresenter" />


### PR DESCRIPTION
Fixes a couple of warnings currntley present

- Two unboxing warnings in ProgressToContentConverter and ComboboxConverter
- Fix pragma enable to use restore in FormViewModel
- Use RadiusX & RadiusY instead of Radius in RadialGaugeStyles & BorderStyles (Also helps to support Avalonia 12)
- Use Placement instead of PlacementMode in DatePicker