### PR TITLE
fix(suki-window): handle resizing on Wayland with no decorations

### DIFF
--- a/SukiUI/Controls/SukiWindow.axaml.cs
+++ b/SukiUI/Controls/SukiWindow.axaml.cs
@@ -1034,8 +1034,6 @@ public class SukiWindow : Window, IDisposable
     {
         if (!CanResize || WindowState != WindowState.Normal) return;
         if (sender is not Border border || border.Tag is not string edge) return;
-        if (VisualRoot is not Window window)
-            return;
 
         var windowEdge = edge switch
         {
@@ -1050,7 +1048,15 @@ public class SukiWindow : Window, IDisposable
             _ => throw new ArgumentOutOfRangeException()
         };
 
-        window.BeginResizeDrag(windowEdge, e);
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            var isWayland = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WAYLAND_DISPLAY"));
+            if (isWayland && WindowDecorations == WindowDecorations.None)
+                WindowDecorations = WindowDecorations.BorderOnly;
+        }
+
+        // this statt VisualRoot verwenden — SukiWindow ist selbst das Window
+        BeginResizeDrag(windowEdge, e);
         e.Handled = true;
     }
 


### PR DESCRIPTION
## Fix: Window resizing on KDE Wayland

### Problem

On Linux with KDE Wayland, `SukiWindow` cannot be resized by dragging the window edges. Two issues were identified:

1. **`WindowDecorations` is set to `None` on Linux** (in `SukiWindow.axaml`), which causes `BeginResizeDrag` to silently fail on Wayland. Wayland requires the compositor to handle resize requests, which is only possible when `WindowDecorations` is not `None`.

2. **`VisualRoot` is `null` in `RaiseResize`** on Wayland, causing an early return before `BeginResizeDrag` is ever called. Since `SukiWindow` extends `Window` directly, `this` can be used instead.

### Changes

**`SukiWindow.axaml.cs`**
- Replaced `VisualRoot as Window` with `this` in `RaiseResize`, since `SukiWindow` is the window itself.
- Added a Wayland detection check: if `WindowDecorations` is still `None` at resize time (e.g. set manually), it is upgraded to `BorderOnly` to ensure `BeginResizeDrag` works.

### Tested on
- KDE Plasma 6, Wayland
- Resizing via all 8 edges and corners confirmed working

---

> **Note on diff size:** The diff appears larger than the 5 actual changed lines due to inconsistent line endings in the repository (mixed CRLF/LF across files). The functional changes are limited to the file listed above.