### PR TITLE
Fix crash when GPU acceleration unavailable (llvmpipe fallback on Linux)

### DIFF
--- a/SukiUI/Controls/GlassMorphism/BlurBackground.cs
+++ b/SukiUI/Controls/GlassMorphism/BlurBackground.cs
@@ -13,6 +13,8 @@ namespace SukiUI.Controls.GlassMorphism;
 
 public class BlurBackground : Control
 {
+    public static bool IsGpuBlurAvailable { get; set; } = true;
+
     public static readonly StyledProperty<bool> IsDynamicProperty = AvaloniaProperty.Register<BlurBackground, bool>(
         nameof(IsDynamic), defaultValue: false);
 
@@ -105,6 +107,9 @@ half4 main(float2 coord) {
         
        public void Render(ImmediateDrawingContext context)
         {
+                if(context == null)
+                    return;
+
                 var leaseFeature = context.TryGetFeature<ISkiaSharpApiLeaseFeature>();
                 using var lease = leaseFeature.Lease();
                 var canvas = lease.SkCanvas;
@@ -128,6 +133,12 @@ half4 main(float2 coord) {
 
                 if(_cachedBackground == null)
                     return;
+
+                if (lease.GrContext == null)
+                {
+                    IsGpuBlurAvailable = false;
+                    return;
+                }
             
                 using var backdropShader = SKShader.CreateImage(_cachedBackground, SKShaderTileMode.Clamp,
                     SKShaderTileMode.Clamp, currentInvertedTransform);

--- a/SukiUI/Controls/GlassMorphism/BlurBackground.cs
+++ b/SukiUI/Controls/GlassMorphism/BlurBackground.cs
@@ -105,11 +105,10 @@ half4 main(float2 coord) {
 
         private bool IsDarkTheme;
         
-       public void Render(ImmediateDrawingContext context)
+        public void Render(ImmediateDrawingContext context)
         {
-                if(context == null)
-                    return;
-
+            if (context is null)
+                return;
                 var leaseFeature = context.TryGetFeature<ISkiaSharpApiLeaseFeature>();
                 using var lease = leaseFeature.Lease();
                 var canvas = lease.SkCanvas;

--- a/SukiUI/Controls/SukiDialog.axaml
+++ b/SukiUI/Controls/SukiDialog.axaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:suki="https://github.com/kikipoulet/SukiUI"
                     xmlns:dialogs="clr-namespace:SukiUI.Dialogs"
+                    xmlns:converters="clr-namespace:SukiUI.Converters"
                     xmlns:glassMorphism="clr-namespace:SukiUI.Controls.GlassMorphism">
     <ControlTheme TargetType="suki:SukiDialog" x:Key="SukiDialogTheme">
         <Setter Property="ClipToBounds" Value="False" />
@@ -15,8 +16,12 @@
                             CornerRadius="25">
                         <Panel>
                             
-                            <suki:GlassCard IsVisible="{TemplateBinding ShowCardBackground}" ClipToBounds="True" CornerRadius="25">
-                                <glassMorphism:SukiBlurBackground Margin="-200"  />
+
+                            <suki:GlassCard IsVisible="{TemplateBinding ShowCardBackground}" 
+                                            ClipToBounds="True" CornerRadius="25">
+                                <glassMorphism:SukiBlurBackground Margin="-200" 
+                                    IsVisible="{Binding BackgroundStyle, RelativeSource={RelativeSource TemplatedParent}, 
+                                        Converter={x:Static converters:SukiDialogBackgroundStyleToBoolConverter.Instance}}" />
                             </suki:GlassCard>
                             
                             

--- a/SukiUI/Controls/SukiDialog.cs
+++ b/SukiUI/Controls/SukiDialog.cs
@@ -4,6 +4,7 @@ using Avalonia;
 using Avalonia.Controls.Primitives;
 using Avalonia.Media;
 using SukiUI.Dialogs;
+using SukiUI.Enums;
 
 namespace SukiUI.Controls
 {
@@ -55,6 +56,16 @@ namespace SukiUI.Controls
         {
             get => GetValue(ShowCardBackgroundProperty);
             set => SetValue(ShowCardBackgroundProperty, value);
+        }
+
+        public static readonly StyledProperty<SukiDialogBackgroundStyle> BackgroundStyleProperty =
+            AvaloniaProperty.Register<SukiDialog, SukiDialogBackgroundStyle>(
+                nameof(BackgroundStyle), defaultValue: SukiDialogBackgroundStyle.Blur);
+
+        public SukiDialogBackgroundStyle BackgroundStyle
+        {
+            get => GetValue(BackgroundStyleProperty);
+            set => SetValue(BackgroundStyleProperty, value);
         }
         
         public static readonly StyledProperty<IBrush?> IconColorProperty = AvaloniaProperty.Register<SukiDialog, IBrush?>(nameof(IconColor));

--- a/SukiUI/Converters/SukiDialogBackgroundStyleToBoolConverter.cs
+++ b/SukiUI/Converters/SukiDialogBackgroundStyleToBoolConverter.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+using SukiUI.Enums;
+
+namespace SukiUI.Converters
+{
+    public class SukiDialogBackgroundStyleToBoolConverter : IValueConverter
+    {
+        public static readonly SukiDialogBackgroundStyleToBoolConverter Instance = new();
+
+        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value is SukiDialogBackgroundStyle style)
+                return style == SukiDialogBackgroundStyle.Blur;
+            return false;
+        }
+
+        public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/SukiUI/Enums/SukiDialogBackgroundStyle.cs
+++ b/SukiUI/Enums/SukiDialogBackgroundStyle.cs
@@ -1,0 +1,8 @@
+namespace SukiUI.Enums
+{
+    public enum SukiDialogBackgroundStyle
+    {
+        Blur,
+        Flat
+    }
+}


### PR DESCRIPTION
[BlurBackground.Render()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) now safely skips blur when [GrContext](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) is null, preventing ArgumentNullException in [SKSurface.Create()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html). Added [SukiDialog.BackgroundStyle](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) property ([Blur](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) / [Flat](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)) so apps can explicitly opt out of GPU blur for software rendering environments.Description: [BlurBackground.Render()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) now safely skips blur when [GrContext](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) is null, preventing ArgumentNullException in [SKSurface.Create()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html). Added [SukiDialog.BackgroundStyle](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) property ([Blur](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) / [Flat](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)) so apps can explicitly opt out of GPU blur for software rendering environments.

Fixes #619 