### PR TITLE
feat: Add render scaling properties to SukiMainHost and SukiWindow

### DIFF
--- a/SukiUI.Demo/SukiUIDemoView.axaml
+++ b/SukiUI.Demo/SukiUIDemoView.axaml
@@ -25,6 +25,8 @@
                  IsTitleBarVisible="{Binding TitleBarVisible, Mode=TwoWay}"
                  ShowBottomBorder="{Binding ShowBottomBar}"
                  ShowTitlebarBackground="{Binding ShowTitleBar}"
+                 RenderScaleX="{Binding RenderScale}"
+                 RenderScaleY="{Binding RenderScale}"
                  mc:Ignorable="d">
     <suki:SukiWindow.TitleBarContextMenu>
         <ContextMenu>
@@ -127,14 +129,42 @@
                                                        DockPanel.Dock="Top"
                                                        FontSize="15"
                                                        FontWeight="DemiBold"
-                                                       Text="Volume" />
-                                            <avalonia:MaterialIcon DockPanel.Dock="Left"
-                                                                   Foreground="{DynamicResource SukiLowText}"
-                                                                   Kind="VolumeLow" />
-                                            <avalonia:MaterialIcon DockPanel.Dock="Right"
-                                                                   Foreground="{DynamicResource SukiLowText}"
-                                                                   Kind="VolumeHigh" />
-                                            <Slider MinWidth="100" Value="50" />
+                                                       Text="{Binding Volume, StringFormat='Volume ({0:F0}%)'}" />
+
+                                            <RepeatButton Classes="Void" DockPanel.Dock="Left"
+                                                          Foreground="{DynamicResource SukiLowText}"
+                                                          Command="{Binding DecreaseVolumeCommand}"
+                                                          Content="{avalonia:MaterialIconExt Kind=VolumeLow}" />
+                                            <RepeatButton Classes="Void" DockPanel.Dock="Right"
+                                                          Foreground="{DynamicResource SukiLowText}"
+                                                          Command="{Binding IncreaseVolumeCommand}"
+                                                          Content="{avalonia:MaterialIconExt Kind=VolumeHigh}" />
+                                            <Slider MinWidth="100" Value="{Binding Volume}" />
+                                        </DockPanel>
+
+                                    </suki:GlassCard>
+
+                                    <suki:GlassCard Padding="15" CornerRadius="15">
+
+                                        <DockPanel>
+                                            <TextBlock Margin="0,0,0,10"
+                                                       VerticalAlignment="Center"
+                                                       DockPanel.Dock="Top"
+                                                       FontSize="15"
+                                                       FontWeight="DemiBold"
+                                                       Text="{Binding RenderScale, StringFormat='Render scale ({0:F2}x)'}" />
+
+                                            <RepeatButton Classes="Void" DockPanel.Dock="Left"
+                                                          Foreground="{DynamicResource SukiLowText}"
+                                                          Command="{Binding DecreaseRenderScaleCommand}"
+                                                          Content="{avalonia:MaterialIconExt Kind=Minus}" />
+
+                                            <RepeatButton Classes="Void" DockPanel.Dock="Right"
+                                                          Foreground="{DynamicResource SukiLowText}"
+                                                          Command="{Binding IncreaseRenderScaleCommand}"
+                                                          Content="{avalonia:MaterialIconExt Kind=Plus}" />
+                                            <Slider MinWidth="100" Minimum="0.1" Maximum="5.0"
+                                                    Value="{Binding RenderScale}" />
                                         </DockPanel>
 
                                     </suki:GlassCard>
@@ -178,7 +208,8 @@
                       Header="Title Bar"
                       ToolTip.Tip="Toggles the title bar.">
                 <MenuItem.Icon>
-                    <avalonia:MaterialIcon Kind="{Binding TitleBarVisible, Converter={x:Static converters:BoolToIconConverters.Visibility}}" />
+                    <avalonia:MaterialIcon
+                        Kind="{Binding TitleBarVisible, Converter={x:Static converters:BoolToIconConverters.Visibility}}" />
                 </MenuItem.Icon>
             </MenuItem>
             <MenuItem Command="{Binding ToggleTitleBackgroundCommand}" Header="Change TitleBar Background Visibility">
@@ -195,7 +226,6 @@
             </MenuItem>
 
 
-
             <MenuItem Header="Window Options">
                 <MenuItem.Icon>
                     <avalonia:MaterialIcon Kind="WindowRestore" />
@@ -204,7 +234,8 @@
                           Header="Window Lock"
                           ToolTip.Tip="Toggles minimizing and resizing.">
                     <MenuItem.Icon>
-                        <avalonia:MaterialIcon Kind="{Binding WindowLocked, Converter={x:Static converters:BoolToIconConverters.WindowLock}}" />
+                        <avalonia:MaterialIcon
+                            Kind="{Binding WindowLocked, Converter={x:Static converters:BoolToIconConverters.WindowLock}}" />
                     </MenuItem.Icon>
                 </MenuItem>
                 <MenuItem Command="{Binding $parent[suki:SukiWindow].ToggleFullScreen}"
@@ -241,7 +272,6 @@
             </MenuItem>
 
 
-
         </MenuItem>
         <MenuItem Header="Theme">
             <MenuItem Click="ThemeMenuItem_OnClick"
@@ -265,12 +295,14 @@
             <MenuItem Header="-" />
             <MenuItem Command="{Binding ToggleAnimationsCommand}" Header="Animations">
                 <MenuItem.Icon>
-                    <avalonia:MaterialIcon Kind="{Binding AnimationsEnabled, Converter={x:Static converters:BoolToIconConverters.Animation}}" />
+                    <avalonia:MaterialIcon
+                        Kind="{Binding AnimationsEnabled, Converter={x:Static converters:BoolToIconConverters.Animation}}" />
                 </MenuItem.Icon>
             </MenuItem>
             <MenuItem Command="{Binding ToggleTransitionsCommand}" Header="Transitions">
                 <MenuItem.Icon>
-                    <avalonia:MaterialIcon Kind="{Binding TransitionsEnabled, Converter={x:Static converters:BoolToIconConverters.Animation}}" />
+                    <avalonia:MaterialIcon
+                        Kind="{Binding TransitionsEnabled, Converter={x:Static converters:BoolToIconConverters.Animation}}" />
                 </MenuItem.Icon>
             </MenuItem>
         </MenuItem>

--- a/SukiUI.Demo/SukiUIDemoView.axaml
+++ b/SukiUI.Demo/SukiUIDemoView.axaml
@@ -139,7 +139,7 @@
                                                           Foreground="{DynamicResource SukiLowText}"
                                                           Command="{Binding IncreaseVolumeCommand}"
                                                           Content="{avalonia:MaterialIconExt Kind=VolumeHigh}" />
-                                            <Slider MinWidth="100" Value="{Binding Volume}" />
+                                            <Slider MinWidth="100" Minimum="0" Maximum="100" Value="{Binding Volume}" />
                                         </DockPanel>
 
                                     </suki:GlassCard>

--- a/SukiUI.Demo/SukiUIDemoViewModel.cs
+++ b/SukiUI.Demo/SukiUIDemoViewModel.cs
@@ -1,176 +1,220 @@
+using Avalonia;
 using Avalonia.Collections;
 using Avalonia.Styling;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using SukiUI.Controls;
 using SukiUI.Demo.Features;
 using SukiUI.Demo.Features.CustomTheme;
+using SukiUI.Demo.Features.Theming;
 using SukiUI.Demo.Services;
 using SukiUI.Demo.Utilities;
-using SukiUI.Models;
-using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Media;
-using SukiUI.Demo.Features.ControlsLibrary.Dialogs;
-using SukiUI.Demo.Features.Theming;
 using SukiUI.Dialogs;
 using SukiUI.Enums;
+using SukiUI.Models;
 using SukiUI.Theme.Shadcn;
 using SukiUI.Toasts;
 
-namespace SukiUI.Demo;
-
-public partial class SukiUIDemoViewModel : ObservableObject
+namespace SukiUI.Demo
 {
-    public IAvaloniaReadOnlyList<DemoPageBase> DemoPages { get; }
-    public PageNavigationService PageNavigationService { get; }
-
-    public IAvaloniaReadOnlyList<SukiColorTheme> Themes { get; }
-
-    public IAvaloniaReadOnlyList<SukiBackgroundStyle> BackgroundStyles { get; }
-
-    public ISukiToastManager ToastManager { get; }
-    public ISukiDialogManager DialogManager { get; }
-
-    [ObservableProperty] private ThemeVariant _baseTheme;
-    [ObservableProperty] private DemoPageBase? _activePage;
-    [ObservableProperty] private bool _windowLocked;
-    [ObservableProperty] private bool _titleBarVisible = true;
-    [ObservableProperty] private SukiBackgroundStyle _backgroundStyle = SukiBackgroundStyle.GradientSoft;
-    [ObservableProperty] private bool _animationsEnabled;
-    [ObservableProperty] private string? _customShaderFile;
-    [ObservableProperty] private bool _transitionsEnabled;
-    [ObservableProperty] private double _transitionTime;
-
-    [ObservableProperty] private bool _showTitleBar = true;
-    [ObservableProperty] private bool _showBottomBar = true;
-
-    private readonly SukiTheme _theme;
-    private readonly ThemingViewModel _theming;
-
-    public SukiUIDemoViewModel(IEnumerable<DemoPageBase> demoPages, PageNavigationService pageNavigationService, ISukiToastManager toastManager, ISukiDialogManager dialogManager)
+    public partial class SukiUIDemoViewModel : ObservableObject
     {
-        ToastManager = toastManager;
-        DialogManager = dialogManager;
-        DemoPages = new AvaloniaList<DemoPageBase>(demoPages.OrderBy(x => x.Index).ThenBy(x => x.DisplayName));
-        PageNavigationService = pageNavigationService;
-        _theming = (ThemingViewModel)DemoPages.First(x => x is ThemingViewModel);
-        _theming.BackgroundStyleChanged += style => BackgroundStyle = style;
-        _theming.BackgroundAnimationsChanged += enabled => AnimationsEnabled = enabled;
-        _theming.CustomBackgroundStyleChanged += shader => CustomShaderFile = shader;
-        _theming.BackgroundTransitionsChanged += enabled => TransitionsEnabled = enabled;
+        private readonly SukiTheme _theme;
+        private readonly ThemingViewModel _theming;
+        [ObservableProperty] private DemoPageBase? _activePage;
+        [ObservableProperty] private bool _animationsEnabled;
+        [ObservableProperty] private SukiBackgroundStyle _backgroundStyle = SukiBackgroundStyle.GradientSoft;
 
-        BackgroundStyles = new AvaloniaList<SukiBackgroundStyle>(Enum.GetValues<SukiBackgroundStyle>());
-        _theme = SukiTheme.GetInstance();
+        [ObservableProperty] private ThemeVariant _baseTheme;
+        [ObservableProperty] private string? _customShaderFile;
+        [ObservableProperty] private double _renderScale = 1.0;
+        [ObservableProperty] private bool _showBottomBar = true;
 
-        // Subscribe to the navigation service (when a page navigation is requested)
-        pageNavigationService.NavigationRequested += pageType =>
+        [ObservableProperty] private bool _showTitleBar = true;
+        [ObservableProperty] private bool _titleBarVisible = true;
+        [ObservableProperty] private bool _transitionsEnabled;
+        [ObservableProperty] private double _transitionTime;
+        [ObservableProperty] private double _volume = 50;
+        [ObservableProperty] private bool _windowLocked;
+
+        public SukiUIDemoViewModel(IEnumerable<DemoPageBase> demoPages, PageNavigationService pageNavigationService,
+            ISukiToastManager toastManager, ISukiDialogManager dialogManager)
         {
-            var page = DemoPages.FirstOrDefault(x => x.GetType() == pageType);
-            if (page is null || ActivePage?.GetType() == pageType) return;
-            ActivePage = page;
-        };
+            ToastManager = toastManager;
+            DialogManager = dialogManager;
+            DemoPages = new AvaloniaList<DemoPageBase>(demoPages.OrderBy(x => x.Index).ThenBy(x => x.DisplayName));
+            PageNavigationService = pageNavigationService;
+            _theming = (ThemingViewModel)DemoPages.First(x => x is ThemingViewModel);
+            _theming.BackgroundStyleChanged += style => BackgroundStyle = style;
+            _theming.BackgroundAnimationsChanged += enabled => AnimationsEnabled = enabled;
+            _theming.CustomBackgroundStyleChanged += shader => CustomShaderFile = shader;
+            _theming.BackgroundTransitionsChanged += enabled => TransitionsEnabled = enabled;
 
-        Themes = _theme.ColorThemes;
-        BaseTheme = _theme.ActiveBaseTheme;
+            BackgroundStyles = new AvaloniaList<SukiBackgroundStyle>(Enum.GetValues<SukiBackgroundStyle>());
+            _theme = SukiTheme.GetInstance();
 
-        // Subscribe to the base theme changed events
-        _theme.OnBaseThemeChanged += variant =>
-        {
-            BaseTheme = variant;
-            ToastManager.CreateSimpleInfoToast()
-                .WithTitle("Theme Changed")
-                .WithContent($"Theme has changed to {variant}.")
+            // Subscribe to the navigation service (when a page navigation is requested)
+            pageNavigationService.NavigationRequested += pageType =>
+            {
+                var page = DemoPages.FirstOrDefault(x => x.GetType() == pageType);
+                if (page is null || ActivePage?.GetType() == pageType) return;
+                ActivePage = page;
+            };
+
+            Themes = _theme.ColorThemes;
+            BaseTheme = _theme.ActiveBaseTheme;
+
+            // Subscribe to the base theme changed events
+            _theme.OnBaseThemeChanged += variant =>
+            {
+                BaseTheme = variant;
+                ToastManager.CreateSimpleInfoToast()
+                    .WithTitle("Theme Changed")
+                    .WithContent($"Theme has changed to {variant}.")
+                    .Queue();
+            };
+
+            // Subscribe to the color theme changed events
+            _theme.OnColorThemeChanged += theme => ToastManager.CreateSimpleInfoToast()
+                .WithTitle("Color Changed")
+                .WithContent($"Color has changed to {theme.DisplayName}.")
                 .Queue();
-        };
+        }
 
-        // Subscribe to the color theme changed events
-        _theme.OnColorThemeChanged += theme => ToastManager.CreateSimpleInfoToast()
-            .WithTitle("Color Changed")
-            .WithContent($"Color has changed to {theme.DisplayName}.")
-            .Queue();
+        public IAvaloniaReadOnlyList<DemoPageBase> DemoPages { get; }
+        public PageNavigationService PageNavigationService { get; }
+
+        public IAvaloniaReadOnlyList<SukiColorTheme> Themes { get; }
+
+        public IAvaloniaReadOnlyList<SukiBackgroundStyle> BackgroundStyles { get; }
+
+        public ISukiToastManager ToastManager { get; }
+        public ISukiDialogManager DialogManager { get; }
+
+        [RelayCommand]
+        private void ToggleAnimations()
+        {
+            AnimationsEnabled = !AnimationsEnabled;
+            ToastManager.CreateSimpleInfoToast()
+                .WithTitle(AnimationsEnabled ? "Animation Enabled" : "Animation Disabled")
+                .WithContent(AnimationsEnabled
+                    ? "Background animations are now enabled."
+                    : "Background animations are now disabled.")
+                .Queue();
+        }
+
+        [RelayCommand]
+        private void ToggleTransitions()
+        {
+            TransitionsEnabled = !TransitionsEnabled;
+            ToastManager.CreateSimpleInfoToast()
+                .WithTitle(TransitionsEnabled ? "Transitions Enabled" : "Transitions Disabled")
+                .WithContent(TransitionsEnabled
+                    ? "Background transitions are now enabled."
+                    : "Background transitions are now disabled.")
+                .Queue();
+        }
+
+        [RelayCommand]
+        private void ToggleBaseTheme()
+        {
+            _theme.SwitchBaseTheme();
+        }
+
+        public void ChangeTheme(SukiColorTheme theme)
+        {
+            _theme.ChangeColorTheme(theme);
+        }
+
+        [RelayCommand]
+        private void ShadCnMode()
+        {
+            Shadcn.Configure(Application.Current, Application.Current.ActualThemeVariant);
+        }
+
+        [RelayCommand]
+        private void CreateCustomTheme()
+        {
+            DialogManager.CreateDialog()
+                .WithViewModel(dialog => new CustomThemeDialogViewModel(_theme, dialog))
+                .TryShow();
+        }
+
+        [RelayCommand]
+        private void ToggleWindowLock()
+        {
+            WindowLocked = !WindowLocked;
+            ToastManager.CreateSimpleInfoToast()
+                .WithTitle($"Window {(WindowLocked ? "Locked" : "Unlocked")}")
+                .WithContent($"Window has been {(WindowLocked ? "locked" : "unlocked")}.")
+                .Queue();
+        }
+
+        [RelayCommand]
+        private void ToggleTitleBackground()
+        {
+            ShowTitleBar = !ShowTitleBar;
+            ShowBottomBar = !ShowBottomBar;
+        }
+
+        [RelayCommand]
+        private void ToggleTitleBar()
+        {
+            TitleBarVisible = !TitleBarVisible;
+            ToastManager.CreateSimpleInfoToast()
+                .WithTitle($"Title Bar {(TitleBarVisible ? "Visible" : "Hidden")}")
+                .WithContent($"Window title bar has been {(TitleBarVisible ? "shown" : "hidden")}.")
+                .Queue();
+        }
+
+        [RelayCommand]
+        private void ToggleRightToLeft()
+        {
+            _theme.IsRightToLeft = !_theme.IsRightToLeft;
+        }
+
+        [RelayCommand]
+        private void DecreaseRenderScale()
+        {
+            RenderScale -= 0.05;
+        }
+
+        [RelayCommand]
+        private void IncreaseRenderScale()
+        {
+            RenderScale += 0.05;
+        }
+
+        [RelayCommand]
+        private void DecreaseVolume()
+        {
+            Volume -= 5;
+        }
+
+        [RelayCommand]
+        private void IncreaseVolume()
+        {
+            Volume += 5;
+        }
+
+        [RelayCommand]
+        private static void OpenUrl(string url)
+        {
+            UrlUtilities.OpenUrl(url);
+        }
+
+        partial void OnBackgroundStyleChanged(SukiBackgroundStyle value)
+        {
+            _theming.BackgroundStyle = value;
+        }
+
+        partial void OnAnimationsEnabledChanged(bool value)
+        {
+            _theming.BackgroundAnimations = value;
+        }
+
+        partial void OnTransitionsEnabledChanged(bool value)
+        {
+            _theming.BackgroundTransitions = value;
+        }
     }
-
-    [RelayCommand]
-    private void ToggleAnimations()
-    {
-        AnimationsEnabled = !AnimationsEnabled;
-        ToastManager.CreateSimpleInfoToast()
-            .WithTitle(AnimationsEnabled ? "Animation Enabled" : "Animation Disabled")
-            .WithContent(AnimationsEnabled ? "Background animations are now enabled." : "Background animations are now disabled.")
-            .Queue();
-    }
-
-    [RelayCommand]
-    private void ToggleTransitions()
-    {
-        TransitionsEnabled = !TransitionsEnabled;
-        ToastManager.CreateSimpleInfoToast()
-            .WithTitle(TransitionsEnabled ? "Transitions Enabled" : "Transitions Disabled")
-            .WithContent(TransitionsEnabled ? "Background transitions are now enabled." : "Background transitions are now disabled.")
-            .Queue();
-    }
-
-    [RelayCommand]
-    private void ToggleBaseTheme() =>
-        _theme.SwitchBaseTheme();
-
-    public void ChangeTheme(SukiColorTheme theme) =>
-        _theme.ChangeColorTheme(theme);
-
-    [RelayCommand]
-    private void ShadCnMode()
-    {
-        Shadcn.Configure(Application.Current, Application.Current.ActualThemeVariant);
-    }
-
-    [RelayCommand]
-    private void CreateCustomTheme()
-    {
-        DialogManager.CreateDialog()
-            .WithViewModel(dialog => new CustomThemeDialogViewModel(_theme, dialog))
-            .TryShow();
-    }
-
-    [RelayCommand]
-    private void ToggleWindowLock()
-    {
-        WindowLocked = !WindowLocked;
-        ToastManager.CreateSimpleInfoToast()
-            .WithTitle($"Window {(WindowLocked ? "Locked" : "Unlocked")}")
-            .WithContent($"Window has been {(WindowLocked ? "locked" : "unlocked")}.")
-            .Queue();
-    }
-
-    [RelayCommand]
-    private void ToggleTitleBackground()
-    {
-        ShowTitleBar = !ShowTitleBar;
-        ShowBottomBar = !ShowBottomBar;
-    }
-
-    [RelayCommand]
-    private void ToggleTitleBar()
-    {
-        TitleBarVisible = !TitleBarVisible;
-        ToastManager.CreateSimpleInfoToast()
-            .WithTitle($"Title Bar {(TitleBarVisible ? "Visible" : "Hidden")}")
-            .WithContent($"Window title bar has been {(TitleBarVisible ? "shown" : "hidden")}.")
-            .Queue();
-    }
-
-    [RelayCommand]
-    private void ToggleRightToLeft() => _theme.IsRightToLeft = !_theme.IsRightToLeft;
-
-    [RelayCommand]
-    private static void OpenUrl(string url) => UrlUtilities.OpenUrl(url);
-
-    partial void OnBackgroundStyleChanged(SukiBackgroundStyle value) =>
-        _theming.BackgroundStyle = value;
-
-    partial void OnAnimationsEnabledChanged(bool value) =>
-        _theming.BackgroundAnimations = value;
-
-    partial void OnTransitionsEnabledChanged(bool value) =>
-        _theming.BackgroundTransitions = value;
 }

--- a/SukiUI/Controls/SukiMainHost.axaml
+++ b/SukiUI/Controls/SukiMainHost.axaml
@@ -11,22 +11,41 @@
     -->
 
     <Design.PreviewWith>
-        <Border Width="400"
-                Height="400"
-                Background="Gray">
-            <suki:SukiMainHost Margin="20"
-                               HorizontalAlignment="Center"
-                               VerticalAlignment="Center"
-                               CornerRadius="10">
-                <suki:GlassCard Margin="20">
-                    <suki:GroupBox Header="SukiUI">
-                        <SelectableTextBlock
-                            Text="SukiUI makes your Avalonia applications more modern. The library offers a large number of animated controls and theme switches."
-                            TextWrapping="Wrap" />
-                    </suki:GroupBox>
-                </suki:GlassCard>
-            </suki:SukiMainHost>
-        </Border>
+        <StackPanel Spacing="20">
+            <Border Width="500"
+                    Background="Gray">
+                <suki:SukiMainHost Margin="20"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center"
+                                   CornerRadius="10">
+                    <suki:GlassCard Margin="20">
+                        <suki:GroupBox Header="SukiUI (1x Render)">
+                            <SelectableTextBlock
+                                Text="SukiUI makes your Avalonia applications more modern. The library offers a large number of animated controls and theme switches."
+                                TextWrapping="Wrap" />
+                        </suki:GroupBox>
+                    </suki:GlassCard>
+                </suki:SukiMainHost>
+            </Border>
+
+            <Border Width="500"
+                    Background="Gray">
+                <suki:SukiMainHost Margin="20"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center"
+                                   CornerRadius="10"
+                                   RenderScaleX="1.5"
+                                   RenderScaleY="1.5">
+                    <suki:GlassCard Margin="20">
+                        <suki:GroupBox Header="SukiUI (1.5x Render)">
+                            <SelectableTextBlock
+                                Text="SukiUI makes your Avalonia applications more modern. The library offers a large number of animated controls and theme switches."
+                                TextWrapping="Wrap" />
+                        </suki:GroupBox>
+                    </suki:GlassCard>
+                </suki:SukiMainHost>
+            </Border>
+        </StackPanel>
     </Design.PreviewWith>
 
     <ControlTheme x:Key="{x:Type suki:SukiMainHost}" TargetType="suki:SukiMainHost">
@@ -34,54 +53,63 @@
         <Setter Property="Margin" Value="0" />
         <Setter Property="Template">
             <ControlTemplate>
-                <VisualLayerManager Name="PART_VisualLayerManager" IsHitTestVisible="True">
-                    <Border Background="Transparent"
-                            ClipToBounds="True"
-                            CornerRadius="{TemplateBinding CornerRadius}">
-                        <Grid>
-                            <Panel Name="PART_Root">
-                                <!--  Margin -100 is there to exclude the unwanted bright corners  -->
-                                <suki:SukiBackground Name="PART_Background"
-                                                     Margin="-150"
-                                                     AnimationEnabled="{TemplateBinding BackgroundAnimationEnabled}"
-                                                     ForceSoftwareRendering="{TemplateBinding BackgroundForceSoftwareRendering}"
-                                                     ShaderCode="{TemplateBinding BackgroundShaderCode}"
-                                                     ShaderFile="{TemplateBinding BackgroundShaderFile}"
-                                                     Style="{TemplateBinding BackgroundStyle}"
-                                                     TransitionTime="{TemplateBinding BackgroundTransitionTime}"
-                                                     TransitionsEnabled="{TemplateBinding BackgroundTransitionsEnabled}" />
+                <LayoutTransformControl RenderTransformOrigin="50%,50%">
+                    <LayoutTransformControl.LayoutTransform>
+                        <ScaleTransform
+                            ScaleX="{Binding RenderScaleX, RelativeSource={RelativeSource TemplatedParent}}"
+                            ScaleY="{Binding RenderScaleY, RelativeSource={RelativeSource TemplatedParent}}" />
+                    </LayoutTransformControl.LayoutTransform>
+                    <VisualLayerManager Name="PART_VisualLayerManager" IsHitTestVisible="True">
+                        <Border Background="Transparent"
+                                ClipToBounds="True"
+                                CornerRadius="{TemplateBinding CornerRadius}">
+                            <Grid>
+                                <Panel Name="PART_Root">
+                                    <!-- Margin -100 is there to exclude the unwanted bright corners -->
+                                    <suki:SukiBackground Name="PART_Background"
+                                                         Margin="-150"
+                                                         AnimationEnabled="{TemplateBinding BackgroundAnimationEnabled}"
+                                                         ForceSoftwareRendering="{TemplateBinding BackgroundForceSoftwareRendering}"
+                                                         ShaderCode="{TemplateBinding BackgroundShaderCode}"
+                                                         ShaderFile="{TemplateBinding BackgroundShaderFile}"
+                                                         Style="{TemplateBinding BackgroundStyle}"
+                                                         TransitionTime="{TemplateBinding BackgroundTransitionTime}"
+                                                         TransitionsEnabled="{TemplateBinding BackgroundTransitionsEnabled}" />
 
-                                <Border Background="White"
-                                        IsHitTestVisible="False"
-                                        IsVisible="{DynamicResource IsLight}"
-                                        Opacity="0.1" />
+                                    <Border Background="White"
+                                            IsHitTestVisible="False"
+                                            IsVisible="{DynamicResource IsLight}"
+                                            Opacity="0.1" />
 
-                                <ContentPresenter x:Name="PART_ContentPresenter"
-                                                  Margin="{TemplateBinding Padding}"
-                                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                  Background="{TemplateBinding Background}"
-                                                  BackgroundSizing="{TemplateBinding BackgroundSizing}"
-                                                  BorderBrush="{TemplateBinding BorderBrush}"
-                                                  BorderThickness="{TemplateBinding BorderThickness}"
-                                                  ClipToBounds="True"
-                                                  Content="{TemplateBinding Content}"
-                                                  ContentTemplate="{TemplateBinding ContentTemplate}"
-                                                  CornerRadius="{TemplateBinding CornerRadius}"
-                                                  IsHitTestVisible="True" />
-                            </Panel>
+                                    <ContentPresenter x:Name="PART_ContentPresenter"
+                                                      Margin="{TemplateBinding Padding}"
+                                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                      Background="{TemplateBinding Background}"
+                                                      BackgroundSizing="{TemplateBinding BackgroundSizing}"
+                                                      BorderBrush="{TemplateBinding BorderBrush}"
+                                                      BorderThickness="{TemplateBinding BorderThickness}"
+                                                      ClipToBounds="True"
+                                                      Content="{TemplateBinding Content}"
+                                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                      CornerRadius="{TemplateBinding CornerRadius}"
+                                                      IsHitTestVisible="True" />
+                                </Panel>
 
-                            <ItemsControl ZIndex="1"
-                                          ItemsSource="{Binding Hosts, RelativeSource={RelativeSource AncestorType={x:Type suki:SukiMainHost}}}">
-                                <ItemsControl.ItemsPanel>
-                                    <ItemsPanelTemplate>
-                                        <Panel />
-                                    </ItemsPanelTemplate>
-                                </ItemsControl.ItemsPanel>
-                            </ItemsControl>
-                        </Grid>
-                    </Border>
-                </VisualLayerManager>
+                                <ItemsControl ZIndex="1"
+                                              ItemsSource="{Binding Hosts, RelativeSource={RelativeSource AncestorType={x:Type suki:SukiMainHost}}}">
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <Panel />
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                </ItemsControl>
+                            </Grid>
+                        </Border>
+                    </VisualLayerManager>
+                </LayoutTransformControl>
+
+
             </ControlTemplate>
         </Setter>
     </ControlTheme>

--- a/SukiUI/Controls/SukiMainHost.axaml.cs
+++ b/SukiUI/Controls/SukiMainHost.axaml.cs
@@ -130,6 +130,9 @@ namespace SukiUI.Controls
 
         private static double CoerceRenderScale(AvaloniaObject property, double scaling)
         {
+            if (double.IsNaN(scaling))
+                return 1.0;
+
             return scaling switch
             {
                 < 0.1 => 0.1,

--- a/SukiUI/Controls/SukiMainHost.axaml.cs
+++ b/SukiUI/Controls/SukiMainHost.axaml.cs
@@ -34,6 +34,12 @@ namespace SukiUI.Controls
         public static readonly StyledProperty<bool> BackgroundForceSoftwareRenderingProperty =
             AvaloniaProperty.Register<SukiMainHost, bool>(nameof(BackgroundForceSoftwareRendering));
 
+        public static readonly StyledProperty<double> RenderScaleXProperty =
+            AvaloniaProperty.Register<SukiMainHost, double>(nameof(RenderScaleX), 1.0, coerce: CoerceRenderScale);
+
+        public static readonly StyledProperty<double> RenderScaleYProperty =
+            AvaloniaProperty.Register<SukiMainHost, double>(nameof(RenderScaleY), 1.0, coerce: CoerceRenderScale);
+
         public static readonly StyledProperty<Avalonia.Controls.Controls> HostsProperty =
             AvaloniaProperty.Register<SukiMainHost, Avalonia.Controls.Controls>(nameof(Hosts));
 
@@ -95,6 +101,24 @@ namespace SukiUI.Controls
         }
 
         /// <summary>
+        /// Gets or sets the horizontal scale factor for rendering.
+        /// </summary>
+        public double RenderScaleX
+        {
+            get => GetValue(RenderScaleXProperty);
+            set => SetValue(RenderScaleXProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the vertical scale factor for rendering.
+        /// </summary>
+        public double RenderScaleY
+        {
+            get => GetValue(RenderScaleYProperty);
+            set => SetValue(RenderScaleYProperty, value);
+        }
+
+        /// <summary>
         /// These controls are displayed above all others and fill the entire window.
         /// You can include <see cref="SukiDialogHost"/> and <see cref="SukiToastHost"/> or create your own custom implementations.
         /// </summary>
@@ -102,6 +126,16 @@ namespace SukiUI.Controls
         {
             get => GetValue(HostsProperty);
             set => SetValue(HostsProperty, value);
+        }
+
+        private static double CoerceRenderScale(AvaloniaObject property, double scaling)
+        {
+            return scaling switch
+            {
+                < 0.1 => 0.1,
+                > 5.0 => 5.0,
+                _ => scaling
+            };
         }
     }
 }

--- a/SukiUI/Controls/SukiWindow.axaml
+++ b/SukiUI/Controls/SukiWindow.axaml
@@ -51,6 +51,8 @@
                                        BackgroundTransitionsEnabled="{TemplateBinding BackgroundTransitionsEnabled}"
                                        CornerRadius="{TemplateBinding RootCornerRadius}"
                                        Foreground="{TemplateBinding Foreground}"
+                                       RenderScaleX="{TemplateBinding RenderScaleX}"
+                                       RenderScaleY="{TemplateBinding RenderScaleY}"
                                        Hosts="{Binding Hosts, RelativeSource={RelativeSource AncestorType={x:Type suki:SukiWindow}}}">
                         <DockPanel LastChildFill="True">
                             <Panel DockPanel.Dock="Top">

--- a/SukiUI/Controls/SukiWindow.axaml.cs
+++ b/SukiUI/Controls/SukiWindow.axaml.cs
@@ -434,6 +434,30 @@ public class SukiWindow : Window, IDisposable
         set => SetValue(BackgroundForceSoftwareRenderingProperty, value);
     }
 
+    public static readonly StyledProperty<double> RenderScaleXProperty =
+        SukiMainHost.RenderScaleXProperty.AddOwner<SukiWindow>();
+
+    /// <summary>
+    /// Gets or sets the horizontal scale factor for rendering.
+    /// </summary>
+    public double RenderScaleX
+    {
+        get => GetValue(RenderScaleXProperty);
+        set => SetValue(RenderScaleXProperty, value);
+    }
+
+    public static readonly StyledProperty<double> RenderScaleYProperty =
+        SukiMainHost.RenderScaleYProperty.AddOwner<SukiWindow>();
+
+    /// <summary>
+    /// Gets or sets the vertical scale factor for rendering.
+    /// </summary>
+    public double RenderScaleY
+    {
+        get => GetValue(RenderScaleYProperty);
+        set => SetValue(RenderScaleYProperty, value);
+    }
+
     public static readonly StyledProperty<Avalonia.Controls.Controls> RightWindowTitleBarControlsProperty =
         AvaloniaProperty.Register<SukiWindow, Avalonia.Controls.Controls>(nameof(RightWindowTitleBarControls));
 


### PR DESCRIPTION
Some people dislike the bulky design of suki, this can be fixable with `ScaleTransform` but it require to be implemented in every window and the downside is that is not possible to scale titlebar and menus due outside of ContentPresenter in own app without re-theme.
To solve this I've added `RenderScaleX` and `RenderScaleY` To `SukiMainHost` (The source) and `SukiWindow` (redirects to SukiMainHost)

## Notes:

- Coarse within: 0.1x <-> 5.0x
- Some popups and context menus are not affected

https://github.com/user-attachments/assets/aaedb6e3-ba4c-464a-b702-97d56f23faa9

<img width="503" height="588" alt="image" src="https://github.com/user-attachments/assets/94498daa-e114-4136-90e2-91e5ff40ee30" />


