### PR TITLE
ci: harden nightly release workflow

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -2,12 +2,38 @@ name: Nightly Release
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Runs at midnight UTC every day
-  workflow_dispatch:  # Allow manual triggering
+    - cron: '0 0 * * *' # Runs at midnight UTC every day
+  workflow_dispatch: # Allow manual triggering
+    inputs:
+      force:
+        description: 'Publish even when nothing changed since the last successful run'
+        type: boolean
+        default: false
+      dry-run:
+        description: 'Build and pack, but do not push to NuGet'
+        type: boolean
+        default: false
+
+concurrency:
+  group: nightly-release-${{ github.ref }}
+  cancel-in-progress: false # Never cancel a run that may already be pushing packages
+
+permissions:
+  contents: read
+  actions: read
+
+env:
+  DOTNET_VERSION: 9.0.x
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  NUGET_OUTPUT: ${{ github.workspace }}/nupkgs
+  PROJECTS: SukiUI/SukiUI.csproj SukiUI.Dock/SukiUI.Dock.csproj
 
 jobs:
   check-changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       has-changes: ${{ steps.check.outputs.has-changes }}
       base-version: ${{ steps.get-version.outputs.base-version }}
@@ -16,45 +42,72 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Need full history for version checking
+          fetch-depth: 0 # Need full history and tags for version checking
+          filter: blob:none # History and tags only, no file blobs
 
       - name: Get last release version
         id: get-version
         run: |
-          # Get the most recent release tag matching semantic versioning
-          LAST_TAG=$(git describe --tags --match "[0-9]*.[0-9]*.[0-9]*" --abbrev=0 2>/dev/null || echo "0.0.0")
-          echo "base-version=${LAST_TAG#v}" >> $GITHUB_OUTPUT
-          echo "Using base version: ${LAST_TAG#v}"
+          set -euo pipefail
+
+          # Highest semantic version tag, not merely the closest one to HEAD.
+          LAST_TAG=$(git tag --list --sort=-v:refname \
+            | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' \
+            | head -n 1 || true)
+          BASE_VERSION="${LAST_TAG#v}"
+          BASE_VERSION="${BASE_VERSION:-0.0.0}"
+
+          echo "base-version=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Using base version: ${BASE_VERSION}"
 
       - name: Check for changes since last successful nightly release
         id: check
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          FORCE: ${{ inputs.force }}
         run: |
-          # Get the date of the last successful nightly release
-          LAST_RELEASE_DATE=$(gh run list --workflow="Nightly Release" --status=success --limit=1 --json createdAt --jq '.[0].createdAt' 2>/dev/null || true)
+          set -euo pipefail
 
-          if [ -z "$LAST_RELEASE_DATE" ]; then
-            echo "No previous successful releases found, proceeding with build"
-            echo "has-changes=true" >> $GITHUB_OUTPUT
+          if [ "$FORCE" = "true" ]; then
+            echo "Forced run requested, proceeding with build"
+            echo "has-changes=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Check if there are any commits since last release
-          CHANGES=$(git log --since="$LAST_RELEASE_DATE" --oneline)
+          # Compare the current commit to the latest successful nightly run on this branch.
+          LAST_SUCCESSFUL_SHA=$(gh run list \
+            --workflow "$GITHUB_WORKFLOW" \
+            --branch "$GITHUB_REF_NAME" \
+            --status success \
+            --limit 1 \
+            --json headSha \
+            --jq '.[0].headSha' 2>/dev/null || true)
 
-          if [ -z "$CHANGES" ]; then
-            echo "No changes since last release at $LAST_RELEASE_DATE"
-            echo "has-changes=false" >> $GITHUB_OUTPUT
+          if [ -z "$LAST_SUCCESSFUL_SHA" ]; then
+            echo "No previous successful releases found, proceeding with build"
+            echo "has-changes=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          CURRENT_SHA=$(git rev-parse HEAD)
+          if [ "$CURRENT_SHA" = "$LAST_SUCCESSFUL_SHA" ]; then
+            echo "No changes since last successful release at $LAST_SUCCESSFUL_SHA"
+            echo "has-changes=false" >> "$GITHUB_OUTPUT"
+            echo "Nightly skipped: no changes since \`$LAST_SUCCESSFUL_SHA\`." >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "Changes detected since last release at $LAST_RELEASE_DATE"
-            echo "has-changes=true" >> $GITHUB_OUTPUT
+            echo "Changes detected since last successful release at $LAST_SUCCESSFUL_SHA"
+            echo "has-changes=true" >> "$GITHUB_OUTPUT"
           fi
 
   publish:
     needs: check-changes
     if: needs.check-changes.outputs.has-changes == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
 
     steps:
       - name: Checkout
@@ -63,36 +116,99 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/Directory.Packages.props', '**/*.csproj') }}
+          restore-keys: ${{ runner.os }}-nuget-
 
       - name: Generate nightly version
         id: version
+        env:
+          BASE_VERSION: ${{ needs.check-changes.outputs.base-version }}
         run: |
-          BASE_VERSION=${{ needs.check-changes.outputs.base-version }}
+          set -euo pipefail
+
           # Remove build metadata if present
           CLEAN_VERSION=${BASE_VERSION%%+*}
 
           # Split version and increment patch number
-          IFS='.' read -r -a version_parts <<< "$CLEAN_VERSION"
-          version_parts[2]=$((version_parts[2] + 1))
-          NEW_VERSION="${version_parts[0]}.${version_parts[1]}.${version_parts[2]}"
+          IFS='.' read -r major minor patch <<< "$CLEAN_VERSION"
+          NEW_VERSION="${major}.${minor}.$((patch + 1))"
 
-          DATE=$(date +'%Y%m%d')
-          NIGHTLY_VERSION="${NEW_VERSION}-nightly${DATE}"
+          DATE=$(date -u +'%Y%m%d')
+          SHORT_SHA=$(git rev-parse --short=7 HEAD)
+          NIGHTLY_VERSION="${NEW_VERSION}-nightly.${DATE}.${SHORT_SHA}"
 
-          echo "NIGHTLY_VERSION=${NIGHTLY_VERSION}" >> $GITHUB_OUTPUT
+          echo "NIGHTLY_VERSION=${NIGHTLY_VERSION}" >> "$GITHUB_OUTPUT"
           echo "Using version: ${NIGHTLY_VERSION}"
+
+      - name: Restore
+        run: |
+          set -euo pipefail
+          for project in $PROJECTS; do
+            dotnet restore "$project"
+          done
 
       - name: Build
         run: |
-          dotnet build -c Release SukiUI/SukiUI.csproj -p:Version=${{ steps.version.outputs.NIGHTLY_VERSION }}
-          dotnet build -c Release SukiUI.Dock/SukiUI.Dock.csproj -p:Version=${{ steps.version.outputs.NIGHTLY_VERSION }}
+          set -euo pipefail
+          for project in $PROJECTS; do
+            dotnet build "$project" -c Release --no-restore \
+              -p:Version="$NIGHTLY_VERSION" \
+              -p:ContinuousIntegrationBuild=true \
+              -p:GeneratePackageOnBuild=false
+          done
+        env:
+          NIGHTLY_VERSION: ${{ steps.version.outputs.NIGHTLY_VERSION }}
 
       - name: Pack
         run: |
-          dotnet pack -c Release -o . SukiUI/SukiUI.csproj -p:Version=${{ steps.version.outputs.NIGHTLY_VERSION }}
-          dotnet pack -c Release -o . SukiUI.Dock/SukiUI.Dock.csproj -p:Version=${{ steps.version.outputs.NIGHTLY_VERSION }}
-          ls
+          set -euo pipefail
+          for project in $PROJECTS; do
+            dotnet pack "$project" -c Release --no-build -o "$NUGET_OUTPUT" \
+              -p:Version="$NIGHTLY_VERSION" \
+              -p:ContinuousIntegrationBuild=true \
+              --include-symbols -p:SymbolPackageFormat=snupkg
+          done
+          ls -l "$NUGET_OUTPUT"
+        env:
+          NIGHTLY_VERSION: ${{ steps.version.outputs.NIGHTLY_VERSION }}
 
-      - name: Publish to GitHub Packages
-        run: dotnet nuget push *.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+      - name: Upload packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-packages-${{ steps.version.outputs.NIGHTLY_VERSION }}
+          path: ${{ env.NUGET_OUTPUT }}/*
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Publish to NuGet.org
+        if: ${{ inputs.dry-run != true && env.NUGET_API_KEY != '' }}
+        run: |
+          set -euo pipefail
+          for package in "$NUGET_OUTPUT"/*.nupkg; do
+            dotnet nuget push "$package" \
+              --api-key "$NUGET_API_KEY" \
+              --source https://api.nuget.org/v3/index.json \
+              --skip-duplicate
+          done
+
+      - name: Summary
+        if: always()
+        env:
+          NIGHTLY_VERSION: ${{ steps.version.outputs.NIGHTLY_VERSION }}
+        run: |
+          {
+            echo "### Nightly \`${NIGHTLY_VERSION}\`"
+            if [ "${{ inputs.dry-run }}" = "true" ]; then
+              echo "- Dry run: packages built but not pushed."
+            elif [ -z "$NUGET_API_KEY" ]; then
+              echo "- \`NUGET_API_KEY\` not set: packages built but not pushed."
+            else
+              echo "- Pushed to [NuGet.org](https://www.nuget.org/packages/SukiUI)."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
dotnet build/pack accept a single project argument and `dotnet nuget push` a single package, so the multi-project and glob invocations failed once more than one item was passed. Loop over projects/packages instead.

Also:
- pack into nupkgs/ (artifacts/ is the MSBuild ArtifactsPath root)
- pick the highest semver tag instead of the closest one, with a 0.0.0 fallback so the patch increment cannot fail under `set -u`
- scope the previous-run lookup to this repo and branch
- skip the redundant pack caused by GeneratePackageOnBuild
- never cancel an in-progress run, it may already be pushing
- add force/dry-run dispatch inputs, NuGet cache, package artifacts, symbol packages, deterministic builds, job timeouts and a run summary
- only push when NUGET_API_KEY is set, so forks build without failing