### PR TITLE
Fix theme-aware colors and flyout style

### DIFF
--- a/SukiUI.Demo/Features/Dashboard/DashboardView.axaml
+++ b/SukiUI.Demo/Features/Dashboard/DashboardView.axaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="SukiUI.Demo.Features.Dashboard.DashboardView"
+﻿<UserControl x:Class="SukiUI.Demo.Features.Dashboard.DashboardView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -653,6 +653,62 @@
                         <TabItem Classes="Pill" Header="Tab 2"></TabItem>
                         <TabItem Classes="Pill" Header="Tab 3"></TabItem>
                     </TabControl>
+                </suki:GroupBox>
+            </suki:GlassCard>
+            <!--  Grid Splitter  -->
+            <suki:GlassCard Width="600"
+                            Height="400"
+                            Margin="15">
+                <suki:GroupBox>
+                    <suki:GroupBox.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <icon:MaterialIcon Foreground="{DynamicResource SukiLowText}" Kind="ArrowSplitVertical" />
+                            <TextBlock Margin="5,0,0,0" Text="Grid Splitter" />
+                        </StackPanel>
+                    </suki:GroupBox.Header>
+
+                    <!--
+                        Columns splitter on the outside with a Rows splitter nested on the left, so both
+                        ResizeDirection branches of the GridSplitter theme are visible at the same time.
+                    -->
+                    <Grid ColumnDefinitions="*,Auto,*">
+                        <Grid Grid.Column="0" RowDefinitions="*,Auto,*">
+                            <Border Grid.Row="0"
+                                    Background="{DynamicResource SukiCardBackground}"
+                                    CornerRadius="{DynamicResource SmallCornerRadius}">
+                                <TextBlock HorizontalAlignment="Center"
+                                           VerticalAlignment="Center"
+                                           Foreground="{DynamicResource SukiLowText}"
+                                           Text="Top" />
+                            </Border>
+
+                            <GridSplitter Grid.Row="1"
+                                          Height="8"
+                                          ResizeDirection="Rows" />
+
+                            <Border Grid.Row="2"
+                                    Background="{DynamicResource SukiCardBackground}"
+                                    CornerRadius="{DynamicResource SmallCornerRadius}">
+                                <TextBlock HorizontalAlignment="Center"
+                                           VerticalAlignment="Center"
+                                           Foreground="{DynamicResource SukiLowText}"
+                                           Text="Bottom" />
+                            </Border>
+                        </Grid>
+
+                        <GridSplitter Grid.Column="1"
+                                      Width="8"
+                                      ResizeDirection="Columns" />
+
+                        <Border Grid.Column="2"
+                                Background="{DynamicResource SukiCardBackground}"
+                                CornerRadius="{DynamicResource SmallCornerRadius}">
+                            <TextBlock HorizontalAlignment="Center"
+                                       VerticalAlignment="Center"
+                                       Foreground="{DynamicResource SukiLowText}"
+                                       Text="Right" />
+                        </Border>
+                    </Grid>
                 </suki:GroupBox>
             </suki:GlassCard>
         </WrapPanel>

--- a/SukiUI/ColorTheme/Dark.axaml
+++ b/SukiUI/ColorTheme/Dark.axaml
@@ -75,4 +75,27 @@
 
     </LinearGradientBrush>
  
+
+    <!--  SimpleTheme palette. Consumed by the Avalonia control themes SukiUI does not
+          re-template, and by SukiUI's DatePicker, TimePicker, Slider, SplitView and
+          CalendarDatePicker themes via the Theme*Brush resources in Theme/ColorsStyles.xaml.  -->
+    <Color x:Key="MediumGray">#2E2E2E</Color>
+    <Color x:Key="BackgroundGray">#252525</Color>
+    <Color x:Key="BorderGray">#353535</Color>
+    <Color x:Key="ThemeCardColor">#FF323232</Color>
+    <Color x:Key="ThemeBackgroundColor">#FF2A2A2A</Color>
+    <Color x:Key="ThemeBorderLowColor">#FF3A3A3A</Color>
+    <Color x:Key="ThemeBorderMidColor">#FF454545</Color>
+    <Color x:Key="ThemeBorderHighColor">#FF606060</Color>
+    <Color x:Key="ThemeControlLowColor">#FF6E7180</Color>
+    <Color x:Key="ThemeControlMidColor">#FF3A3A3A</Color>
+    <Color x:Key="ThemeControlMidHighColor">#FF55565C</Color>
+    <Color x:Key="ThemeControlHighColor">#FF9A9A9A</Color>
+    <Color x:Key="ThemeControlVeryHighColor">#FFB4B4B4</Color>
+    <Color x:Key="ThemeControlHighlightLowColor">#FF3A3A3A</Color>
+    <Color x:Key="ThemeControlHighlightMidColor">#FF505050</Color>
+    <Color x:Key="ThemeControlHighlightHighColor">#FF909090</Color>
+    <Color x:Key="ThemeForegroundColor">#EDFFFFFF</Color>
+    <Color x:Key="ThemeForegroundLowColor">#FFB4B4B4</Color>
+
 </ResourceDictionary>

--- a/SukiUI/ColorTheme/Light.axaml
+++ b/SukiUI/ColorTheme/Light.axaml
@@ -72,4 +72,26 @@
     <Color x:Key="SukiNeedleBrush">#999999</Color>
     <Color x:Key="GaugeBackgroundBrush" >#aaffffff</Color>
 
+    <!--  SimpleTheme palette. Consumed by the Avalonia control themes SukiUI does not
+          re-template, and by SukiUI's DatePicker, TimePicker, Slider, SplitView and
+          CalendarDatePicker themes via the Theme*Brush resources in Theme/ColorsStyles.xaml.  -->
+    <Color x:Key="MediumGray">#F4F4F4</Color>
+    <Color x:Key="BackgroundGray">#fafafa</Color>
+    <Color x:Key="BorderGray">#ebebeb</Color>
+    <Color x:Key="ThemeCardColor">#FFFFFF</Color>
+    <Color x:Key="ThemeBackgroundColor">#FFECECEC</Color>
+    <Color x:Key="ThemeBorderLowColor">#FFF3F3F3</Color>
+    <Color x:Key="ThemeBorderMidColor">#FFECECEC</Color>
+    <Color x:Key="ThemeBorderHighColor">#FFAAAAAA</Color>
+    <Color x:Key="ThemeControlLowColor">#FF868999</Color>
+    <Color x:Key="ThemeControlMidColor">#FFF5F5F5</Color>
+    <Color x:Key="ThemeControlMidHighColor">#FFC2C3C9</Color>
+    <Color x:Key="ThemeControlHighColor">#FF686868</Color>
+    <Color x:Key="ThemeControlVeryHighColor">#FF5B5B5B</Color>
+    <Color x:Key="ThemeControlHighlightLowColor">#FFF0F0F0</Color>
+    <Color x:Key="ThemeControlHighlightMidColor">#FFD0D0D0</Color>
+    <Color x:Key="ThemeControlHighlightHighColor">#FF808080</Color>
+    <Color x:Key="ThemeForegroundColor">#FF000000</Color>
+    <Color x:Key="ThemeForegroundLowColor">#FF808080</Color>
+
 </ResourceDictionary>

--- a/SukiUI/Controls/Touch/MobileNumberPicker/MobileNumberPickerPopup.axaml
+++ b/SukiUI/Controls/Touch/MobileNumberPicker/MobileNumberPickerPopup.axaml
@@ -4,12 +4,12 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SukiUI.Controls.Touch.MobileNumberPicker.MobileNumberPickerPopup">
-    <Border ClipToBounds="True" Padding="10" CornerRadius="45" Background="{DynamicResource DialogBackground}">
+    <Border ClipToBounds="True" Padding="10" CornerRadius="45" Background="{DynamicResource SukiCardBackground}">
     <Border Height="460" Width="750">
         <Grid>
 
             <Grid
-                Background="{DynamicResource DialogBackground}"
+                Background="{DynamicResource SukiControlTouchBackground}"
                 Height="200"
                 HorizontalAlignment="Center"
                 Margin="20,40,20,20"
@@ -19,7 +19,7 @@
                 PointerCaptureLost="OnPointerCaptureLost"
                 VerticalAlignment="Top"
                 Width="300">
-                <StackPanel Margin="0,0,0,000" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <StackPanel Margin="0,0,0,0" HorizontalAlignment="Center" VerticalAlignment="Center">
 
                     <TextBlock
                         FontSize="30"
@@ -57,7 +57,7 @@
                         Text="2"
                         VerticalAlignment="Center" />
                 </StackPanel>
-                <Border Height="1" Background="{DynamicResource SukiControlBorderBrush}" Margin="00,164,0,0" Width="150" />
+                <Border Height="1" Background="{DynamicResource SukiControlBorderBrush}" Margin="0,164,0,0" Width="150" />
                 <Border Height="1" Background="{DynamicResource SukiControlBorderBrush}" Width="150" />
             </Grid>
 
@@ -68,14 +68,14 @@
                                           Width="70"  Foreground="{DynamicResource Accent}" Opacity="0.7"
                                           Height="70" />
             </Button>
-            
+
             <Button Click="minus" Margin="0,0,0,90" HorizontalAlignment="Left" Classes="Enormous Transparent" VerticalAlignment="Center">
                 <iconPacks:PackIconLucide  HorizontalAlignment="Center" VerticalAlignment="Center" Kind="{x:Static iconPacks:PackIconLucideKind.Minus}"
                                            Width="70" Margin="0,50"  Foreground="{DynamicResource Accent}" Opacity="0.7"
                                            Height="70" />
             </Button>
 -->
-       
+
         </Grid>
     </Border>
     </Border>

--- a/SukiUI/Theme/ColorsStyles.xaml
+++ b/SukiUI/Theme/ColorsStyles.xaml
@@ -3,33 +3,18 @@
        xmlns:sys="clr-namespace:System;assembly=netstandard">
     <Style.Resources>
 
-        <Color x:Key="MediumGray">#F4F4F4</Color>
-        <Color x:Key="BackgroundGray">#fafafa</Color>
-        <Color x:Key="BorderGray">#ebebeb</Color>
-
         <Color x:Key="ThemeAccentColor">#0063bb</Color>
         <Color x:Key="ThemeAccentColor2">#0063bb</Color>
         <Color x:Key="ThemeAccentColor3">#0063bb</Color>
         <Color x:Key="ThemeAccentColor4">#003f8e</Color>
         <Color x:Key="ThemeAccentBadgeColor">#300063bb</Color>
 
-        <Color x:Key="ThemeCardColor">#FFFFFF</Color>
-        <Color x:Key="ThemeBackgroundColor">#FFECECEC</Color>
-        <Color x:Key="ThemeBorderLowColor">#FFF3F3F3</Color>
-        <Color x:Key="ThemeBorderMidColor">#FFECECEC</Color>
-        <Color x:Key="ThemeBorderHighColor">#FFAAAAAA</Color>
-
-        <Color x:Key="ThemeControlLowColor">#FF868999</Color>
-        <Color x:Key="ThemeControlMidColor">#FFF5F5F5</Color>
-        <Color x:Key="ThemeControlMidHighColor">#FFC2C3C9</Color>
-        <Color x:Key="ThemeControlHighColor">#FF686868</Color>
-        <Color x:Key="ThemeControlVeryHighColor">#FF5B5B5B</Color>
-
-        <Color x:Key="ThemeControlHighlightLowColor">#FFF0F0F0</Color>
-        <Color x:Key="ThemeControlHighlightMidColor">#FFD0D0D0</Color>
-        <Color x:Key="ThemeControlHighlightHighColor">#FF808080</Color>
-        <Color x:Key="ThemeForegroundColor">#FF000000</Color>
-        <Color x:Key="ThemeForegroundLowColor">#FF808080</Color>
+        <!--
+            Colors that differ between light and dark live in ColorTheme/Light.axaml and
+            ColorTheme/Dark.axaml so they participate in ThemeDictionaries. Defining them here would
+            pin one value across both variants and shadow the theme-aware ones. The brushes below stay
+            here: DynamicResource re-resolves them per variant.
+        -->
 
         <Color x:Key="HighlightBadgeColor">#30fd7d00</Color>
         <Color x:Key="HighlightColor">#fd7d00</Color>
@@ -42,7 +27,7 @@
         <SolidColorBrush x:Key="ThemeBackgroundBrush" Color="{DynamicResource ThemeBackgroundColor}" />
         <SolidColorBrush x:Key="ThemeBorderLowBrush" Color="{DynamicResource ThemeBorderLowColor}" />
         <SolidColorBrush x:Key="ThemeBorderMidBrush" Color="{DynamicResource ThemeBorderMidColor}" />
-        <SolidColorBrush x:Key="ThemeBorderHighBrush" Color="#dedede" />
+        <SolidColorBrush x:Key="ThemeBorderHighBrush" Color="{DynamicResource ThemeBorderHighColor}" />
         <SolidColorBrush x:Key="ThemeControlLowBrush" Color="{DynamicResource ThemeControlLowColor}" />
         <SolidColorBrush x:Key="ThemeControlMidBrush" Color="{DynamicResource ThemeControlMidColor}" />
         <SolidColorBrush x:Key="ThemeControlMidHighBrush" Color="{DynamicResource ThemeControlMidHighColor}" />

--- a/SukiUI/Theme/FlyoutPresenter.axaml
+++ b/SukiUI/Theme/FlyoutPresenter.axaml
@@ -2,18 +2,18 @@
     <ControlTheme x:Key="SukiFlyoutPresenterStyle" TargetType="FlyoutPresenter">
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Stretch" />
-        <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderMidBrush}" />
-        <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="Padding" Value="4" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Padding" Value="0" />
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
-        <Setter Property="TextElement.Foreground" Value="{DynamicResource SukiText}"/>
-        <Setter Property="Cursor" Value="Arrow"/>
-   <!--     <Setter Property="FlowDirection" Value="{TemplateBinding FlowDirection}"/> -->
+        <Setter Property="TextElement.Foreground" Value="{DynamicResource SukiText}" />
+        <Setter Property="Cursor" Value="Arrow" />
+        <!--     <Setter Property="FlowDirection" Value="{TemplateBinding FlowDirection}"/> -->
         <Setter Property="Template">
             <ControlTemplate>
-                <Border Name="LayoutRoot" 
+                <Border Name="LayoutRoot"
                         Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
@@ -23,7 +23,9 @@
                             <DoubleTransition Property="Opacity" Duration="0:0:0.3" />
                         </Transitions>
                     </Border.Transitions>
-                    <ScrollViewer HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
+                    <ScrollViewer
+                        HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                        VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
                         <ContentPresenter Name="PART_ContentPresenter"
                                           Margin="{TemplateBinding Padding}"
                                           HorizontalAlignment="Stretch"

--- a/SukiUI/Theme/Shadcn/BlackWhiteTheme.axaml
+++ b/SukiUI/Theme/Shadcn/BlackWhiteTheme.axaml
@@ -1,6 +1,5 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:controls="https://github.com/kikipoulet/SukiUI"
                     xmlns:system="clr-namespace:System;assembly=netstandard">
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key='Light'>
@@ -10,15 +9,15 @@
             <Color x:Key="SukiCardBackground">#ffffff</Color>
         </ResourceDictionary>
         <ResourceDictionary x:Key='Dark'>
-        
+
             <Color x:Key='SukiPrimaryColor'>White</Color>
             <system:Double x:Key="GlassOpacity">0.09</system:Double>
             <BoxShadows x:Key="SukiSwitchShadow">0 0 0 0 Transparent</BoxShadows>
             <Color x:Key="SukiCardBackground">#2a2a2a</Color>
             <Color x:Key="GlassBorderBrush">White</Color>
             <LinearGradientBrush x:Key="PopupGradientBrush" StartPoint="0%,0%" EndPoint="100%,100%">
-                <GradientStop Color="{DynamicResource Transparent}" Offset="0"></GradientStop>
-                <GradientStop Color="{DynamicResource Transparent}" Offset="0.9"></GradientStop>
+                <GradientStop Color="Transparent" Offset="0"></GradientStop>
+                <GradientStop Color="Transparent" Offset="0.9"></GradientStop>
 
             </LinearGradientBrush>
         </ResourceDictionary>


### PR DESCRIPTION
Moved shared SimpleTheme palette colors from ColorsStyles into Light/Dark theme dictionaries so light/dark switching resolves the correct values, and updated ThemeBorderHighBrush to use the theme resource instead of a hardcoded color. Also adjusted FlyoutPresenter defaults to transparent/unstyled container settings, updated MobileNumberPicker popup backgrounds to Suki resources, added a GridSplitter showcase to the dashboard demo, and cleaned minor XAML issues (unused xmlns, transparent gradient stops, formatting).