### PR TITLE
Fix DataGrid scrollbar visibility sizing

### DIFF
--- a/SukiUI/Theme/ColorsStyles.xaml
+++ b/SukiUI/Theme/ColorsStyles.xaml
@@ -84,7 +84,7 @@
         <sys:Double x:Key="FontSizeNormal">14</sys:Double>
         <sys:Double x:Key="FontSizeLarge">14</sys:Double>
 
-        <sys:Double x:Key="ScrollBarThickness">18</sys:Double>
+        <sys:Double x:Key="ScrollBarThickness">10</sys:Double>
         <sys:Double x:Key="ScrollBarThumbThickness">8</sys:Double>
 
         <sys:Double x:Key="IconElementThemeHeight">20</sys:Double>

--- a/SukiUI/Theme/DataGridStyles.axaml
+++ b/SukiUI/Theme/DataGridStyles.axaml
@@ -1,4 +1,4 @@
-<Styles xmlns="https://github.com/avaloniaui"
+﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:collections="using:Avalonia.Collections"
         xmlns:objectModel="clr-namespace:System.Collections.ObjectModel;assembly=netstandard">
@@ -357,6 +357,13 @@
                         </DataGridRowsPresenter>
 
                         <!--
+                            Width/Height are required, not cosmetic: DataGrid.ComputeScrollBarVisibility
+                            reads ScrollBar.Width and ScrollBar.Height directly, and an unset value is NaN,
+                            which makes every MathUtilities comparison false and suppresses both bars
+                            permanently. Fluent avoids it by spanning the presenters so the bars overlay the
+                            cells (IsVerticalScrollBarOverCells); SukiUI reserves a gutter instead, so it has
+                            to supply the number.
+
                             These bars are not inside a ScrollViewer, so ScrollBar.AttachToScrollViewer()
                             never runs for them and nothing propagates the owner's setting; the binding is
                             what makes DataGrid's ScrollViewer.AllowAutoHide reach them. Everything else
@@ -365,6 +372,7 @@
                         <ScrollBar Name="PART_VerticalScrollbar"
                                    Grid.Row="1"
                                    Grid.Column="2"
+                                   Width="{DynamicResource ScrollBarThickness}"
                                    HorizontalAlignment="Right"
                                    AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}"
                                    Orientation="Vertical" />
@@ -376,6 +384,7 @@
                             <Rectangle Name="PART_FrozenColumnScrollBarSpacer" />
                             <ScrollBar Name="PART_HorizontalScrollbar"
                                        Grid.Column="1"
+                                       Height="{DynamicResource ScrollBarThickness}"
                                        AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}"
                                        Orientation="Horizontal" />
                         </Grid>

--- a/SukiUI/Theme/ScrollBar.axaml
+++ b/SukiUI/Theme/ScrollBar.axaml
@@ -1,4 +1,4 @@
-<ResourceDictionary xmlns="https://github.com/avaloniaui"
+﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:content="clr-namespace:SukiUI.Content"
                     xmlns:converters="clr-namespace:SukiUI.Converters">
@@ -97,10 +97,10 @@
         <Setter Property="Background" Value="Transparent" />
 
         <!--
-            Avalonia's built-in expand/collapse defaults (0.5s in, 2s out) feel sluggish for a bar this
-            thin; expand as soon as the pointer arrives and collapse shortly after it leaves.
+            Both shortened from Avalonia's stock timings (0.5s in, 2s out). A bar this thin wants to
+            respond quickly on approach and get out of the way soon after the pointer leaves.
         -->
-        <Setter Property="ShowDelay" Value="0:0:0" />
+        <Setter Property="ShowDelay" Value="0:0:0.25" />
         <Setter Property="HideDelay" Value="0:0:0.35" />
 
         <Style Selector="^ /template/ RepeatButton.repeattrack">
@@ -129,7 +129,7 @@
         </Style>
 
         <Style Selector="^:vertical">
-            <Setter Property="MinWidth" Value="10" />
+            <Setter Property="MinWidth" Value="{DynamicResource ScrollBarThickness}" />
             <Setter Property="HorizontalAlignment" Value="Right" />
             <Setter Property="Template">
                 <ControlTemplate>
@@ -248,7 +248,7 @@
         </Style>
 
         <Style Selector="^:horizontal">
-            <Setter Property="MinHeight" Value="10" />
+            <Setter Property="MinHeight" Value="{DynamicResource ScrollBarThickness}" />
             <Setter Property="VerticalAlignment" Value="Bottom" />
             <Setter Property="Template">
                 <ControlTemplate>


### PR DESCRIPTION
Set `ScrollBarThickness` to 10 and use it consistently for scrollbar minimum dimensions. DataGrid template scrollbars now bind explicit `Width`/`Height` to avoid NaN size values that break `ComputeScrollBarVisibility` checks and can suppress both bars. Also tuned auto-hide timing to quicker in/out behavior for thinner scrollbars.