### PR TITLE
Enable menu scrollbars and fix arrow button sizing

### DIFF
--- a/SukiUI/Theme/ContextMenu.axaml
+++ b/SukiUI/Theme/ContextMenu.axaml
@@ -1,6 +1,8 @@
-<ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+﻿<ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:theme="clr-namespace:SukiUI.Theme">
     <ControlTheme x:Key="SukiContextMenuStyle" TargetType="ContextMenu">
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
         <Setter Property="Background" Value="{DynamicResource SukiCardBackground}" />
         <Setter Property="CornerRadius" Value="6" />
         <Setter Property="BorderBrush" Value="{DynamicResource SukiMenuBorderBrush}" />

--- a/SukiUI/Theme/MenuFlyoutPresenter.axaml
+++ b/SukiUI/Theme/MenuFlyoutPresenter.axaml
@@ -1,6 +1,8 @@
-<ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+﻿<ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:theme="clr-namespace:SukiUI.Theme">
     <ControlTheme x:Key="SukiMenuFlyoutPresenterStyle" TargetType="MenuFlyoutPresenter">
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
         <Setter Property="Background" Value="{DynamicResource SukiCardBackground}" />
         <Setter Property="CornerRadius" Value="6" />
         <Setter Property="BorderBrush" Value="{DynamicResource SukiMenuBorderBrush}" />

--- a/SukiUI/Theme/MenuScrollViewer.axaml
+++ b/SukiUI/Theme/MenuScrollViewer.axaml
@@ -1,4 +1,4 @@
-<ResourceDictionary xmlns="https://github.com/avaloniaui"
+﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:content="clr-namespace:SukiUI.Content"
                     xmlns:converters="clr-namespace:Avalonia.Controls.Converters;assembly=Avalonia.Controls">
@@ -101,6 +101,15 @@
                 </DockPanel>
             </ControlTemplate>
         </Setter>
+
+        <Style Selector="^ /template/ RepeatButton">
+            <Setter Property="Height" Value="20" />
+            <Setter Property="MinHeight" Value="0" />
+            <Setter Property="MinWidth" Value="0" />
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="CornerRadius" Value="0" />
+        </Style>
 
         <Style Selector="^ /template/ RepeatButton:pointerover > Viewbox > Path">
             <Setter Property="Fill" Value="{DynamicResource SukiText}" />


### PR DESCRIPTION
Set both vertical and horizontal ScrollViewer visibility to Auto for ContextMenu and MenuFlyoutPresenter themes so overflow can scroll by default. Also added a template style for MenuScrollViewer RepeatButtons to normalize height, padding, border, and corner radius for consistent up/down scroll button sizing.