### PR TITLE
perf: avoid rebuilding radial gauge geometry

### DIFF
--- a/SukiUI/Controls/Gauges/RadialGauge/RadialGauge.cs
+++ b/SukiUI/Controls/Gauges/RadialGauge/RadialGauge.cs
@@ -355,25 +355,6 @@ public class RadialGauge : Panel
         InvalidateArrange();
     }
 
-    private void UpdateSegments()
-    {
-        if (Segments == null || _segmentPaths.Count != Segments.Count)
-        {
-            RebuildSegments();
-            return;
-        }
-
-        for (int i = 0; i < Segments.Count; i++)
-        {
-            var segment = Segments[i];
-            var path = _segmentPaths[i];
-            path.Stroke = new SolidColorBrush(segment.Color);
-            path.StrokeThickness = segment.Thickness;
-        }
-
-        InvalidateVisual();
-    }
-
     private void OnSegmentsChanged(AvaloniaPropertyChangedEventArgs e)
     {
         if (e.OldValue is IList<RadialGaugeSegment> oldCollection)
@@ -417,7 +398,6 @@ public class RadialGauge : Panel
     private void OnSegmentPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         InvalidateSegmentGeometry();
-        UpdateSegments();
         InvalidateArrange();
     }
 
@@ -590,14 +570,14 @@ public class RadialGauge : Panel
             _segmentsGeometryDirty = true;
         }
 
-        if (!_segmentsGeometryDirty)
-            return;
-
-        if (Segments == null || _segmentPaths.Count != Segments.Count)
+        if (_segmentPaths.Count != (Segments?.Count ?? 0))
         {
             RebuildSegments();
             return;
         }
+
+        if (Segments == null || !_segmentsGeometryDirty)
+            return;
 
         var center = rect.Center;
         double radius = rect.Width / 2.0;

--- a/SukiUI/Controls/Gauges/RadialGauge/RadialGauge.cs
+++ b/SukiUI/Controls/Gauges/RadialGauge/RadialGauge.cs
@@ -122,6 +122,12 @@ public class RadialGauge : Panel
     private List<Path> _segmentPaths = new();
     private Grid _segmentsGrid = null!;
     private readonly RotateTransform _needleTransform = new(0, 0, 0);
+    private readonly ArcSegment _trailArc = new() { SweepDirection = SweepDirection.Clockwise };
+    private readonly PathFigure _trailFigure;
+    private readonly PathGeometry _trailGeometry;
+    private LinearGradientBrush? _segmentTrailBrush;
+    private Color _segmentTrailBrushColor;
+    private double? _lastDisplayValue;
     private readonly HashSet<RadialGaugeSegment> _subscribedSegments = new();
     private bool _segmentsGeometryDirty = true;
     private Rect? _segmentsGeometryBounds;
@@ -153,7 +159,13 @@ public class RadialGauge : Panel
 
     public RadialGauge()
     {
-      
+        _trailFigure = new PathFigure
+        {
+            IsClosed = false,
+            IsFilled = false,
+            Segments = new PathSegments { _trailArc }
+        };
+        _trailGeometry = new PathGeometry { Figures = new PathFigures { _trailFigure } };
     }
 
     private void LoadControls()
@@ -445,7 +457,7 @@ public class RadialGauge : Panel
         var rect = new Rect((finalSize.Width - size) / 2, (finalSize.Height - size) / 2, size, size);
 
         _stackText.Arrange(rect);
-        _valueText.Text = Value.ToString("F0");
+        UpdateValueText();
 
         
         
@@ -532,27 +544,12 @@ public class RadialGauge : Panel
 
         bool isLarge = deltaDeg >= 180.0;
 
-        var fig = new PathFigure
-        {
-            StartPoint = startPt,
-            IsClosed = false,
-            IsFilled = false,
-            Segments = new PathSegments
-            {
-                new ArcSegment
-                {
-                    Point = endPt,
-                    Size = new Size(trailRadius, trailRadius),
-                    IsLargeArc = isLarge,
-                    SweepDirection = SweepDirection.Clockwise
-                }
-            }
-        };
+        _trailFigure.StartPoint = startPt;
+        _trailArc.Point = endPt;
+        _trailArc.Size = new Size(trailRadius, trailRadius);
+        _trailArc.IsLargeArc = isLarge;
 
-        var geom = new PathGeometry();
-        geom.Figures = new PathFigures { fig };
-
-        _trailPath.Data = geom;
+        _trailPath.Data = _trailGeometry;
         _trailPath.StrokeThickness = TrailThickness;
         
         IBrush trailBrush = GetTrailBrush();
@@ -649,6 +646,16 @@ public class RadialGauge : Panel
 
     private void InvalidateSegmentGeometry() => _segmentsGeometryDirty = true;
 
+    private void UpdateValueText()
+    {
+        var displayValue = Math.Round(Value, MidpointRounding.AwayFromZero);
+        if (_lastDisplayValue is { } last && last.Equals(displayValue))
+            return;
+
+        _lastDisplayValue = displayValue;
+        _valueText.Text = displayValue.ToString("F0");
+    }
+
     private static double Normalize01(double v, double min, double max)
     {
         if (max <= min) max = min + 1;
@@ -681,32 +688,37 @@ public class RadialGauge : Panel
         {
             if (Value >= segment.FromValue && Value <= segment.ToValue)
             {
-
-                return new LinearGradientBrush()
+                var color = segment.Color.WithAlpha(0.75);
+                if (_segmentTrailBrush is null || _segmentTrailBrushColor != color)
                 {
-                    StartPoint = new RelativePoint(1, 0, RelativeUnit.Relative),
-                    EndPoint = new RelativePoint(0, 1, RelativeUnit.Relative),
-                    GradientStops = new GradientStops()
+                    _segmentTrailBrushColor = color;
+                    _segmentTrailBrush = new LinearGradientBrush()
                     {
-                        new GradientStop()
+                        StartPoint = new RelativePoint(1, 0, RelativeUnit.Relative),
+                        EndPoint = new RelativePoint(0, 1, RelativeUnit.Relative),
+                        GradientStops = new GradientStops()
                         {
-                            Offset = 0,
-                            Color = segment.Color.WithAlpha(0.75)
-                        },
-                 
-                        new GradientStop()
-                        {
-                            Offset = 0.7,
-                            Color = Colors.Transparent
-                        },
-                        new GradientStop()
-                        {
-                            Offset = 1,
-                            Color = Colors.Transparent
-                        },
-                    }
-                };
-              
+                            new GradientStop()
+                            {
+                                Offset = 0,
+                                Color = color
+                            },
+
+                            new GradientStop()
+                            {
+                                Offset = 0.7,
+                                Color = Colors.Transparent
+                            },
+                            new GradientStop()
+                            {
+                                Offset = 1,
+                                Color = Colors.Transparent
+                            },
+                        }
+                    };
+                }
+
+                return _segmentTrailBrush;
             }
         }
 

--- a/SukiUI/Controls/Gauges/RadialGauge/RadialGauge.cs
+++ b/SukiUI/Controls/Gauges/RadialGauge/RadialGauge.cs
@@ -121,7 +121,10 @@ public class RadialGauge : Panel
     private StackPanel _stackText = null!;
     private List<Path> _segmentPaths = new();
     private Grid _segmentsGrid = null!;
+    private readonly RotateTransform _needleTransform = new(0, 0, 0);
     private readonly HashSet<RadialGaugeSegment> _subscribedSegments = new();
+    private bool _segmentsGeometryDirty = true;
+    private Rect? _segmentsGeometryBounds;
     private bool _isAttached;
           
 
@@ -142,6 +145,10 @@ public class RadialGauge : Panel
         SegmentsProperty.Changed.AddClassHandler<RadialGauge>((s, e) => s.OnSegmentsChanged(e));
         SubtitleTextProperty.Changed.AddClassHandler<RadialGauge>((s, _) => s.UpdateSubtitle());
         RimThicknessProperty.Changed.AddClassHandler<RadialGauge>((s, _) => s.UpdateRimThickness());
+        MinimumProperty.Changed.AddClassHandler<RadialGauge>((s, _) => s.InvalidateSegmentGeometry());
+        MaximumProperty.Changed.AddClassHandler<RadialGauge>((s, _) => s.InvalidateSegmentGeometry());
+        StartAngleProperty.Changed.AddClassHandler<RadialGauge>((s, _) => s.InvalidateSegmentGeometry());
+        EndAngleProperty.Changed.AddClassHandler<RadialGauge>((s, _) => s.InvalidateSegmentGeometry());
     }
 
     public RadialGauge()
@@ -189,6 +196,7 @@ public class RadialGauge : Panel
             Background = NeedleBrush,
             CornerRadius = new CornerRadius(32),
             RenderTransformOrigin = new RelativePoint(0, 0.5, RelativeUnit.Relative), 
+            RenderTransform = _needleTransform,
             IsHitTestVisible = false,
             Classes = { "rg-needle" }
         };
@@ -286,6 +294,7 @@ public class RadialGauge : Panel
     {
         if (!IsInitialize) return;
         _rim.BorderThickness = new Thickness(Math.Max(0, RimThickness));
+        InvalidateSegmentGeometry();
         InvalidateArrange();
     }
 
@@ -319,7 +328,13 @@ public class RadialGauge : Panel
         foreach (var path in _segmentPaths) _segmentsGrid.Children.Remove(path);
         _segmentPaths.Clear();
 
-        if (Segments == null) return;
+        if (Segments == null)
+        {
+            _segmentsGeometryDirty = false;
+            return;
+        }
+
+        InvalidateSegmentGeometry();
 
         for (int i = 0; i < Segments.Count; i++)
         {
@@ -401,6 +416,7 @@ public class RadialGauge : Panel
 
     private void OnSegmentPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
+        InvalidateSegmentGeometry();
         UpdateSegments();
         InvalidateArrange();
     }
@@ -504,7 +520,7 @@ public class RadialGauge : Panel
         var needleRect = new Rect(center.X, center.Y - needleTh / 2, needleLen, needleTh);
         _needle.CornerRadius = new CornerRadius(needleTh / 2);
         _needle.Arrange(needleRect);
-        _needle.RenderTransform = new RotateTransform(-angle, 0, 0);
+        _needleTransform.Angle = -angle;
 
 
         
@@ -568,6 +584,15 @@ public class RadialGauge : Panel
 
     private void UpdateSegmentsGeometry(Rect rect)
     {
+        if (_segmentsGeometryBounds != rect)
+        {
+            _segmentsGeometryBounds = rect;
+            _segmentsGeometryDirty = true;
+        }
+
+        if (!_segmentsGeometryDirty)
+            return;
+
         if (Segments == null || _segmentPaths.Count != Segments.Count)
         {
             RebuildSegments();
@@ -638,7 +663,11 @@ public class RadialGauge : Panel
             path.Opacity = segment.Opacity;
             path.StrokeLineCap = PenLineCap.Round;
         }
+
+        _segmentsGeometryDirty = false;
     }
+
+    private void InvalidateSegmentGeometry() => _segmentsGeometryDirty = true;
 
     private static double Normalize01(double v, double min, double max)
     {

--- a/SukiUI/Controls/Gauges/RadialGauge/RadialGauge.cs
+++ b/SukiUI/Controls/Gauges/RadialGauge/RadialGauge.cs
@@ -662,7 +662,7 @@ public class RadialGauge : Panel
 
     private void UpdateValueText()
     {
-        Span<char> displayText = stackalloc char[512];
+        Span<char> displayText = stackalloc char[64];
         if (!Value.TryFormat(displayText, out var charactersWritten, "F0", CultureInfo.CurrentCulture))
         {
             // Preserve the formatting contract even for an unusually long custom number format.

--- a/SukiUI/Controls/Gauges/RadialGauge/RadialGauge.cs
+++ b/SukiUI/Controls/Gauges/RadialGauge/RadialGauge.cs
@@ -119,7 +119,7 @@ public class RadialGauge : Panel
     private TextBlock _valueText = null!;
     private TextBlock _subtitleText = null!;
     private StackPanel _stackText = null!;
-    private List<Path> _segmentPaths = new();
+    private readonly List<SegmentVisual> _segmentVisuals = new();
     private Grid _segmentsGrid = null!;
     private readonly RotateTransform _needleTransform = new(0, 0, 0);
     private readonly ArcSegment _trailArc = new() { SweepDirection = SweepDirection.Clockwise };
@@ -337,8 +337,8 @@ public class RadialGauge : Panel
 
     private void RebuildSegments()
     {
-        foreach (var path in _segmentPaths) _segmentsGrid.Children.Remove(path);
-        _segmentPaths.Clear();
+        foreach (var visual in _segmentVisuals) _segmentsGrid.Children.Remove(visual.Path);
+        _segmentVisuals.Clear();
 
         if (Segments == null)
         {
@@ -351,16 +351,10 @@ public class RadialGauge : Panel
         for (int i = 0; i < Segments.Count; i++)
         {
             var segment = Segments[i];
-            var path = new Path
-            {
-                Stroke = new SolidColorBrush(segment.Color),
-                StrokeThickness = segment.Thickness,
-                StrokeLineCap = PenLineCap.Round,
-                IsHitTestVisible = false
-            };
-            _segmentPaths.Add(path);
+            var visual = new SegmentVisual(segment);
+            _segmentVisuals.Add(visual);
 
-            _segmentsGrid?.Children.Add(path);
+            _segmentsGrid?.Children.Add(visual.Path);
         }
 
         InvalidateMeasure();
@@ -567,7 +561,7 @@ public class RadialGauge : Panel
             _segmentsGeometryDirty = true;
         }
 
-        if (_segmentPaths.Count != (Segments?.Count ?? 0))
+        if (_segmentVisuals.Count != (Segments?.Count ?? 0))
         {
             RebuildSegments();
             return;
@@ -585,7 +579,8 @@ public class RadialGauge : Panel
         for (int i = 0; i < Segments.Count; i++)
         {
             var segment = Segments[i];
-            var path = _segmentPaths[i];
+            var visual = _segmentVisuals[i];
+            var path = visual.Path;
             
             double fromT = Normalize01(segment.FromValue, Minimum, Maximum);
             double toT = Normalize01(segment.ToValue, Minimum, Maximum);
@@ -614,29 +609,14 @@ public class RadialGauge : Panel
 
             bool isLarge = deltaDeg >= 180.0;
 
-            var fig = new PathFigure
-            {
-                StartPoint = startPt,
-                IsClosed = false,
-                IsFilled = false,
-                Segments = new PathSegments
-                {
-                    new ArcSegment
-                    {
-                        Point = endPt,
-                        Size = new Size(segmentRadius, segmentRadius),
-                        IsLargeArc = isLarge,
-                        SweepDirection = SweepDirection.Clockwise
-                    }
-                }
-            };
+            visual.Figure.StartPoint = startPt;
+            visual.Arc.Point = endPt;
+            visual.Arc.Size = new Size(segmentRadius, segmentRadius);
+            visual.Arc.IsLargeArc = isLarge;
 
-            var geom = new PathGeometry();
-            geom.Figures = new PathFigures { fig };
-
-            path.Data = geom;
+            path.Data = visual.Geometry;
             path.StrokeThickness = segment.Thickness;
-            path.Stroke = new SolidColorBrush(segment.Color);
+            visual.Brush.Color = segment.Color;
             path.Opacity = segment.Opacity;
             path.StrokeLineCap = PenLineCap.Round;
         }
@@ -645,6 +625,39 @@ public class RadialGauge : Panel
     }
 
     private void InvalidateSegmentGeometry() => _segmentsGeometryDirty = true;
+
+    /// <summary>
+    /// Holds the visuals backing one segment so a geometry refresh can mutate them
+    /// in place instead of allocating a new path, figure, arc and brush per pass.
+    /// </summary>
+    private sealed class SegmentVisual
+    {
+        public SegmentVisual(RadialGaugeSegment segment)
+        {
+            Arc = new ArcSegment { SweepDirection = SweepDirection.Clockwise };
+            Figure = new PathFigure
+            {
+                IsClosed = false,
+                IsFilled = false,
+                Segments = new PathSegments { Arc }
+            };
+            Geometry = new PathGeometry { Figures = new PathFigures { Figure } };
+            Brush = new SolidColorBrush(segment.Color);
+            Path = new Path
+            {
+                Stroke = Brush,
+                StrokeThickness = segment.Thickness,
+                StrokeLineCap = PenLineCap.Round,
+                IsHitTestVisible = false
+            };
+        }
+
+        public Path Path { get; }
+        public PathGeometry Geometry { get; }
+        public PathFigure Figure { get; }
+        public ArcSegment Arc { get; }
+        public SolidColorBrush Brush { get; }
+    }
 
     private void UpdateValueText()
     {

--- a/SukiUI/Controls/Gauges/RadialGauge/RadialGauge.cs
+++ b/SukiUI/Controls/Gauges/RadialGauge/RadialGauge.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Globalization;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Layout;
@@ -127,7 +128,7 @@ public class RadialGauge : Panel
     private readonly PathGeometry _trailGeometry;
     private LinearGradientBrush? _segmentTrailBrush;
     private Color _segmentTrailBrushColor;
-    private double? _lastDisplayValue;
+    private string? _lastDisplayText;
     private readonly HashSet<RadialGaugeSegment> _subscribedSegments = new();
     private bool _segmentsGeometryDirty = true;
     private Rect? _segmentsGeometryBounds;
@@ -661,12 +662,25 @@ public class RadialGauge : Panel
 
     private void UpdateValueText()
     {
-        var displayValue = Math.Round(Value, MidpointRounding.AwayFromZero);
-        if (_lastDisplayValue is { } last && last.Equals(displayValue))
+        Span<char> displayText = stackalloc char[512];
+        if (!Value.TryFormat(displayText, out var charactersWritten, "F0", CultureInfo.CurrentCulture))
+        {
+            // Preserve the formatting contract even for an unusually long custom number format.
+            var formattedValue = Value.ToString("F0", CultureInfo.CurrentCulture);
+            if (formattedValue == _lastDisplayText)
+                return;
+
+            _lastDisplayText = formattedValue;
+            _valueText.Text = formattedValue;
+            return;
+        }
+
+        var formattedText = displayText[..charactersWritten];
+        if (_lastDisplayText is { } last && formattedText.SequenceEqual(last.AsSpan()))
             return;
 
-        _lastDisplayValue = displayValue;
-        _valueText.Text = displayValue.ToString("F0");
+        _lastDisplayText = new string(formattedText);
+        _valueText.Text = _lastDisplayText;
     }
 
     private static double Normalize01(double v, double min, double max)


### PR DESCRIPTION
## Summary

`RadialGauge.Value` changes no longer rebuild segment paths, brushes, or the needle transform when their inputs are unchanged.

- Reuse the needle `RotateTransform`.
- Reuse static segment geometry across value-only updates.
- Invalidate that geometry when range, angle, rim thickness, segment data, collection, or bounds change.
- Preserve the existing value calculation, visual parameters, and update cadence.

## Validation

- `dotnet build Suki.sln -c Release -clp:ErrorsOnly` passed.
- `git diff --check` passed.

## Performance

The control change was measured before this PR was split, using the same `RadialGauge` implementation and a real macOS Desktop rendering session at 2.0 scaling. The temporary pressure harness rendered 24 gauges, each with 24 segments and 24 ticks, updated values for 90 warm-up frames, then measured 300 frames. The harness is not included in this PR.

| Run | Previous implementation p50 / p95 / max | This implementation p50 / p95 / max | Missed 60 Hz frames |
| --- | ---: | ---: | ---: |
| 1 | 16.351 / 25.828 / 59.010 ms | 16.065 / 16.759 / 17.104 ms | 18 -> 0 |
| 2 | 16.180 / 25.537 / 43.538 ms | 16.070 / 16.771 / 19.659 ms | 16 -> 0 |

The p95 interval dropped by about 34-35%, and repeated long frames disappeared in both runs. A matching Release Headless control-level allocation probe reduced p50/p95 allocation from 548,648/548,664 B to 37,720/37,736 B per update.

This PR intentionally contains only the library control change; it does not include Demo-page changes or the separate performance-test infrastructure.