### PR TITLE
perf: streamline GlassCard template instantiation

### DIFF
--- a/SukiUI/Controls/GlassMorphism/GlassCard.axaml
+++ b/SukiUI/Controls/GlassMorphism/GlassCard.axaml
@@ -1,7 +1,14 @@
-﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:suki="clr-namespace:SukiUI.Controls"
-                    xmlns:converters="https://github.com/kikipoulet/SukiUI">
+                    xmlns:suki="clr-namespace:SukiUI.Controls">
+    <Transitions x:Key="SukiGlassCardBorderTransitions">
+        <BrushTransition Property="{x:Static Border.BorderBrushProperty}" Duration="0:0:0.15" />
+        <DoubleTransition Property="{x:Static Visual.OpacityProperty}" Duration="0:0:0.15" />
+    </Transitions>
+    <Transitions x:Key="SukiGlassCardClipBorderTransitions">
+        <BrushTransition Property="{x:Static Border.BorderBrushProperty}" Duration="0:0:0.15" />
+    </Transitions>
+
     <ControlTheme x:Key="SukiGlassCardStyle" TargetType="suki:GlassCard">
         <Setter Property="BorderBrush" Value="{DynamicResource GlassBorderBrush}" />
         <Setter Property="Background" Value="{DynamicResource SukiGlassCardBackground}" />
@@ -9,107 +16,41 @@
         <Setter Property="Template">
             <ControlTemplate>
                 <Panel Name="RootPanel" Opacity="0">
-                    
-                    
-                    <Border Name="PART_BorderCardLight" IsVisible="{DynamicResource IsLight}" Classes="GlassCardBorderPartCard" RenderTransformOrigin="50%,50%"
-                            Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            ClipToBounds="{TemplateBinding ClipToBounds}"
-                            CornerRadius="{TemplateBinding CornerRadius}"
-                            Opacity="{DynamicResource GlassOpacity}">
-                        <Border.Transitions>
-                            <Transitions>
-                                <DoubleTransition Property="Width"
-                                                  Duration="0:0:0.5"
-                                                  Easing="QuadraticEaseOut" />
-                                <DoubleTransition Property="Height"
-                                                  Duration="0:0:0.5"
-                                                  Easing="QuadraticEaseOut" />
-                            </Transitions>
-                        </Border.Transitions>
-                        <Border.Transitions>
-                            <Transitions>
-                                <!-- <BrushTransition Property="Background" Duration="0:0:0.15" /> -->
-                                <BrushTransition Property="BorderBrush" Duration="0:0:0.15" />
-                                <DoubleTransition Property="Opacity" Duration="0:0:0.15" />
-                            </Transitions>
-                        </Border.Transitions>
-                    </Border>
-                    
-                    <Border Name="PART_BorderCardDark" IsVisible="{DynamicResource IsDark}" Classes="GlassCardBorderPartCard" RenderTransformOrigin="50%,50%"
-                            Background="{TemplateBinding Background}"
-                           
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            ClipToBounds="{TemplateBinding ClipToBounds}"
-                            CornerRadius="{TemplateBinding CornerRadius}"
-                            Opacity="{DynamicResource GlassOpacity}">
-                        <Border.BorderBrush>
-                            <LinearGradientBrush >
-                                <LinearGradientBrush.StartPoint>
-                                    <MultiBinding Converter="{x:Static converters:StartPointLiquidConverter.Instance}">
-                                        <Binding Path="Bounds.Width"  RelativeSource="{RelativeSource TemplatedParent}"/>
-                                        <Binding Path="Bounds.Height" RelativeSource="{RelativeSource TemplatedParent}"/>
-                                    </MultiBinding>
-                                </LinearGradientBrush.StartPoint>
-                                <LinearGradientBrush.EndPoint>
-                                    <MultiBinding Converter="{x:Static converters:EndPointLiquidConverter.Instance}">
-                                        <Binding Path="Bounds.Width"  RelativeSource="{RelativeSource TemplatedParent}"/>
-                                        <Binding Path="Bounds.Height" RelativeSource="{RelativeSource TemplatedParent}"/>
-                                    </MultiBinding>
-                                </LinearGradientBrush.EndPoint>
+                    <suki:GlassCardBorder Name="PART_BorderCard"
+                                          Classes="GlassCardBorderPartCard"
+                                          RenderTransformOrigin="50%,50%"
+                                          Transitions="{StaticResource SukiGlassCardBorderTransitions}"
+                                          Background="{TemplateBinding Background}"
+                                          LightBorderBrush="{TemplateBinding BorderBrush}"
+                                          UseDarkBorder="{DynamicResource IsDark}"
+                                          DarkBorderStartColor="{DynamicResource SukiLiquid1}"
+                                          DarkBorderEndColor="{DynamicResource SukiLiquid2}"
+                                          BorderThickness="{TemplateBinding BorderThickness}"
+                                          ClipToBounds="{TemplateBinding ClipToBounds}"
+                                          CornerRadius="{TemplateBinding CornerRadius}"
+                                          Opacity="{DynamicResource GlassOpacity}" />
 
-                                <GradientStop Offset="0"   Color="{DynamicResource SukiLiquid1}"/>
-                                <GradientStop Offset="0.5" Color="Transparent"/>
-                                <GradientStop Offset="1"   Color="{DynamicResource SukiLiquid2}"/>
-                            </LinearGradientBrush>
-                        </Border.BorderBrush>
-                        <Border.Transitions>
-                            <Transitions>
-                                <DoubleTransition Property="Width"
-                                                  Duration="0:0:0.5"
-                                                  Easing="QuadraticEaseOut" />
-                                <DoubleTransition Property="Height"
-                                                  Duration="0:0:0.5"
-                                                  Easing="QuadraticEaseOut" />
-                            </Transitions>
-                        </Border.Transitions>
-                        <Border.Transitions>
-                            <Transitions>
-                                <!-- <BrushTransition Property="Background" Duration="0:0:0.15" /> -->
-                                <BrushTransition Property="BorderBrush" Duration="0:0:0.15" />
-                                <DoubleTransition Property="Opacity" Duration="0:0:0.15" />
-                            </Transitions>
-                        </Border.Transitions>
-                    </Border>
-                    
-                  
-                    
-                    
                     <Border Name="PART_ClipBorder"
+                            Transitions="{StaticResource SukiGlassCardClipBorderTransitions}"
                             Background="{DynamicResource SukiPrimaryColor0}"
                             BorderBrush="{DynamicResource SukiPrimaryColor0}"
                             BorderThickness="{TemplateBinding BorderThickness}"
                             ClipToBounds="{TemplateBinding ClipToBounds}"
                             CornerRadius="{TemplateBinding CornerRadius}">
-                        <Border.Transitions>
-                            <Transitions>
-                                <BrushTransition Property="BorderBrush" Duration="0:0:0.15" />
-                            </Transitions>
-                        </Border.Transitions>
-                        <ContentPresenter Name="PART_CP" Margin="{TemplateBinding Padding}"
+                        <ContentPresenter Name="PART_CP"
+                                          Margin="{TemplateBinding Padding}"
                                           Content="{TemplateBinding Content}" />
                     </Border>
                 </Panel>
             </ControlTemplate>
         </Setter>
         <Style Selector="^.Control">
-            <Setter Property="IsAnimated" Value="False"></Setter>
-            <Setter Property="Padding" Value="0"></Setter>
+            <Setter Property="IsAnimated" Value="False" />
+            <Setter Property="Padding" Value="0" />
         </Style>
         <Style Selector="^.Discrete">
             <Setter Property="BorderBrush" Value="{DynamicResource SukiControlBorderBrush}" />
-            <Setter Property="Padding" Value="0"></Setter>
+            <Setter Property="Padding" Value="0" />
         </Style>
         <Style Selector="^.Control /template/ Border.GlassCardBorderPartCard">
             <Setter Property="Background" Value="{DynamicResource ControlSukiGlassCardBackground}" />

--- a/SukiUI/Controls/GlassMorphism/GlassCard.axaml.cs
+++ b/SukiUI/Controls/GlassMorphism/GlassCard.axaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Windows.Input;
 using Avalonia;
@@ -8,6 +8,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
+using Avalonia.Media;
 using Avalonia.Rendering.Composition;
 using Avalonia.Rendering.Composition.Animations;
 using SukiUI.Helpers;
@@ -17,6 +18,12 @@ namespace SukiUI.Controls;
 public class GlassCard : ContentControl
 {
     private ContextMenu? _attachedContextMenu;
+    private Panel? _rootPanel;
+    private Border? _cardBorder;
+    private Border? _legacyCardBorder;
+    private Border? _clipBorder;
+    private bool _animateAppliedTemplate;
+
     public new static readonly StyledProperty<CornerRadius> CornerRadiusProperty =
         AvaloniaProperty.Register<GlassCard, CornerRadius>(nameof(CornerRadius), new CornerRadius(20));
 
@@ -101,38 +108,46 @@ public class GlassCard : ContentControl
     {
         base.OnApplyTemplate(e);
 
-        if (IsAnimated)
-        {
-            var b = e.NameScope.Get<Panel>("RootPanel");
-            b.Loaded += (sender, args) =>
-            {
-                if (ElementComposition.GetElementVisual(b) is { } visual)
-                    CompositionAnimationHelper.MakeOpacityAnimated(visual);
-            };
+        _rootPanel = e.NameScope.Find<Panel>("RootPanel");
+        _cardBorder = e.NameScope.Find<Border>("PART_BorderCard") ??
+                      e.NameScope.Find<Border>("PART_BorderCardLight");
+        _legacyCardBorder = e.NameScope.Find<Border>("PART_BorderCardDark");
+        if (ReferenceEquals(_legacyCardBorder, _cardBorder))
+            _legacyCardBorder = null;
+        _clipBorder = e.NameScope.Find<Border>("PART_ClipBorder");
+        _animateAppliedTemplate = IsAnimated;
 
-            var b2 = e.NameScope.Get<Border>("PART_BorderCardLight");
-            b2.Loaded += (sender, args) =>
-            {
-                if (ElementComposition.GetElementVisual(b2) is { } visual)
-                    CompositionAnimationHelper.MakeSizeAnimated(visual);
-            };
-            
-            var b2d = e.NameScope.Get<Border>("PART_BorderCardDark");
-            b2d.Loaded += (sender, args) =>
-            {
-                if (ElementComposition.GetElementVisual(b2d) is { } visual)
-                    CompositionAnimationHelper.MakeSizeAnimated(visual);
-            };
+        if (IsLoaded)
+            ConfigureAnimations();
+    }
 
-            var b3 = e.NameScope.Get<Border>("PART_ClipBorder");
-            b3.Loaded += (sender, args) =>
-            {
-                if (ElementComposition.GetElementVisual(b3) is { } visual)
-                    CompositionAnimationHelper.MakeSizeAnimated(visual);
-            };
+    protected override void OnLoaded(RoutedEventArgs e)
+    {
+        base.OnLoaded(e);
+        ConfigureAnimations();
+    }
 
-        }
+    private void ConfigureAnimations()
+    {
+        if (!_animateAppliedTemplate)
+            return;
 
+        MakeOpacityAnimated(_rootPanel);
+        MakeSizeAnimated(_cardBorder);
+        MakeSizeAnimated(_legacyCardBorder);
+        MakeSizeAnimated(_clipBorder);
+    }
+
+    private static void MakeOpacityAnimated(Control? control)
+    {
+        if (control is not null && ElementComposition.GetElementVisual(control) is { } visual)
+            CompositionAnimationHelper.MakeOpacityAnimated(visual);
+    }
+
+    private static void MakeSizeAnimated(Control? control)
+    {
+        if (control is not null && ElementComposition.GetElementVisual(control) is { } visual)
+            CompositionAnimationHelper.MakeSizeAnimated(visual);
     }
 
     private void AttachContextMenu(ContextMenu? contextMenu)
@@ -164,5 +179,151 @@ public class GlassCard : ContentControl
     {
         base.OnPointerReleased(e);
         PseudoClasses.Set(":pointerdown", false);
+    }
+}
+
+internal sealed class GlassCardBorder : Border
+{
+    public static readonly StyledProperty<IBrush?> LightBorderBrushProperty =
+        AvaloniaProperty.Register<GlassCardBorder, IBrush?>(nameof(LightBorderBrush));
+
+    public static readonly StyledProperty<bool> UseDarkBorderProperty =
+        AvaloniaProperty.Register<GlassCardBorder, bool>(nameof(UseDarkBorder));
+
+    public static readonly StyledProperty<Color> DarkBorderStartColorProperty =
+        AvaloniaProperty.Register<GlassCardBorder, Color>(nameof(DarkBorderStartColor));
+
+    public static readonly StyledProperty<Color> DarkBorderEndColorProperty =
+        AvaloniaProperty.Register<GlassCardBorder, Color>(nameof(DarkBorderEndColor));
+
+    private LinearGradientBrush? _darkBorderBrush;
+    private GradientStop? _darkBorderStart;
+    private GradientStop? _darkBorderEnd;
+    private Size _gradientSize = new(double.NaN, double.NaN);
+
+    protected override Type StyleKeyOverride => typeof(Border);
+
+    public IBrush? LightBorderBrush
+    {
+        get => GetValue(LightBorderBrushProperty);
+        set => SetValue(LightBorderBrushProperty, value);
+    }
+
+    public bool UseDarkBorder
+    {
+        get => GetValue(UseDarkBorderProperty);
+        set => SetValue(UseDarkBorderProperty, value);
+    }
+
+    public Color DarkBorderStartColor
+    {
+        get => GetValue(DarkBorderStartColorProperty);
+        set => SetValue(DarkBorderStartColorProperty, value);
+    }
+
+    public Color DarkBorderEndColor
+    {
+        get => GetValue(DarkBorderEndColorProperty);
+        set => SetValue(DarkBorderEndColorProperty, value);
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+
+        if (change.Property == UseDarkBorderProperty)
+        {
+            UpdateBorderBrush(suppressTransition: true);
+        }
+        else if (change.Property == LightBorderBrushProperty && !UseDarkBorder)
+        {
+            UpdateBorderBrush(suppressTransition: false);
+        }
+        else if (change.Property == DarkBorderStartColorProperty)
+        {
+            if (_darkBorderStart is not null)
+                _darkBorderStart.Color = DarkBorderStartColor;
+        }
+        else if (change.Property == DarkBorderEndColorProperty && _darkBorderEnd is not null)
+        {
+            _darkBorderEnd.Color = DarkBorderEndColor;
+        }
+    }
+
+    protected override Size ArrangeOverride(Size finalSize)
+    {
+        if (UseDarkBorder)
+            UpdateGradientGeometry(finalSize);
+        return base.ArrangeOverride(finalSize);
+    }
+
+    private void UpdateBorderBrush(bool suppressTransition)
+    {
+        var suspendTransitions = suppressTransition && IsLoaded && Transitions is not null;
+        var transitions = suspendTransitions ? Transitions : null;
+        if (suspendTransitions)
+            Transitions = null;
+
+        try
+        {
+            if (UseDarkBorder)
+            {
+                SetCurrentValue(BorderBrushProperty, GetDarkBorderBrush());
+                UpdateGradientGeometry(Bounds.Size);
+            }
+            else
+            {
+                SetCurrentValue(BorderBrushProperty, LightBorderBrush);
+            }
+        }
+        finally
+        {
+            if (suspendTransitions)
+                Transitions = transitions;
+        }
+    }
+
+    private LinearGradientBrush GetDarkBorderBrush()
+    {
+        if (_darkBorderBrush is not null)
+            return _darkBorderBrush;
+
+        _darkBorderStart = new GradientStop
+        {
+            Offset = 0,
+            Color = DarkBorderStartColor
+        };
+        _darkBorderEnd = new GradientStop
+        {
+            Offset = 1,
+            Color = DarkBorderEndColor
+        };
+        _darkBorderBrush = new LinearGradientBrush
+        {
+            GradientStops =
+            [
+                _darkBorderStart,
+                new GradientStop { Offset = 0.5, Color = Colors.Transparent },
+                _darkBorderEnd
+            ]
+        };
+        return _darkBorderBrush;
+    }
+
+    private void UpdateGradientGeometry(Size size)
+    {
+        if (_darkBorderBrush is null || size == _gradientSize)
+            return;
+
+        _gradientSize = size;
+        var min = Math.Min(size.Width, size.Height);
+        var max = Math.Max(size.Width, size.Height);
+        if (!double.IsFinite(min) || !double.IsFinite(max) || min <= 0 || max <= 0)
+            return;
+
+        var factor = Math.Abs(min / max);
+        var y = 1 / (1.75 * factor);
+        _darkBorderBrush.StartPoint = new RelativePoint(0.2, -y, RelativeUnit.Relative);
+        _darkBorderBrush.EndPoint = new RelativePoint(0.8, 1 + y, RelativeUnit.Relative);
     }
 }

--- a/SukiUI/Controls/GlassMorphism/GlassCard.axaml.cs
+++ b/SukiUI/Controls/GlassMorphism/GlassCard.axaml.cs
@@ -22,7 +22,7 @@ public class GlassCard : ContentControl
     private Border? _cardBorder;
     private Border? _legacyCardBorder;
     private Border? _clipBorder;
-    private bool _animateAppliedTemplate;
+    private bool _animationsEnabled;
 
     public new static readonly StyledProperty<CornerRadius> CornerRadiusProperty =
         AvaloniaProperty.Register<GlassCard, CornerRadius>(nameof(CornerRadius), new CornerRadius(20));
@@ -115,7 +115,7 @@ public class GlassCard : ContentControl
         if (ReferenceEquals(_legacyCardBorder, _cardBorder))
             _legacyCardBorder = null;
         _clipBorder = e.NameScope.Find<Border>("PART_ClipBorder");
-        _animateAppliedTemplate = IsAnimated;
+        _animationsEnabled = IsAnimated;
 
         if (IsLoaded)
             ConfigureAnimations();
@@ -129,7 +129,7 @@ public class GlassCard : ContentControl
 
     private void ConfigureAnimations()
     {
-        if (!_animateAppliedTemplate)
+        if (!_animationsEnabled)
             return;
 
         MakeOpacityAnimated(_rootPanel);
@@ -162,7 +162,7 @@ public class GlassCard : ContentControl
 
 
 
-    private void ContextMenuOnOpening(object sender, CancelEventArgs e)
+    private void ContextMenuOnOpening(object? sender, CancelEventArgs e)
     {
         PseudoClasses.Set(":pointerdown", false);
     }
@@ -182,7 +182,12 @@ public class GlassCard : ContentControl
     }
 }
 
-internal sealed class GlassCardBorder : Border
+/// <summary>
+/// Border used by the <see cref="GlassCard"/> template. Renders either <see cref="LightBorderBrush"/>
+/// or a lazily built liquid gradient (<see cref="DarkBorderStartColor"/>/<see cref="DarkBorderEndColor"/>)
+/// depending on <see cref="UseDarkBorder"/>, so a single border serves both theme variants.
+/// </summary>
+public sealed class GlassCardBorder : Border
 {
     public static readonly StyledProperty<IBrush?> LightBorderBrushProperty =
         AvaloniaProperty.Register<GlassCardBorder, IBrush?>(nameof(LightBorderBrush));
@@ -201,6 +206,9 @@ internal sealed class GlassCardBorder : Border
     private GradientStop? _darkBorderEnd;
     private Size _gradientSize = new(double.NaN, double.NaN);
 
+    // Selectors match on StyleKey, so this keeps the "/template/ Border.GlassCardBorderPartCard"
+    // styles in GlassCard.axaml (.Accent, .Primary, IsOpaque, ...) matching this control.
+    // Removing it silently disables all of them.
     protected override Type StyleKeyOverride => typeof(Border);
 
     public IBrush? LightBorderBrush
@@ -239,10 +247,9 @@ internal sealed class GlassCardBorder : Border
         {
             UpdateBorderBrush(suppressTransition: false);
         }
-        else if (change.Property == DarkBorderStartColorProperty)
+        else if (change.Property == DarkBorderStartColorProperty && _darkBorderStart is not null)
         {
-            if (_darkBorderStart is not null)
-                _darkBorderStart.Color = DarkBorderStartColor;
+            _darkBorderStart.Color = DarkBorderStartColor;
         }
         else if (change.Property == DarkBorderEndColorProperty && _darkBorderEnd is not null)
         {
@@ -315,12 +322,12 @@ internal sealed class GlassCardBorder : Border
         if (_darkBorderBrush is null || size == _gradientSize)
             return;
 
-        _gradientSize = size;
         var min = Math.Min(size.Width, size.Height);
         var max = Math.Max(size.Width, size.Height);
         if (!double.IsFinite(min) || !double.IsFinite(max) || min <= 0 || max <= 0)
             return;
 
+        _gradientSize = size;
         var factor = Math.Abs(min / max);
         var y = 1 / (1.75 * factor);
         _darkBorderBrush.StartPoint = new RelativePoint(0.2, -y, RelativeUnit.Relative);

--- a/SukiUI/Controls/GlassMorphism/GlassCardLiquidStyle.axaml
+++ b/SukiUI/Controls/GlassMorphism/GlassCardLiquidStyle.axaml
@@ -1,89 +1,55 @@
-﻿<Styles xmlns="https://github.com/avaloniaui"
+<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:suki="https://github.com/kikipoulet/SukiUI">
     <Design.PreviewWith>
-        <StackPanel Spacing="25" >
-            <suki:GlassCard Height="200" Width="200"></suki:GlassCard>
-            <suki:GlassCard Height="40" Width="200"></suki:GlassCard>
-         
+        <StackPanel Spacing="25">
+            <suki:GlassCard Height="200" Width="200" />
+            <suki:GlassCard Height="40" Width="200" />
         </StackPanel>
     </Design.PreviewWith>
-    
-  
+
+    <Styles.Resources>
+        <Transitions x:Key="SukiGlassCardLiquidBorderTransitions">
+            <BrushTransition Property="{x:Static Border.BorderBrushProperty}" Duration="0:0:0.15" />
+            <DoubleTransition Property="{x:Static Visual.OpacityProperty}" Duration="0:0:0.15" />
+        </Transitions>
+        <Transitions x:Key="SukiGlassCardLiquidClipBorderTransitions">
+            <BrushTransition Property="{x:Static Border.BorderBrushProperty}" Duration="0:0:0.15" />
+        </Transitions>
+    </Styles.Resources>
+
     <Style Selector="suki|GlassCard">
-        
         <Setter Property="BorderThickness" Value="1.2" />
-        
         <Setter Property="Background" Value="{DynamicResource SukiGlassCardBackground}" />
         <Setter Property="Padding" Value="20" />
         <Setter Property="Template">
             <ControlTemplate>
                 <Panel Name="RootPanel" Opacity="0">
-                    <Border Name="PART_BorderCard" RenderTransformOrigin="50%,50%"
-                            Background="{TemplateBinding Background}"
-                            
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            ClipToBounds="{TemplateBinding ClipToBounds}"
-                            CornerRadius="{TemplateBinding CornerRadius}"
-                            Opacity="{DynamicResource GlassOpacity}">
-                        
-                        <Border.BorderBrush>
-                            <LinearGradientBrush >
-                                <LinearGradientBrush.StartPoint>
-                                    <MultiBinding Converter="{x:Static suki:StartPointLiquidConverter.Instance}">
-                                        <Binding Path="Bounds.Width"  RelativeSource="{RelativeSource TemplatedParent}"/>
-                                        <Binding Path="Bounds.Height" RelativeSource="{RelativeSource TemplatedParent}"/>
-                                    </MultiBinding>
-                                </LinearGradientBrush.StartPoint>
-                                <LinearGradientBrush.EndPoint>
-                                    <MultiBinding Converter="{x:Static suki:EndPointLiquidConverter.Instance}">
-                                        <Binding Path="Bounds.Width"  RelativeSource="{RelativeSource TemplatedParent}"/>
-                                        <Binding Path="Bounds.Height" RelativeSource="{RelativeSource TemplatedParent}"/>
-                                    </MultiBinding>
-                                </LinearGradientBrush.EndPoint>
+                    <suki:GlassCardBorder Name="PART_BorderCard"
+                                          RenderTransformOrigin="50%,50%"
+                                          Transitions="{StaticResource SukiGlassCardLiquidBorderTransitions}"
+                                          Background="{TemplateBinding Background}"
+                                          UseDarkBorder="True"
+                                          DarkBorderStartColor="{DynamicResource SukiLiquid1}"
+                                          DarkBorderEndColor="{DynamicResource SukiLiquid2}"
+                                          BorderThickness="{TemplateBinding BorderThickness}"
+                                          ClipToBounds="{TemplateBinding ClipToBounds}"
+                                          CornerRadius="{TemplateBinding CornerRadius}"
+                                          Opacity="{DynamicResource GlassOpacity}" />
 
-                                <GradientStop Offset="0"   Color="{DynamicResource SukiLiquid1}"/>
-                                <GradientStop Offset="0.5" Color="Transparent"/>
-                                <GradientStop Offset="1"   Color="{DynamicResource SukiLiquid2}"/>
-                            </LinearGradientBrush>
-                        </Border.BorderBrush>
-                        
-                        <Border.Transitions>
-                            <Transitions>
-                                <DoubleTransition Property="Width"
-                                                  Duration="0:0:0.5"
-                                                  Easing="QuadraticEaseOut" />
-                                <DoubleTransition Property="Height"
-                                                  Duration="0:0:0.5"
-                                                  Easing="QuadraticEaseOut" />
-                            </Transitions>
-                        </Border.Transitions>
-                        <Border.Transitions>
-                            <Transitions>
-                                <!-- <BrushTransition Property="Background" Duration="0:0:0.15" /> -->
-                                <BrushTransition Property="BorderBrush" Duration="0:0:0.15" />
-                                <DoubleTransition Property="Opacity" Duration="0:0:0.15" />
-                            </Transitions>
-                        </Border.Transitions>
-                    </Border>
                     <Border Name="PART_ClipBorder"
+                            Transitions="{StaticResource SukiGlassCardLiquidClipBorderTransitions}"
                             Background="{DynamicResource SukiPrimaryColor0}"
                             BorderBrush="{DynamicResource SukiPrimaryColor0}"
                             BorderThickness="{TemplateBinding BorderThickness}"
                             ClipToBounds="{TemplateBinding ClipToBounds}"
                             CornerRadius="{TemplateBinding CornerRadius}">
-                        <Border.Transitions>
-                            <Transitions>
-                                <BrushTransition Property="BorderBrush" Duration="0:0:0.15" />
-                            </Transitions>
-                        </Border.Transitions>
-                        <ContentPresenter Name="PART_CP" Margin="{TemplateBinding Padding}"
+                        <ContentPresenter Name="PART_CP"
+                                          Margin="{TemplateBinding Padding}"
                                           Content="{TemplateBinding Content}" />
                     </Border>
                 </Panel>
             </ControlTemplate>
-    </Setter>
-        </Style>
-
-   
+        </Setter>
+    </Style>
 </Styles>

--- a/SukiUI/Helpers/CompositionAnimationHelper.cs
+++ b/SukiUI/Helpers/CompositionAnimationHelper.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Avalonia.Rendering.Composition;
 using Avalonia.Rendering.Composition.Animations;
 
@@ -6,142 +8,88 @@ namespace SukiUI.Helpers
 {
     public class CompositionAnimationHelper
     {
-        public static void MakeScrollable(CompositionVisual compositionVisual, double millis = 250)
+        private enum AnimationKind
+        {
+            Scrollable,
+            Opacity,
+            Size,
+            SizeOpacity
+        }
+
+        /// <summary>
+        /// An <see cref="ImplicitAnimationCollection"/> holds no per-visual state, so a single instance can be
+        /// reused by every visual sharing the same compositor and duration instead of being rebuilt per call.
+        /// </summary>
+        private static readonly ConditionalWeakTable<Compositor, Dictionary<(AnimationKind, double), ImplicitAnimationCollection>> Cache = new();
+
+        public static void MakeScrollable(CompositionVisual compositionVisual, double millis = 250) =>
+            Apply(compositionVisual, AnimationKind.Scrollable, millis);
+
+        public static void MakeOpacityAnimated(CompositionVisual compositionVisual, double millis = 700) =>
+            Apply(compositionVisual, AnimationKind.Opacity, millis);
+
+        public static void MakeSizeAnimated(CompositionVisual compositionVisual, double millis = 450) =>
+            Apply(compositionVisual, AnimationKind.Size, millis);
+
+        public static void MakeSizeOpacityAnimated(CompositionVisual compositionVisual, double millis = 450) =>
+            Apply(compositionVisual, AnimationKind.SizeOpacity, millis);
+
+        private static void Apply(CompositionVisual? compositionVisual, AnimationKind kind, double millis)
         {
             if (compositionVisual == null)
                 return;
-        
-            Compositor compositor = compositionVisual.Compositor;
 
-            var animationGroup = compositor.CreateAnimationGroup();
-            Vector3KeyFrameAnimation offsetAnimation = compositor.CreateVector3KeyFrameAnimation();
-            offsetAnimation.Target = "Offset";
+            var compositor = compositionVisual.Compositor;
+            var cache = Cache.GetOrCreateValue(compositor);
+            var key = (kind, millis);
 
-            offsetAnimation.InsertExpressionKeyFrame(1.0f, "this.FinalValue");
-            offsetAnimation.Duration = TimeSpan.FromMilliseconds(millis);
+            if (!cache.TryGetValue(key, out var animations))
+            {
+                animations = Create(compositor, kind, TimeSpan.FromMilliseconds(millis));
+                cache[key] = animations;
+            }
 
-            ImplicitAnimationCollection implicitAnimationCollection = compositor.CreateImplicitAnimationCollection();
-            animationGroup.Add(offsetAnimation);
-            implicitAnimationCollection["Offset"] = animationGroup;
-            compositionVisual.ImplicitAnimations = implicitAnimationCollection;
+            compositionVisual.ImplicitAnimations = animations;
         }
-        
-            public static void MakeOpacityAnimated(CompositionVisual compositionVisual, double millis = 700)
-    {
-        if (compositionVisual == null)
-            return;
 
-        Compositor compositor = compositionVisual.Compositor;
+        private static ImplicitAnimationCollection Create(Compositor compositor, AnimationKind kind, TimeSpan duration)
+        {
+            var animationGroup = compositor.CreateAnimationGroup();
 
-        var animationGroup = compositor.CreateAnimationGroup();
-      
-        
-        ScalarKeyFrameAnimation opacityAnimation = compositor.CreateScalarKeyFrameAnimation();
-        opacityAnimation.Target = "Opacity";
-        opacityAnimation.InsertExpressionKeyFrame(1.0f, "this.FinalValue");
-        opacityAnimation.Duration = TimeSpan.FromMilliseconds(millis);
-        
-    
-       
-        Vector3KeyFrameAnimation offsetAnimation = compositor.CreateVector3KeyFrameAnimation();
-        offsetAnimation.Target = "Offset";
-        offsetAnimation.InsertExpressionKeyFrame(1.0f, "this.FinalValue");
-        offsetAnimation.Duration = TimeSpan.FromMilliseconds(millis);
-        
+            if (kind is AnimationKind.Size or AnimationKind.SizeOpacity)
+            {
+                var sizeAnimation = compositor.CreateVector2KeyFrameAnimation();
+                sizeAnimation.Target = "Size";
+                sizeAnimation.InsertExpressionKeyFrame(1.0f, "this.FinalValue");
+                sizeAnimation.Duration = duration;
+                animationGroup.Add(sizeAnimation);
+            }
 
-        animationGroup.Add(offsetAnimation);
-        animationGroup.Add(opacityAnimation);
-      
-        
-        ImplicitAnimationCollection implicitAnimationCollection = compositor.CreateImplicitAnimationCollection();
-        implicitAnimationCollection["Opacity"] = animationGroup;
-        implicitAnimationCollection["Offset"] = animationGroup;
+            if (kind is AnimationKind.Opacity or AnimationKind.SizeOpacity)
+            {
+                var opacityAnimation = compositor.CreateScalarKeyFrameAnimation();
+                opacityAnimation.Target = "Opacity";
+                opacityAnimation.InsertExpressionKeyFrame(1.0f, "this.FinalValue");
+                opacityAnimation.Duration = duration;
+                animationGroup.Add(opacityAnimation);
+            }
 
-        
-        compositionVisual.ImplicitAnimations = implicitAnimationCollection;
+            var offsetAnimation = compositor.CreateVector3KeyFrameAnimation();
+            offsetAnimation.Target = "Offset";
+            offsetAnimation.InsertExpressionKeyFrame(1.0f, "this.FinalValue");
+            offsetAnimation.Duration = duration;
+            animationGroup.Add(offsetAnimation);
 
-    }
+            var implicitAnimationCollection = compositor.CreateImplicitAnimationCollection();
+            implicitAnimationCollection["Offset"] = animationGroup;
 
-    public static void MakeSizeAnimated(CompositionVisual compositionVisual, double millis =450)
-    {
-        if (compositionVisual == null)
-            return;
+            if (kind is AnimationKind.Size or AnimationKind.SizeOpacity)
+                implicitAnimationCollection["Size"] = animationGroup;
 
-        Compositor compositor = compositionVisual.Compositor;
+            if (kind is AnimationKind.Opacity or AnimationKind.SizeOpacity)
+                implicitAnimationCollection["Opacity"] = animationGroup;
 
-        var animationGroup = compositor.CreateAnimationGroup();
-        
-        Vector2KeyFrameAnimation sizeAnimation = compositor.CreateVector2KeyFrameAnimation();
-        sizeAnimation.Target = "Size";
-        sizeAnimation.InsertExpressionKeyFrame(1.0f, "this.FinalValue");
-        sizeAnimation.Duration = TimeSpan.FromMilliseconds(millis);
-        
-      
-        
-        Vector3KeyFrameAnimation offsetAnimation = compositor.CreateVector3KeyFrameAnimation();
-        offsetAnimation.Target = "Offset";
-        offsetAnimation.InsertExpressionKeyFrame(1.0f, "this.FinalValue");
-        offsetAnimation.Duration = TimeSpan.FromMilliseconds(millis);
-        
-        
-        
-        animationGroup.Add(sizeAnimation);
-
-        animationGroup.Add(offsetAnimation);
-        
-        ImplicitAnimationCollection implicitAnimationCollection = compositor.CreateImplicitAnimationCollection();
-        implicitAnimationCollection["Size"] = animationGroup;
-        implicitAnimationCollection["Offset"] = animationGroup;
-
-        
-        compositionVisual.ImplicitAnimations = implicitAnimationCollection;
-
-    }
-    
-    
-    public static void MakeSizeOpacityAnimated(CompositionVisual compositionVisual, double millis =450)
-    {
-        if (compositionVisual == null)
-            return;
-
-        Compositor compositor = compositionVisual.Compositor;
-
-        var animationGroup = compositor.CreateAnimationGroup();
-        
-        Vector2KeyFrameAnimation sizeAnimation = compositor.CreateVector2KeyFrameAnimation();
-        sizeAnimation.Target = "Size";
-        sizeAnimation.InsertExpressionKeyFrame(1.0f, "this.FinalValue");
-        sizeAnimation.Duration = TimeSpan.FromMilliseconds(millis);
-        
-      
-        
-        Vector3KeyFrameAnimation offsetAnimation = compositor.CreateVector3KeyFrameAnimation();
-        offsetAnimation.Target = "Offset";
-        offsetAnimation.InsertExpressionKeyFrame(1.0f, "this.FinalValue");
-        offsetAnimation.Duration = TimeSpan.FromMilliseconds(millis);
-        
-        
-        ScalarKeyFrameAnimation opacityAnimation = compositor.CreateScalarKeyFrameAnimation();
-        opacityAnimation.Target = "Opacity";
-        opacityAnimation.InsertExpressionKeyFrame(1.0f, "this.FinalValue");
-        opacityAnimation.Duration = TimeSpan.FromMilliseconds(millis);
-
-        
-        
-        animationGroup.Add(sizeAnimation);
-        animationGroup.Add(opacityAnimation);
-
-        animationGroup.Add(offsetAnimation);
-        
-        ImplicitAnimationCollection implicitAnimationCollection = compositor.CreateImplicitAnimationCollection();
-        implicitAnimationCollection["Size"] = animationGroup;
-        implicitAnimationCollection["Opacity"] = animationGroup;
-        implicitAnimationCollection["Offset"] = animationGroup;
-
-        
-        compositionVisual.ImplicitAnimations = implicitAnimationCollection;
-
-    }
-
+            return implicitAnimationCollection;
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Replace the light/dark chrome layers in the default `GlassCard` template with one internal border.
- Lazily create the dark gradient and update its geometry during arrange.
- Share transition definitions and avoid per-template `Loaded` closures.
- Preserve existing `Border` template selectors, custom templates, animations, and theme behavior.

## Benchmark

Release Avalonia Headless benchmark, three interleaved baseline/optimized runs (p50):

| Scenario | p50 frame time | p50 managed allocation |
| --- | ---: | ---: |
| 25 dark animated cards | 14.630 -> 10.360 ms (-29.2%) | 3,969,096 -> 2,784,688 B (-29.8%) |
| 50 dark animated cards | 27.535 -> 22.114 ms (-19.7%) | 7,871,120 -> 5,467,576 B (-30.5%) |
| 100 dark animated cards | 57.590 -> 43.804 ms (-23.9%) | 15,996,976 -> 11,173,496 B (-30.2%) |
| 50 light animated cards | 27.453 -> 21.904 ms (-20.2%) | 7,871,120 -> 5,118,976 B (-35.0%) |
| 50 dark non-animated cards | 28.699 -> 21.835 ms (-23.9%) | 7,451,120 -> 5,227,976 B (-29.8%) |
| Theme switch, 50 cards | 17.492 -> 10.972 ms (-37.3%) | 2,177,320 -> 1,138,408 B (-47.7%) |
| Theme switch, 100 cards | 35.443 -> 20.903 ms (-41.0%) | 4,567,560 -> 2,373,144 B (-48.0%) |

## Validation

- `dotnet build Suki.sln -c Release -clp:ErrorsOnly`
- Verified dark/light theme switching, custom templates, existing template selectors, implicit animations, and gradient geometry.
- macOS Desktop/Skia snapshots were byte-identical before and after across the default and major GlassCard style variants.

## Notes

A dense 100-card cold mount remains above a 60 Hz frame budget. The remaining cost calls for host-level virtualization or lazy page creation rather than a change to `GlassCard` semantics.