### PR TITLE
perf: release behavior overlays when controls detach

### DIFF
--- a/SukiUI/Animations/ErrorBehavior.cs
+++ b/SukiUI/Animations/ErrorBehavior.cs
@@ -18,6 +18,13 @@ public static class ErrorBehavior
     private const double ErrorOpacityTarget = 0.1;
 
     private static readonly Dictionary<Control, PopupData> _popups = new();
+
+    /// <summary>
+    /// Popups grouped by the <see cref="ScrollViewer"/> they scroll with, so a scroll event only
+    /// touches the popups that need repositioning and only subscribes once per host.
+    /// </summary>
+    private static readonly Dictionary<ScrollViewer, List<PopupData>> _scrollHosts = new();
+
     public static readonly AttachedProperty<bool> IsActiveProperty =
         AvaloniaProperty.RegisterAttached<Control, bool>(
             "IsActive",
@@ -303,10 +310,7 @@ public static class ErrorBehavior
             timer.Start();
         };
 
-        if (scrollViewer != null)
-        {
-            scrollViewer.ScrollChanged += OnScrollChanged;
-        }
+        RegisterScrollHost(popupData);
 
         _popups[control] = popupData;
 
@@ -325,23 +329,32 @@ public static class ErrorBehavior
 
         popupData.IsHiding = true;
         popupData.Timer.Stop();
+
+        // Read the live opacities before cancelling: cancelling an in-flight fade reverts the
+        // animated value to its pre-animation base, which would make these fades no-ops.
+        var outerBorder = popupData.Popup.Child is Grid popupGrid
+            ? popupGrid.Children[0] as Border
+            : null;
+        var borderFadeFrom = outerBorder?.Opacity ?? 0;
+        var controlFadeFrom = control.Opacity;
+
         var cancellationToken = popupData.BeginAnimation();
 
-        if (popupData.Popup.Child is Grid popupGrid && popupGrid.Children[0] is Border outerBorder)
+        if (outerBorder != null)
         {
-            await AnimateOpacityAsync(outerBorder, outerBorder.Opacity, 0, cancellationToken);
+            await AnimateOpacityAsync(outerBorder, borderFadeFrom, 0, cancellationToken);
         }
 
         if (!IsCurrentInactivePopup(control, popupData))
             return;
 
         popupData.Popup.IsOpen = false;
-        await AnimateOpacityAsync(control, control.Opacity, popupData.OriginalOpacity, cancellationToken);
+        await AnimateOpacityAsync(control, controlFadeFrom, popupData.OriginalOpacity, cancellationToken);
 
         if (!IsCurrentInactivePopup(control, popupData))
             return;
 
-        control.Opacity = popupData.OriginalOpacity;
+        control.SetCurrentValue(Visual.OpacityProperty, popupData.OriginalOpacity);
         ReleasePopup(control, popupData, restoreOpacity: false);
         UnsubscribeFromLifecycle(control);
     }
@@ -392,14 +405,40 @@ public static class ErrorBehavior
         popupData.Popup.Child = null;
         ((ISetLogicalParent)popupData.Popup).SetParent(null);
 
-        if (popupData.ScrollViewer != null)
-            popupData.ScrollViewer.ScrollChanged -= OnScrollChanged;
+        UnregisterScrollHost(popupData);
 
         if (restoreOpacity)
-            control.Opacity = popupData.OriginalOpacity;
+            control.SetCurrentValue(Visual.OpacityProperty, popupData.OriginalOpacity);
 
         if (_popups.TryGetValue(control, out var current) && ReferenceEquals(current, popupData))
             _popups.Remove(control);
+    }
+
+    private static void RegisterScrollHost(PopupData popupData)
+    {
+        if (popupData.ScrollViewer is not { } scrollViewer) return;
+
+        if (!_scrollHosts.TryGetValue(scrollViewer, out var hosted))
+        {
+            hosted = new List<PopupData>();
+            _scrollHosts[scrollViewer] = hosted;
+            scrollViewer.ScrollChanged += OnScrollChanged;
+        }
+
+        hosted.Add(popupData);
+    }
+
+    private static void UnregisterScrollHost(PopupData popupData)
+    {
+        if (popupData.ScrollViewer is not { } scrollViewer) return;
+        if (!_scrollHosts.TryGetValue(scrollViewer, out var hosted)) return;
+
+        hosted.Remove(popupData);
+
+        if (hosted.Count != 0) return;
+
+        _scrollHosts.Remove(scrollViewer);
+        scrollViewer.ScrollChanged -= OnScrollChanged;
     }
 
     private static async Task AnimateOpacityAsync(Visual visual, double from, double to,
@@ -417,37 +456,47 @@ public static class ErrorBehavior
         }
         catch (OperationCanceledException)
         {
-            // A detach or fast reactivation superseded this animation.
+            // Defensive: Avalonia signals cancellation by completing the task rather than
+            // throwing, so a detach or fast reactivation normally just returns early here.
         }
     }
 
     private static void OnScrollChanged(object? sender, ScrollChangedEventArgs e)
     {
         if (sender is not ScrollViewer scrollViewer) return;
+        if (!_scrollHosts.TryGetValue(scrollViewer, out var hosted)) return;
 
-        foreach (var kvp in _popups)
+        // Reverse index walk: re-placing a popup can close it, which unregisters it from this list.
+        for (var i = hosted.Count - 1; i >= 0; i--)
         {
-            if (kvp.Value.ScrollViewer == scrollViewer && kvp.Value.Popup.IsOpen)
-            {
-                var popup = kvp.Value.Popup;
-                var placement = popup.Placement;
-                popup.Placement = PlacementMode.AnchorAndGravity;
-                popup.Placement = placement;
-            }
+            if (i >= hosted.Count) continue;
+
+            var popup = hosted[i].Popup;
+            if (!popup.IsOpen) continue;
+
+            var placement = popup.Placement;
+            popup.Placement = PlacementMode.AnchorAndGravity;
+            popup.Placement = placement;
         }
     }
 
     private sealed class PopupData(Popup popup, DispatcherTimer timer, ScrollViewer? scrollViewer,
         double originalOpacity)
     {
-        private CancellationTokenSource _animationCancellation = new();
+        private CancellationTokenSource? _animationCancellation = new();
 
         public Popup Popup { get; } = popup;
         public DispatcherTimer Timer { get; } = timer;
         public ScrollViewer? ScrollViewer { get; } = scrollViewer;
         public double OriginalOpacity { get; } = originalOpacity;
         public bool IsHiding { get; set; }
-        public CancellationToken AnimationToken => _animationCancellation.Token;
+
+        /// <summary>
+        /// Token for the current animation batch, or an already-cancelled token once released.
+        /// Never touches a disposed source, so callers cannot trip an <see cref="ObjectDisposedException"/>.
+        /// </summary>
+        public CancellationToken AnimationToken =>
+            _animationCancellation?.Token ?? new CancellationToken(true);
 
         public CancellationToken BeginAnimation()
         {
@@ -458,8 +507,11 @@ public static class ErrorBehavior
 
         public void CancelAnimations()
         {
-            _animationCancellation.Cancel();
-            _animationCancellation.Dispose();
+            var cancellation = Interlocked.Exchange(ref _animationCancellation, null);
+            if (cancellation is null) return;
+
+            cancellation.Cancel();
+            cancellation.Dispose();
         }
     }
 }

--- a/SukiUI/Animations/ErrorBehavior.cs
+++ b/SukiUI/Animations/ErrorBehavior.cs
@@ -18,8 +18,6 @@ public static class ErrorBehavior
     private const double ErrorOpacityTarget = 0.1;
 
     private static readonly Dictionary<Control, PopupData> _popups = new();
-    private static readonly Dictionary<Control, double> _originalOpacities = new();
-
     public static readonly AttachedProperty<bool> IsActiveProperty =
         AvaloniaProperty.RegisterAttached<Control, bool>(
             "IsActive",
@@ -127,54 +125,49 @@ public static class ErrorBehavior
 
         if (isActive)
         {
-            if (control.Bounds.Width <= 0)
-            {
-                control.AttachedToVisualTree += DeferShowError;
-                control.LayoutUpdated += DeferShowErrorOnLayout;
-                return;
-            }
-            ShowError(control);
+            SubscribeToLifecycle(control);
+            TryShowError(control);
         }
         else
         {
-            control.AttachedToVisualTree -= DeferShowError;
             control.LayoutUpdated -= DeferShowErrorOnLayout;
             HideError(control);
         }
     }
 
-    private static void DeferShowError(object? sender, VisualTreeAttachmentEventArgs e)
+    private static void TryShowError(Control control)
     {
-        if (sender is not Control control) return;
-        control.AttachedToVisualTree -= DeferShowError;
-        if (control.Bounds.Width > 0 && GetIsActive(control))
+        if (!GetIsActive(control) || !control.IsAttachedToVisualTree())
+            return;
+
+        if (control.Bounds.Width <= 0 || control.Bounds.Height <= 0)
         {
             control.LayoutUpdated -= DeferShowErrorOnLayout;
-            ShowError(control);
+            control.LayoutUpdated += DeferShowErrorOnLayout;
+            return;
         }
+
+        control.LayoutUpdated -= DeferShowErrorOnLayout;
+        ShowError(control);
     }
 
     private static void DeferShowErrorOnLayout(object? sender, EventArgs e)
     {
         if (sender is not Control control) return;
-        if (control.Bounds.Width > 0 && GetIsActive(control))
-        {
-            control.LayoutUpdated -= DeferShowErrorOnLayout;
-            control.AttachedToVisualTree -= DeferShowError;
-            ShowError(control);
-        }
+        TryShowError(control);
     }
 
     private static void ShowError(Control control)
     {
-        ((Visual)control).Animate(Visual.OpacityProperty)
-            .From(control.Opacity)
-            .To(ErrorOpacityTarget)
-            .WithDuration(TimeSpan.FromMilliseconds(AnimationDurationMs))
-            .WithEasing(new CubicEaseInOut())
-            .Start();
+        if (_popups.TryGetValue(control, out var existingPopup))
+        {
+            if (!existingPopup.IsHiding)
+                return;
 
-        _originalOpacities[control] = control.Opacity;
+            ReleasePopup(control, existingPopup, restoreOpacity: true);
+        }
+
+        var originalOpacity = control.Opacity;
 
         var width = control.Bounds.Width + 3;
         var height = control.Bounds.Height + 3;
@@ -278,9 +271,13 @@ public static class ErrorBehavior
         var currentAngle = 0.0;
         var angleStep = 360.0 / (speed / 16.0);
 
+        var scrollViewer = control.FindAncestorOfType<ScrollViewer>();
+        var popupData = new PopupData(popup, timer, scrollViewer, originalOpacity);
+
         timer.Tick += (_, _) =>
         {
-            if (!_popups.ContainsKey(control) || !popup.IsOpen)
+            if (!_popups.TryGetValue(control, out var current) ||
+                !ReferenceEquals(current, popupData) || !popup.IsOpen)
             {
                 timer.Stop();
                 return;
@@ -295,27 +292,25 @@ public static class ErrorBehavior
 
         popup.Opened += (_, _) =>
         {
+            if (!_popups.TryGetValue(control, out var current) ||
+                !ReferenceEquals(current, popupData) || !popup.IsOpen)
+                return;
+
             popupContent.Measure(new Avalonia.Size(double.PositiveInfinity, double.PositiveInfinity));
 
-            outerBorder.Animate(Visual.OpacityProperty)
-                .From(0)
-                .To(1)
-                .WithDuration(TimeSpan.FromMilliseconds(AnimationDurationMs))
-                .Start();
+            _ = AnimateOpacityAsync(outerBorder, 0, 1, popupData.AnimationToken);
 
             timer.Start();
         };
 
-        var scrollViewer = control.FindAncestorOfType<ScrollViewer>();
         if (scrollViewer != null)
         {
             scrollViewer.ScrollChanged += OnScrollChanged;
         }
 
-        _popups[control] = new PopupData(popup, timer, scrollViewer);
+        _popups[control] = popupData;
 
-        control.AttachedToVisualTree += OnControlAttachedToVisualTree;
-        control.DetachedFromVisualTree += OnControlDetachedFromVisualTree;
+        _ = AnimateOpacityAsync(control, originalOpacity, ErrorOpacityTarget, popupData.AnimationToken);
 
         popup.IsOpen = true;
     }
@@ -323,57 +318,38 @@ public static class ErrorBehavior
     private static async void HideError(Control control)
     {
         if (!_popups.TryGetValue(control, out var popupData))
+        {
+            UnsubscribeFromLifecycle(control);
+            return;
+        }
+
+        popupData.IsHiding = true;
+        popupData.Timer.Stop();
+        var cancellationToken = popupData.BeginAnimation();
+
+        if (popupData.Popup.Child is Grid popupGrid && popupGrid.Children[0] is Border outerBorder)
+        {
+            await AnimateOpacityAsync(outerBorder, outerBorder.Opacity, 0, cancellationToken);
+        }
+
+        if (!IsCurrentInactivePopup(control, popupData))
             return;
 
-        var popup = popupData.Popup;
-        var timer = popupData.Timer;
+        popupData.Popup.IsOpen = false;
+        await AnimateOpacityAsync(control, control.Opacity, popupData.OriginalOpacity, cancellationToken);
 
-        timer?.Stop();
+        if (!IsCurrentInactivePopup(control, popupData))
+            return;
 
-        if (popup.Child is Grid popupGrid && popupGrid.Children[0] is Border outerBorder)
-        {
-            await outerBorder.Animate(Visual.OpacityProperty)
-                .From(1)
-                .To(0)
-                .WithDuration(TimeSpan.FromMilliseconds(AnimationDurationMs))
-                .RunAsync();
-
-            popup.IsOpen = false;
-            popup.Child = null;
-            ((ISetLogicalParent)popup).SetParent(null);
-            _popups.Remove(control);
-        }
-
-        if (popupData.ScrollViewer != null)
-        {
-            popupData.ScrollViewer.ScrollChanged -= OnScrollChanged;
-        }
-
-        if (_originalOpacities.TryGetValue(control, out var originalOpacity))
-        {
-            ((Visual)control).Animate(Visual.OpacityProperty)
-                .From(control.Opacity)
-                .To(originalOpacity)
-                .WithDuration(TimeSpan.FromMilliseconds(AnimationDurationMs))
-                .WithEasing(new CubicEaseInOut())
-                .Start();
-
-            _originalOpacities.Remove(control);
-        }
-
-        control.AttachedToVisualTree -= OnControlAttachedToVisualTree;
-        control.DetachedFromVisualTree -= OnControlDetachedFromVisualTree;
+        control.Opacity = popupData.OriginalOpacity;
+        ReleasePopup(control, popupData, restoreOpacity: false);
+        UnsubscribeFromLifecycle(control);
     }
 
     private static void OnControlAttachedToVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
     {
-        if (sender is not Control control) return;
-        if (!GetIsActive(control)) return;
-
-        if (_popups.TryGetValue(control, out var popupData) && !popupData.Popup.IsOpen)
-        {
-            popupData.Popup.IsOpen = true;
-        }
+        if (sender is Control control)
+            TryShowError(control);
     }
 
     private static void OnControlDetachedFromVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
@@ -382,8 +358,66 @@ public static class ErrorBehavior
 
         if (_popups.TryGetValue(control, out var popupData))
         {
-            popupData.Popup.IsOpen = false;
-            popupData.Timer?.Stop();
+            ReleasePopup(control, popupData, restoreOpacity: true);
+        }
+
+        control.LayoutUpdated -= DeferShowErrorOnLayout;
+        if (!GetIsActive(control))
+            UnsubscribeFromLifecycle(control);
+    }
+
+    private static bool IsCurrentInactivePopup(Control control, PopupData popupData) =>
+        !GetIsActive(control) && _popups.TryGetValue(control, out var current) &&
+        ReferenceEquals(current, popupData);
+
+    private static void SubscribeToLifecycle(Control control)
+    {
+        control.AttachedToVisualTree -= OnControlAttachedToVisualTree;
+        control.DetachedFromVisualTree -= OnControlDetachedFromVisualTree;
+        control.AttachedToVisualTree += OnControlAttachedToVisualTree;
+        control.DetachedFromVisualTree += OnControlDetachedFromVisualTree;
+    }
+
+    private static void UnsubscribeFromLifecycle(Control control)
+    {
+        control.AttachedToVisualTree -= OnControlAttachedToVisualTree;
+        control.DetachedFromVisualTree -= OnControlDetachedFromVisualTree;
+    }
+
+    private static void ReleasePopup(Control control, PopupData popupData, bool restoreOpacity)
+    {
+        popupData.CancelAnimations();
+        popupData.Timer.Stop();
+        popupData.Popup.IsOpen = false;
+        popupData.Popup.Child = null;
+        ((ISetLogicalParent)popupData.Popup).SetParent(null);
+
+        if (popupData.ScrollViewer != null)
+            popupData.ScrollViewer.ScrollChanged -= OnScrollChanged;
+
+        if (restoreOpacity)
+            control.Opacity = popupData.OriginalOpacity;
+
+        if (_popups.TryGetValue(control, out var current) && ReferenceEquals(current, popupData))
+            _popups.Remove(control);
+    }
+
+    private static async Task AnimateOpacityAsync(Visual visual, double from, double to,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await visual.Animate(Visual.OpacityProperty)
+                .From(from)
+                .To(to)
+                .WithDuration(TimeSpan.FromMilliseconds(AnimationDurationMs))
+                .WithEasing(new CubicEaseInOut())
+                .WithCancellationToken(cancellationToken)
+                .RunAsync();
+        }
+        catch (OperationCanceledException)
+        {
+            // A detach or fast reactivation superseded this animation.
         }
     }
 
@@ -403,5 +437,29 @@ public static class ErrorBehavior
         }
     }
 
-    private record PopupData(Popup Popup, DispatcherTimer Timer, ScrollViewer? ScrollViewer);
+    private sealed class PopupData(Popup popup, DispatcherTimer timer, ScrollViewer? scrollViewer,
+        double originalOpacity)
+    {
+        private CancellationTokenSource _animationCancellation = new();
+
+        public Popup Popup { get; } = popup;
+        public DispatcherTimer Timer { get; } = timer;
+        public ScrollViewer? ScrollViewer { get; } = scrollViewer;
+        public double OriginalOpacity { get; } = originalOpacity;
+        public bool IsHiding { get; set; }
+        public CancellationToken AnimationToken => _animationCancellation.Token;
+
+        public CancellationToken BeginAnimation()
+        {
+            CancelAnimations();
+            _animationCancellation = new CancellationTokenSource();
+            return _animationCancellation.Token;
+        }
+
+        public void CancelAnimations()
+        {
+            _animationCancellation.Cancel();
+            _animationCancellation.Dispose();
+        }
+    }
 }

--- a/SukiUI/Animations/GlowBehavior.cs
+++ b/SukiUI/Animations/GlowBehavior.cs
@@ -85,46 +85,48 @@ public static class GlowBehavior
 
         if (isActive)
         {
-            if (control.Bounds.Width <= 0)
-            {
-                control.AttachedToVisualTree += DeferShowContour;
-                control.LayoutUpdated += DeferShowContourOnLayout;
-                return;
-            }
-            ShowContour(control);
+            SubscribeToLifecycle(control);
+            TryShowContour(control);
         }
         else
         {
-            control.AttachedToVisualTree -= DeferShowContour;
             control.LayoutUpdated -= DeferShowContourOnLayout;
             HideContour(control);
         }
     }
 
-    private static void DeferShowContour(object? sender, VisualTreeAttachmentEventArgs e)
+    private static void TryShowContour(Control control)
     {
-        if (sender is not Control control) return;
-        control.AttachedToVisualTree -= DeferShowContour;
-        if (control.Bounds.Width > 0 && GetIsActive(control))
+        if (!GetIsActive(control) || !control.IsAttachedToVisualTree())
+            return;
+
+        if (control.Bounds.Width <= 0 || control.Bounds.Height <= 0)
         {
             control.LayoutUpdated -= DeferShowContourOnLayout;
-            ShowContour(control);
+            control.LayoutUpdated += DeferShowContourOnLayout;
+            return;
         }
+
+        control.LayoutUpdated -= DeferShowContourOnLayout;
+        ShowContour(control);
     }
 
     private static void DeferShowContourOnLayout(object? sender, EventArgs e)
     {
         if (sender is not Control control) return;
-        if (control.Bounds.Width > 0 && GetIsActive(control))
-        {
-            control.LayoutUpdated -= DeferShowContourOnLayout;
-            control.AttachedToVisualTree -= DeferShowContour;
-            ShowContour(control);
-        }
+        TryShowContour(control);
     }
 
     private static void ShowContour(Control control)
     {
+        if (_popups.TryGetValue(control, out var existingPopup))
+        {
+            if (!existingPopup.IsHiding)
+                return;
+
+            ReleasePopup(control, existingPopup);
+        }
+
         var width = control.Bounds.Width + 3;
         var height = control.Bounds.Height + 3;
         var color = GetColor(control);
@@ -178,9 +180,13 @@ public static class GlowBehavior
         var currentAngle = 0.0;
         var angleStep = 360.0 / (speed / 16.0);
 
+        var scrollViewer = control.FindAncestorOfType<ScrollViewer>();
+        var popupData = new PopupData(popup, timer, scrollViewer);
+
         timer.Tick += (_, _) =>
         {
-            if (!_popups.ContainsKey(control) || !popup.IsOpen)
+            if (!_popups.TryGetValue(control, out var current) ||
+                !ReferenceEquals(current, popupData) || !popup.IsOpen)
             {
                 timer.Stop();
                 return;
@@ -195,27 +201,23 @@ public static class GlowBehavior
 
         popup.Opened += (_, _) =>
         {
+            if (!_popups.TryGetValue(control, out var current) ||
+                !ReferenceEquals(current, popupData) || !popup.IsOpen)
+                return;
+
             border.Measure(new Avalonia.Size(double.PositiveInfinity, double.PositiveInfinity));
-            
-            border.Animate(Visual.OpacityProperty)
-                .From(0)
-                .To(1)
-                .WithDuration(TimeSpan.FromMilliseconds(AnimationDurationMs))
-                .Start();
+
+            _ = AnimateOpacityAsync(border, 0, 1, popupData.AnimationToken);
 
             timer.Start();
         };
 
-        var scrollViewer = control.FindAncestorOfType<ScrollViewer>();
         if (scrollViewer != null)
         {
             scrollViewer.ScrollChanged += OnScrollChanged;
         }
 
-        _popups[control] = new PopupData(popup, timer, scrollViewer);
-
-        control.AttachedToVisualTree += OnControlAttachedToVisualTree;
-        control.DetachedFromVisualTree += OnControlDetachedFromVisualTree;
+        _popups[control] = popupData;
 
         popup.IsOpen = true;
     }
@@ -223,46 +225,32 @@ public static class GlowBehavior
     private static async void HideContour(Control control)
     {
         if (!_popups.TryGetValue(control, out var popupData))
-            return;
-
-        var popup = popupData.Popup;
-        var timer = popupData.Timer;
-
-        timer?.Stop();
-
-        if (popup.Child is Border border)
         {
-            await border.Animate(Visual.OpacityProperty)
-                .From(1)
-                .To(0)
-                .WithDuration(TimeSpan.FromMilliseconds(AnimationDurationMs))
-                .RunAsync();
-
-            popup.IsOpen = false;
-            popup.Child = null;
-            ((ISetLogicalParent)popup).SetParent(null);
-
-            if (popupData.ScrollViewer != null)
-            {
-                popupData.ScrollViewer.ScrollChanged -= OnScrollChanged;
-            }
-
-            _popups.Remove(control);
+            UnsubscribeFromLifecycle(control);
+            return;
         }
 
-        control.AttachedToVisualTree -= OnControlAttachedToVisualTree;
-        control.DetachedFromVisualTree -= OnControlDetachedFromVisualTree;
+        popupData.IsHiding = true;
+        popupData.Timer.Stop();
+        var cancellationToken = popupData.BeginAnimation();
+
+        if (popupData.Popup.Child is Border border)
+        {
+            await AnimateOpacityAsync(border, border.Opacity, 0, cancellationToken);
+        }
+
+        if (!_popups.TryGetValue(control, out var current) ||
+            !ReferenceEquals(current, popupData) || GetIsActive(control))
+            return;
+
+        ReleasePopup(control, popupData);
+        UnsubscribeFromLifecycle(control);
     }
 
     private static void OnControlAttachedToVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
     {
-        if (sender is not Control control) return;
-        if (!GetIsActive(control)) return;
-
-        if (_popups.TryGetValue(control, out var popupData) && !popupData.Popup.IsOpen)
-        {
-            popupData.Popup.IsOpen = true;
-        }
+        if (sender is Control control)
+            TryShowContour(control);
     }
 
     private static void OnControlDetachedFromVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
@@ -271,8 +259,58 @@ public static class GlowBehavior
 
         if (_popups.TryGetValue(control, out var popupData))
         {
-            popupData.Popup.IsOpen = false;
-            popupData.Timer?.Stop();
+            ReleasePopup(control, popupData);
+        }
+
+        control.LayoutUpdated -= DeferShowContourOnLayout;
+        if (!GetIsActive(control))
+            UnsubscribeFromLifecycle(control);
+    }
+
+    private static void SubscribeToLifecycle(Control control)
+    {
+        control.AttachedToVisualTree -= OnControlAttachedToVisualTree;
+        control.DetachedFromVisualTree -= OnControlDetachedFromVisualTree;
+        control.AttachedToVisualTree += OnControlAttachedToVisualTree;
+        control.DetachedFromVisualTree += OnControlDetachedFromVisualTree;
+    }
+
+    private static void UnsubscribeFromLifecycle(Control control)
+    {
+        control.AttachedToVisualTree -= OnControlAttachedToVisualTree;
+        control.DetachedFromVisualTree -= OnControlDetachedFromVisualTree;
+    }
+
+    private static void ReleasePopup(Control control, PopupData popupData)
+    {
+        popupData.CancelAnimations();
+        popupData.Timer.Stop();
+        popupData.Popup.IsOpen = false;
+        popupData.Popup.Child = null;
+        ((ISetLogicalParent)popupData.Popup).SetParent(null);
+
+        if (popupData.ScrollViewer != null)
+            popupData.ScrollViewer.ScrollChanged -= OnScrollChanged;
+
+        if (_popups.TryGetValue(control, out var current) && ReferenceEquals(current, popupData))
+            _popups.Remove(control);
+    }
+
+    private static async Task AnimateOpacityAsync(Visual visual, double from, double to,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await visual.Animate(Visual.OpacityProperty)
+                .From(from)
+                .To(to)
+                .WithDuration(TimeSpan.FromMilliseconds(AnimationDurationMs))
+                .WithCancellationToken(cancellationToken)
+                .RunAsync();
+        }
+        catch (OperationCanceledException)
+        {
+            // A detach or fast reactivation superseded this animation.
         }
     }
 
@@ -292,5 +330,27 @@ public static class GlowBehavior
         }
     }
 
-    private record PopupData(Popup Popup, DispatcherTimer Timer, ScrollViewer? ScrollViewer);
+    private sealed class PopupData(Popup popup, DispatcherTimer timer, ScrollViewer? scrollViewer)
+    {
+        private CancellationTokenSource _animationCancellation = new();
+
+        public Popup Popup { get; } = popup;
+        public DispatcherTimer Timer { get; } = timer;
+        public ScrollViewer? ScrollViewer { get; } = scrollViewer;
+        public bool IsHiding { get; set; }
+        public CancellationToken AnimationToken => _animationCancellation.Token;
+
+        public CancellationToken BeginAnimation()
+        {
+            CancelAnimations();
+            _animationCancellation = new CancellationTokenSource();
+            return _animationCancellation.Token;
+        }
+
+        public void CancelAnimations()
+        {
+            _animationCancellation.Cancel();
+            _animationCancellation.Dispose();
+        }
+    }
 }

--- a/SukiUI/Animations/GlowBehavior.cs
+++ b/SukiUI/Animations/GlowBehavior.cs
@@ -14,6 +14,12 @@ public static class GlowBehavior
 
     private static readonly Dictionary<Control, PopupData> _popups = new();
 
+    /// <summary>
+    /// Popups grouped by the <see cref="ScrollViewer"/> they scroll with, so a scroll event only
+    /// touches the popups that need repositioning and only subscribes once per host.
+    /// </summary>
+    private static readonly Dictionary<ScrollViewer, List<PopupData>> _scrollHosts = new();
+
     public static readonly AttachedProperty<bool> IsActiveProperty =
         AvaloniaProperty.RegisterAttached<Control, bool>(
             "IsActive",
@@ -212,10 +218,7 @@ public static class GlowBehavior
             timer.Start();
         };
 
-        if (scrollViewer != null)
-        {
-            scrollViewer.ScrollChanged += OnScrollChanged;
-        }
+        RegisterScrollHost(popupData);
 
         _popups[control] = popupData;
 
@@ -232,11 +235,17 @@ public static class GlowBehavior
 
         popupData.IsHiding = true;
         popupData.Timer.Stop();
+
+        // Read the live opacity before cancelling: cancelling an in-flight fade reverts the
+        // animated value to its pre-animation base, which would make the fade-out a no-op.
+        var border = popupData.Popup.Child as Border;
+        var fadeFrom = border?.Opacity ?? 0;
+
         var cancellationToken = popupData.BeginAnimation();
 
-        if (popupData.Popup.Child is Border border)
+        if (border != null)
         {
-            await AnimateOpacityAsync(border, border.Opacity, 0, cancellationToken);
+            await AnimateOpacityAsync(border, fadeFrom, 0, cancellationToken);
         }
 
         if (!_popups.TryGetValue(control, out var current) ||
@@ -289,11 +298,37 @@ public static class GlowBehavior
         popupData.Popup.Child = null;
         ((ISetLogicalParent)popupData.Popup).SetParent(null);
 
-        if (popupData.ScrollViewer != null)
-            popupData.ScrollViewer.ScrollChanged -= OnScrollChanged;
+        UnregisterScrollHost(popupData);
 
         if (_popups.TryGetValue(control, out var current) && ReferenceEquals(current, popupData))
             _popups.Remove(control);
+    }
+
+    private static void RegisterScrollHost(PopupData popupData)
+    {
+        if (popupData.ScrollViewer is not { } scrollViewer) return;
+
+        if (!_scrollHosts.TryGetValue(scrollViewer, out var hosted))
+        {
+            hosted = new List<PopupData>();
+            _scrollHosts[scrollViewer] = hosted;
+            scrollViewer.ScrollChanged += OnScrollChanged;
+        }
+
+        hosted.Add(popupData);
+    }
+
+    private static void UnregisterScrollHost(PopupData popupData)
+    {
+        if (popupData.ScrollViewer is not { } scrollViewer) return;
+        if (!_scrollHosts.TryGetValue(scrollViewer, out var hosted)) return;
+
+        hosted.Remove(popupData);
+
+        if (hosted.Count != 0) return;
+
+        _scrollHosts.Remove(scrollViewer);
+        scrollViewer.ScrollChanged -= OnScrollChanged;
     }
 
     private static async Task AnimateOpacityAsync(Visual visual, double from, double to,
@@ -310,35 +345,45 @@ public static class GlowBehavior
         }
         catch (OperationCanceledException)
         {
-            // A detach or fast reactivation superseded this animation.
+            // Defensive: Avalonia signals cancellation by completing the task rather than
+            // throwing, so a detach or fast reactivation normally just returns early here.
         }
     }
 
     private static void OnScrollChanged(object? sender, ScrollChangedEventArgs e)
     {
         if (sender is not ScrollViewer scrollViewer) return;
+        if (!_scrollHosts.TryGetValue(scrollViewer, out var hosted)) return;
 
-        foreach (var kvp in _popups)
+        // Reverse index walk: re-placing a popup can close it, which unregisters it from this list.
+        for (var i = hosted.Count - 1; i >= 0; i--)
         {
-            if (kvp.Value.ScrollViewer == scrollViewer && kvp.Value.Popup.IsOpen)
-            {
-                var popup = kvp.Value.Popup;
-                var placement = popup.Placement;
-                popup.Placement = PlacementMode.AnchorAndGravity;
-                popup.Placement = placement;
-            }
+            if (i >= hosted.Count) continue;
+
+            var popup = hosted[i].Popup;
+            if (!popup.IsOpen) continue;
+
+            var placement = popup.Placement;
+            popup.Placement = PlacementMode.AnchorAndGravity;
+            popup.Placement = placement;
         }
     }
 
     private sealed class PopupData(Popup popup, DispatcherTimer timer, ScrollViewer? scrollViewer)
     {
-        private CancellationTokenSource _animationCancellation = new();
+        private CancellationTokenSource? _animationCancellation = new();
 
         public Popup Popup { get; } = popup;
         public DispatcherTimer Timer { get; } = timer;
         public ScrollViewer? ScrollViewer { get; } = scrollViewer;
         public bool IsHiding { get; set; }
-        public CancellationToken AnimationToken => _animationCancellation.Token;
+
+        /// <summary>
+        /// Token for the current animation batch, or an already-cancelled token once released.
+        /// Never touches a disposed source, so callers cannot trip an <see cref="ObjectDisposedException"/>.
+        /// </summary>
+        public CancellationToken AnimationToken =>
+            _animationCancellation?.Token ?? new CancellationToken(true);
 
         public CancellationToken BeginAnimation()
         {
@@ -349,8 +394,11 @@ public static class GlowBehavior
 
         public void CancelAnimations()
         {
-            _animationCancellation.Cancel();
-            _animationCancellation.Dispose();
+            var cancellation = Interlocked.Exchange(ref _animationCancellation, null);
+            if (cancellation is null) return;
+
+            cancellation.Cancel();
+            cancellation.Dispose();
         }
     }
 }

--- a/SukiUI/Animations/LoadingBehavior.cs
+++ b/SukiUI/Animations/LoadingBehavior.cs
@@ -18,6 +18,12 @@ public static class LoadingBehavior
     private static readonly Dictionary<Control, PopupData> _popups = new();
     private static readonly Dictionary<Control, double> _originalOpacities = new();
 
+    /// <summary>
+    /// Popups grouped by the <see cref="ScrollViewer"/> they scroll with, so a scroll event only
+    /// touches the popups that need repositioning and only subscribes once per host.
+    /// </summary>
+    private static readonly Dictionary<ScrollViewer, List<PopupData>> _scrollHosts = new();
+
     public static readonly AttachedProperty<bool> IsBusyProperty =
         AvaloniaProperty.RegisterAttached<Control, bool>(
             "IsBusy",
@@ -55,6 +61,9 @@ public static class LoadingBehavior
         {
             if (isBusy)
             {
+                // Track lifecycle so the dictionary entry is released if this control is ever
+                // attached and then detached again.
+                SubscribeToLifecycle(control);
                 _originalOpacities[control] = control.Opacity;
                 control.Animate(Visual.OpacityProperty)
                     .From(control.Opacity)
@@ -86,6 +95,11 @@ public static class LoadingBehavior
 
     private static void ShowBusy(Control control)
     {
+        if (_popups.ContainsKey(control))
+            return;
+
+        SubscribeToLifecycle(control);
+
         var originalOpacity = control.Opacity;
         var dimOpacity = GetDimOpacity(control);
 
@@ -128,15 +142,11 @@ public static class LoadingBehavior
         };
 
         var scrollViewer = control.FindAncestorOfType<ScrollViewer>();
-        if (scrollViewer != null)
-        {
-            scrollViewer.ScrollChanged += OnScrollChanged;
-        }
+        var popupData = new PopupData(popup, scrollViewer);
 
-        _popups[control] = new PopupData(popup, scrollViewer);
+        RegisterScrollHost(popupData);
 
-        control.AttachedToVisualTree += OnControlAttachedToVisualTree;
-        control.DetachedFromVisualTree += OnControlDetachedFromVisualTree;
+        _popups[control] = popupData;
 
         popup.IsOpen = true;
     }
@@ -144,9 +154,14 @@ public static class LoadingBehavior
     private static async void HideBusy(Control control)
     {
         if (!_originalOpacities.TryGetValue(control, out var originalOpacity))
+        {
+            // Nothing to unwind: a detach already released this control's overlay.
+            UnsubscribeFromLifecycle(control);
             return;
+        }
 
         var dimOpacity = GetDimOpacity(control);
+        _popups.TryGetValue(control, out var popupData);
 
         await control.Animate(Visual.OpacityProperty)
             .From(dimOpacity)
@@ -154,11 +169,15 @@ public static class LoadingBehavior
             .WithDuration(TimeSpan.FromMilliseconds(AnimationDurationMs))
             .RunAsync();
 
-        control.Opacity = originalOpacity;
+        // A detach during the fade already released everything; do not resurrect it.
+        if (popupData != null && !IsCurrentPopup(control, popupData))
+            return;
+
+        control.SetCurrentValue(Visual.OpacityProperty, originalOpacity);
         _originalOpacities.Remove(control);
         control.IsHitTestVisible = true;
 
-        if (_popups.TryGetValue(control, out var popupData) && popupData.Popup.Child is Loading loading)
+        if (popupData?.Popup.Child is Loading loading)
         {
             await loading.Animate(Visual.OpacityProperty)
                 .From(1)
@@ -166,31 +185,26 @@ public static class LoadingBehavior
                 .WithDuration(TimeSpan.FromMilliseconds(AnimationDurationMs))
                 .RunAsync();
 
-            popupData.Popup.IsOpen = false;
-            popupData.Popup.Child = null;
-            ((ISetLogicalParent)popupData.Popup).SetParent(null);
+            if (!IsCurrentPopup(control, popupData))
+                return;
 
-            if (popupData.ScrollViewer != null)
-            {
-                popupData.ScrollViewer.ScrollChanged -= OnScrollChanged;
-            }
-
-            _popups.Remove(control);
+            ReleasePopup(control, popupData, restoreOpacity: false);
         }
 
-        control.AttachedToVisualTree -= OnControlAttachedToVisualTree;
-        control.DetachedFromVisualTree -= OnControlDetachedFromVisualTree;
+        if (!GetIsBusy(control))
+            UnsubscribeFromLifecycle(control);
     }
+
+    private static bool IsCurrentPopup(Control control, PopupData popupData) =>
+        _popups.TryGetValue(control, out var current) && ReferenceEquals(current, popupData);
 
     private static void OnControlAttachedToVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
     {
         if (sender is not Control control) return;
         if (!GetIsBusy(control)) return;
 
-        if (_popups.TryGetValue(control, out var popupData) && !popupData.Popup.IsOpen)
-        {
-            popupData.Popup.IsOpen = true;
-        }
+        // The overlay is fully released on detach, so reattaching rebuilds it.
+        ShowBusy(control);
     }
 
     private static void OnControlDetachedFromVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
@@ -198,26 +212,94 @@ public static class LoadingBehavior
         if (sender is not Control control) return;
 
         if (_popups.TryGetValue(control, out var popupData))
+            ReleasePopup(control, popupData, restoreOpacity: true);
+
+        if (!GetIsBusy(control))
+            UnsubscribeFromLifecycle(control);
+    }
+
+    private static void SubscribeToLifecycle(Control control)
+    {
+        control.AttachedToVisualTree -= OnControlAttachedToVisualTree;
+        control.DetachedFromVisualTree -= OnControlDetachedFromVisualTree;
+        control.AttachedToVisualTree += OnControlAttachedToVisualTree;
+        control.DetachedFromVisualTree += OnControlDetachedFromVisualTree;
+    }
+
+    private static void UnsubscribeFromLifecycle(Control control)
+    {
+        control.AttachedToVisualTree -= OnControlAttachedToVisualTree;
+        control.DetachedFromVisualTree -= OnControlDetachedFromVisualTree;
+    }
+
+    private static void ReleasePopup(Control control, PopupData popupData, bool restoreOpacity)
+    {
+        popupData.Popup.IsOpen = false;
+        popupData.Popup.Child = null;
+        ((ISetLogicalParent)popupData.Popup).SetParent(null);
+
+        UnregisterScrollHost(popupData);
+
+        if (restoreOpacity && _originalOpacities.TryGetValue(control, out var originalOpacity))
         {
-            popupData.Popup.IsOpen = false;
+            control.SetCurrentValue(Visual.OpacityProperty, originalOpacity);
+            _originalOpacities.Remove(control);
+            control.IsHitTestVisible = true;
         }
+
+        if (_popups.TryGetValue(control, out var current) && ReferenceEquals(current, popupData))
+            _popups.Remove(control);
+    }
+
+    private static void RegisterScrollHost(PopupData popupData)
+    {
+        if (popupData.ScrollViewer is not { } scrollViewer) return;
+
+        if (!_scrollHosts.TryGetValue(scrollViewer, out var hosted))
+        {
+            hosted = new List<PopupData>();
+            _scrollHosts[scrollViewer] = hosted;
+            scrollViewer.ScrollChanged += OnScrollChanged;
+        }
+
+        hosted.Add(popupData);
+    }
+
+    private static void UnregisterScrollHost(PopupData popupData)
+    {
+        if (popupData.ScrollViewer is not { } scrollViewer) return;
+        if (!_scrollHosts.TryGetValue(scrollViewer, out var hosted)) return;
+
+        hosted.Remove(popupData);
+
+        if (hosted.Count != 0) return;
+
+        _scrollHosts.Remove(scrollViewer);
+        scrollViewer.ScrollChanged -= OnScrollChanged;
     }
 
     private static void OnScrollChanged(object? sender, ScrollChangedEventArgs e)
     {
         if (sender is not ScrollViewer scrollViewer) return;
+        if (!_scrollHosts.TryGetValue(scrollViewer, out var hosted)) return;
 
-        foreach (var kvp in _popups)
+        // Reverse index walk: re-placing a popup can close it, which unregisters it from this list.
+        for (var i = hosted.Count - 1; i >= 0; i--)
         {
-            if (kvp.Value.ScrollViewer == scrollViewer && kvp.Value.Popup.IsOpen)
-            {
-                var popup = kvp.Value.Popup;
-                var placement = popup.Placement;
-                popup.Placement = PlacementMode.Center;
-                popup.Placement = placement;
-            }
+            if (i >= hosted.Count) continue;
+
+            var popup = hosted[i].Popup;
+            if (!popup.IsOpen) continue;
+
+            var placement = popup.Placement;
+            popup.Placement = PlacementMode.Center;
+            popup.Placement = placement;
         }
     }
 
-    private record PopupData(Popup Popup, ScrollViewer? ScrollViewer);
+    private sealed class PopupData(Popup popup, ScrollViewer? scrollViewer)
+    {
+        public Popup Popup { get; } = popup;
+        public ScrollViewer? ScrollViewer { get; } = scrollViewer;
+    }
 }

--- a/SukiUI/Animations/VisibilityBehavior.cs
+++ b/SukiUI/Animations/VisibilityBehavior.cs
@@ -94,11 +94,32 @@ public static class VisibilityBehavior
             }
         }
 
-        control.DetachedFromVisualTree += (_, _) =>
-        {
-            _originalDimensions.Remove(control);
-            _lastDimensions.Remove(control);
-        };
+        TrackLifecycle(control);
+    }
+
+    /// <summary>
+    /// Subscribes a shared static handler so the dimension caches are released when the control
+    /// detaches. Idempotent: a closure per call would accumulate handlers and keep the control alive.
+    /// </summary>
+    private static void TrackLifecycle(Control control)
+    {
+        control.DetachedFromVisualTree -= OnControlDetachedFromVisualTree;
+        control.DetachedFromVisualTree += OnControlDetachedFromVisualTree;
+    }
+
+    private static void OnControlDetachedFromVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
+    {
+        if (sender is not Control control) return;
+
+        control.DetachedFromVisualTree -= OnControlDetachedFromVisualTree;
+        _originalDimensions.Remove(control);
+        _lastDimensions.Remove(control);
+    }
+
+    private static void SetLastDimensions(Control control, double width, double height)
+    {
+        _lastDimensions[control] = (width, height);
+        TrackLifecycle(control);
     }
 
     private static void AnimateShow(Control control, double hiddenScale, bool animateDims)
@@ -126,7 +147,7 @@ public static class VisibilityBehavior
                 else
                 {
                     if (control.Bounds.Width > 0 && control.Bounds.Height > 0)
-                        _lastDimensions[control] = (control.Bounds.Width, control.Bounds.Height);
+                        SetLastDimensions(control, control.Bounds.Width, control.Bounds.Height);
                     control.Width = double.NaN;
                     control.Height = double.NaN;
                 }
@@ -150,7 +171,7 @@ public static class VisibilityBehavior
             SaveOriginalDimensions(control);
             currentWidth = control.Bounds.Width;
             currentHeight = control.Bounds.Height;
-            _lastDimensions[control] = (currentWidth, currentHeight);
+            SetLastDimensions(control, currentWidth, currentHeight);
         }
 
         RunAnimation(control, 1, 0, 1.0, hiddenScale, animateDims, currentWidth, currentHeight,
@@ -213,7 +234,7 @@ public static class VisibilityBehavior
 
         if (w > 0 && h > 0)
         {
-            _lastDimensions[control] = (w, h);
+            SetLastDimensions(control, w, h);
             return (w, h);
         }
 
@@ -224,6 +245,8 @@ public static class VisibilityBehavior
     {
         if (!_originalDimensions.ContainsKey(control))
             _originalDimensions[control] = (control.Width, control.Height);
+
+        TrackLifecycle(control);
     }
 
     private static void SetScale(Control control, double scale)


### PR DESCRIPTION
## Summary

- release GlowBehavior and ErrorBehavior popup resources synchronously when their control leaves the visual tree
- stop the per-control dispatcher timer, detach ScrollViewer subscriptions, clear popup content and logical parents, and remove static dictionary entries
- preserve active behavior semantics by recreating the overlay after reattachment
- cancel superseded fades so a stale asynchronous cleanup cannot remove a newly reactivated overlay
- store ErrorBehavior's original opacity with the popup lifecycle instead of in a second static control dictionary

## Problem

Both behaviors used controls as strong keys in static dictionaries. Detaching a control only closed its popup and stopped its timer, leaving the dictionary entry, popup content, logical-parent chain, and subscriptions alive. Repeated navigation therefore retained every detached control subtree.

## Performance

Measured with an Avalonia Headless Release probe on .NET 10. Each scenario repeatedly created and detached batches of 20 controls, disconnected the closed window content, forced full GC, and then inspected the private behavior dictionary plus WeakReferences. The baseline is upstream main at df3f7bf; the optimized result is 3ae759b.

| Behavior | Detached controls | Dictionary entries before | Dictionary entries after | Live WeakReferences before | Live WeakReferences after | Managed heap delta before | Managed heap delta after | Reduction |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| Glow | 20 | 20 | 0 | 20/20 | 0/20 | 1,591,320 B | 172,712 B | 89.1% |
| Glow | 100 | 100 | 0 | 100/100 | 0/100 | 9,276,400 B | 340,560 B | 96.3% |
| Error | 20 | 20 | 0 | 20/20 | 0/20 | 4,234,640 B | 1,484,312 B | 65.0% |
| Error | 100 | 100 | 0 | 100/100 | 0/100 | 15,807,408 B | 1,627,752 B | 89.7% |

The heap delta is a forced-GC process measurement and includes Headless framework noise; the dictionary and WeakReference results directly verify that detached controls are no longer retained.

## Validation

- Headless detach/GC benchmark for 20 and 100 Glow and Error controls
- Headless lifecycle regression covering detach, active reattach, fast deactivate/reactivate, and final cleanup
- dotnet build Suki.sln -c Release
